### PR TITLE
add alt+home shorcut and CTRL+mouse wheel zoom

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -270,6 +270,9 @@ void KiwixApp::createAction()
     connect(mpa_actions[RandomArticleAction], &QAction::triggered,
             this, [=]() { this->openRandomUrl(false); });
 
+    CREATE_ACTION(OpenHomePageAction, tr("Home page"));
+    SET_SHORTCUT(OpenHomePageAction, QKeySequence(Qt::ALT + Qt::Key_Home));
+    
     CREATE_ACTION_ICON(PrintAction, "print", tr("Print"));
     SET_SHORTCUT(PrintAction, QKeySequence::Print);
     connect(mpa_actions[PrintAction], &QAction::triggered,

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -23,6 +23,7 @@ public:
     enum Actions {
         KiwixServeAction,
         RandomArticleAction,
+        OpenHomePageAction,
         PrintAction,
         NewTabAction,
         CloseTabAction,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,6 +29,7 @@ MainWindow::MainWindow(QWidget *parent) :
         else
             setWindowTitle(tr("Library") + " - Kiwix");
     });
+    addAction(app->getAction(KiwixApp::OpenHomePageAction));
 #if !SYSTEMTITLEBAR
     setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
 #endif

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -59,6 +59,12 @@ TabBar::TabBar(QWidget *parent) :
                 QUITIFNULL(current);
                 current->setZoomFactor(1.0);
             });
+    connect(app->getAction(KiwixApp::OpenHomePageAction), &QAction::triggered,
+            this, [=]() {
+                auto current = this->currentWidget();
+                QUITIFNULL(current);
+                current->setUrl("zim://" + current->zimId() + ".zim/");
+            });
 }
 
 void TabBar::setStackedWidget(QStackedWidget *widget) {

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -53,3 +53,14 @@ void WebView::onUrlChanged(const QUrl& url) {
         emit iconChanged(m_icon);
     }
 }
+
+void WebView::wheelEvent(QWheelEvent *event) {
+    if ((event->modifiers() & Qt::ControlModifier) != 0)
+    {
+        if (event->angleDelta().y() > 0) {
+            KiwixApp::instance()->getAction(KiwixApp::ZoomInAction)->activate(QAction::Trigger);
+        } else if (event->angleDelta().y() < 0) {
+            KiwixApp::instance()->getAction(KiwixApp::ZoomOutAction)->activate(QAction::Trigger);
+        }
+    }
+}

--- a/src/webview.h
+++ b/src/webview.h
@@ -3,6 +3,7 @@
 
 #include <QWebEngineView>
 #include <QIcon>
+#include <QWheelEvent>
 
 #include <kiwix/reader.h>
 
@@ -29,6 +30,8 @@ signals:
 
 protected:
     virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type);
+    void wheelEvent(QWheelEvent *event);
+    
     QString m_currentZimId;
     QIcon m_icon;
 };


### PR DESCRIPTION
When a webview is created, a QShortcut is set and connected to the slot
"openHomePage" that loads the home page thanks to the ZimId.

fixes #141 
fixes #146 