### PR TITLE
Keep the mp_stackWidget in sync with the tabBar.

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -34,10 +34,6 @@ TabBar::TabBar(QWidget *parent) :
                     return;
                 }
                 this->closeTab(index);
-                auto widget = mp_stackedWidget->widget(index);
-                mp_stackedWidget->removeWidget(widget);
-                widget->setParent(nullptr);
-                delete widget;
             });
     connect(app->getAction(KiwixApp::ZoomInAction), &QAction::triggered,
             this, [=]() {
@@ -183,6 +179,8 @@ void TabBar::closeTab(int index)
     if (index == 0)
         return;
     auto webview = widget(index);
+    mp_stackedWidget->removeWidget(webview);
+    webview->setParent(nullptr);
     removeTab(index);
     webview->close();
     delete webview;


### PR DESCRIPTION
We need to remove the child widget from the stackWidget before we remove
the tab. Else the onCurrentChanged will try to get the widget of the new
tab and if the tab and the stack are not in sync, we may get the wrong
widget.

As `closeTab` remove the widget from the stack we don't need to remove
it again in listen of `CloseTabAction`.