### PR TITLE
Workaroud the contentType handling of QTWebEngine.

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -47,6 +47,7 @@ UrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *request)
     }
     BlobBuffer* buffer = new BlobBuffer(entry.getBlob());
     auto mimeType = QByteArray::fromStdString(entry.getMimetype());
+    mimeType = mimeType.split(';')[0];
     connect(buffer, &QIODevice::aboutToClose, buffer, &QObject::deleteLater);
     request->reply(mimeType, buffer);
 }


### PR DESCRIPTION
It seems that QTWebEngine doesn't correctly handle a "complex" mimeType
(`text/html; charset=utf-8`). In this case, it handles the content as
`plain/text`.

So let pass only the first part of the full mimeType without the charset.

Fix #50