### PR TITLE
Honor the application color scheme

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,8 +1,3 @@
-QWidget {
-    background-color: #EAECF0;
-}
-
-
 /* ------------------------------------
    The topBar
 */
@@ -13,7 +8,7 @@ TopWidget {
     margin: 0px;
     padding: 0px;
     border: none;
-    border-bottom: 2px solid #ccc;
+    border-bottom: 2px solid palette(mid);
 }
 
 TopWidget::separator {
@@ -31,15 +26,14 @@ QToolButton {
 }
 
 SearchBar {
-    background-color: white;
+    background-color: palette(light);
     background-image: url(":/icons/search.svg");
     background-repeat: no-repeat;
     padding: 2px 2px 2px 40px;
     max-height: 40px;
     margin: 5px;
-    color: #666;
     font-size: 16px;
-    border: 2px solid #ccc;
+    border: 2px solid palette(mid);
     border-radius: 5px;
 }
 
@@ -48,8 +42,8 @@ SearchBar {
 */
 
 TopWidget QToolButton:pressed {
-    background-color: #D9E9FF;
-    border: 1px solid #3366CC;
+    background-color: palette(highlight);
+    border: 1px solid palette(mid);
     border-radius: 2px;
 }
 
@@ -81,14 +75,8 @@ QMenu::icon {
 }
 
 QMenu::item:selected {
-    background-color: #D9E9FF;
-    border: 1px solid #3366CC;
-}
-
-QMenu::indicator {
-    color: #666666;
-    width: 13px;
-    height: 13px;
+    background-color: palette(highlight);
+    border: 1px solid palette(mid);
 }
 
 /* -----------------------------------------
@@ -100,14 +88,10 @@ QTabBar {
     icon-size: 24px;
 }
 
-QTabBar::tear {
-     background-color: blue;
-}
-
 QTabWidget::pane {
     top: -2px;
     border: none;
-    border-top: 2px solid #ccc;
+    border-top: 2px solid palette(mid);
 }
 
 QTabBar::tab {
@@ -116,15 +100,15 @@ QTabBar::tab {
     min-height: 40px;
     max-height: 40px;
     border: none;
-    border-right: 2px solid #ccc;
-    border-bottom: 2px solid #ccc;
+    border-right: 2px solid palette(mid);
+    border-bottom: 2px solid palette(mid);
     border-radius: 0px;
     padding: 2px;
 }
 
 QTabBar::tab:selected {
-    background-color: white;
-    border-bottom: 2px solid white;
+    background-color: palette(light);
+    border-bottom: 2px solid palette(mid);
 }
 
 QTabBar::close-button {
@@ -132,12 +116,11 @@ QTabBar::close-button {
     subcontrol-position: right;
 }
 
-
 /* -----------------------------------------
     TabWidget
 */
 
 #aboutText {
     padding: 20px;
-    background-color: white;
+    background-color: palette(window);
 }


### PR DESCRIPTION
Right now most colors are fixed to a permanent light theme, which can make Kiwix not fit in with other Qt applications.
Additionally the interface can become unreadable as undefined colors revert to the system's default color theme. In the case of Breeze Dark (KDE's default dark theme) the text camouflages into the menu.
This should alleviate the problem, although the icons will still look out of place in dark themes.