### PR TITLE
kiwix-serve integration in kiwix-dekstop

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -60,7 +60,8 @@ SOURCES += \
     src/contentmanagerside.cpp \
     src/readinglistbar.cpp \
     src/klistwidgetitem.cpp \
-    src/opdsrequestmanager.cpp
+    src/opdsrequestmanager.cpp \
+    src/localkiwixserver.cpp
 
 HEADERS += \
     src/mainwindow.h \
@@ -82,14 +83,16 @@ HEADERS += \
     src/contentmanagerside.h \
     src/readinglistbar.h \
     src/klistwidgetitem.h \
-    src/opdsrequestmanager.h
+    src/opdsrequestmanager.h \
+    src/localkiwixserver.h
 
 FORMS += \
     ui/mainwindow.ui \
     ui/about.ui \
     src/tocsidebar.ui \
     src/contentmanagerside.ui \
-    src/readinglistbar.ui
+    src/readinglistbar.ui \
+    ui/localkiwixserver.ui
 
 TRANSLATIONS = "resources/i18n/kiwix-desktop_fr.ts"
 CODECFORSRC = UTF-8

--- a/resources/css/localServer.css
+++ b/resources/css/localServer.css
@@ -1,0 +1,15 @@
+QWidget {
+    background-color: white;
+}
+
+QPushButton {
+    border: none;
+    padding: 3px;
+    color:blue;
+    outline: 0;
+}
+
+QPushButton:hover {
+    background-color: blue;
+    color: white;
+}

--- a/resources/kiwix.qrc
+++ b/resources/kiwix.qrc
@@ -61,6 +61,8 @@
         <file>fonts/SegoeUI/seguisb.ttf</file>
         <file>fonts/SegoeUI/segoeui.ttf</file>
         <file>texts/about.html</file>
+        <file>texts/kiwixServerText.html</file>
+        <file>texts/kiwixServerRunningText.html</file>
         <file>icons/search_backward.svg</file>
         <file>icons/search_forward.svg</file>
         <file>icons/kiwix-app-icons-square.svg</file>

--- a/resources/style.qrc
+++ b/resources/style.qrc
@@ -2,5 +2,6 @@
     <qresource prefix="/">
         <file>css/style.css</file>
         <file>css/popup.css</file>
+        <file>css/localServer.css</file>
     </qresource>
 </RCC>

--- a/resources/texts/kiwixServerRunningText.html
+++ b/resources/texts/kiwixServerRunningText.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<html><head><meta name="qrichtext" content="1" /><style type="text/css">
+p, li { white-space: pre-wrap; }
+</style></head><body style=" font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;">
+<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-weight:600;">Local Kiwix server</span></p>
+<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;"><br /></p>
+<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">The Kiwix Server is running and can be accessed in the local network at :</p></body></html>

--- a/resources/texts/kiwixServerText.html
+++ b/resources/texts/kiwixServerText.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<html><head><meta name="qrichtext" content="1" /><style type="text/css">
+p, li { white-space: pre-wrap; }
+</style></head><body style=" font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;">
+<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-weight:600;">Local Kiwix server</span></p>
+<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;"><br /></p>
+<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Starting a server allows other computers in the local network to access your Kiwix library with a standard web browser.</p></body></html>

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -30,7 +30,8 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
       m_libraryDirectory(findLibraryDirectory()),
       m_library(),
       mp_downloader(createDownloader()),
-      m_manager(&m_library, mp_downloader)
+      m_manager(&m_library, mp_downloader),
+      mp_server(new kiwix::KiwixServe(8181))
 {
     m_qtTranslator.load(QLocale(), "qt", "_",
                         QLibraryInfo::location(QLibraryInfo::TranslationsPath));
@@ -103,6 +104,10 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
 
 KiwixApp::~KiwixApp()
 {
+    if (mp_server) {
+        mp_server->shutDown();
+        delete mp_server;
+    }
     if (mp_downloader) {
         mp_downloader->close();
         delete mp_downloader;
@@ -264,7 +269,6 @@ void KiwixApp::createAction()
 {
     CREATE_ACTION_ICON(KiwixServeAction, "share", tr("Local Kiwix Server"));
     SET_SHORTCUT(KiwixServeAction, QKeySequence(Qt::CTRL+Qt::Key_I));
-    HIDE_ACTION(KiwixServeAction);
 
     CREATE_ACTION_ICON(RandomArticleAction, "random", tr("Random Article"));
     SET_SHORTCUT(RandomArticleAction, QKeySequence(Qt::CTRL+Qt::Key_R));

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -5,6 +5,7 @@
 #include "contentmanager.h"
 #include "mainwindow.h"
 #include "kiwix/downloader.h"
+#include <kiwix/kiwixserve.h>
 #include "tabbar.h"
 #include "tocsidebar.h"
 #include "urlschemehandler.h"
@@ -73,6 +74,7 @@ public:
     TabBar* getTabWidget() { return mp_tabWidget; }
     QAction* getAction(Actions action);
     QString getLibraryDirectory() { return m_libraryDirectory; };
+    kiwix::KiwixServe* getLocalServer() { return mp_server; }
 
     bool isCurrentArticleBookmarked();
 
@@ -103,6 +105,7 @@ private:
     TabBar* mp_tabWidget;
     SideBarType m_currentSideType;
     QErrorMessage* mp_errorDialog;
+    kiwix::KiwixServe* mp_server;
 
     QAction*     mpa_actions[MAX_ACTION];
 

--- a/src/localkiwixserver.cpp
+++ b/src/localkiwixserver.cpp
@@ -1,0 +1,81 @@
+#include "localkiwixserver.h"
+#include "ui_localkiwixserver.h"
+#include "kiwixapp.h"
+#include <QDesktopServices>
+#include <QMessageBox>
+#include <thread>
+
+LocalKiwixServer::LocalKiwixServer(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::LocalKiwixServer)
+{
+    ui->setupUi(this);
+
+    QFile styleFile(":/css/localServer.css");
+    styleFile.open(QIODevice::ReadOnly);
+    auto byteContent = styleFile.readAll();
+    styleFile.close();
+    QString style(byteContent);
+    setStyleSheet(style);
+
+    mp_server = KiwixApp::instance()->getLocalServer();
+    m_port = mp_server->getPort();
+
+    connect(ui->KiwixServerButton, SIGNAL(clicked()), this, SLOT(runOrStopServer()));
+    connect(ui->OpenInBrowserButton, SIGNAL(clicked()), this, SLOT(openInBrowser()));
+    const QHostAddress &localhost = QHostAddress(QHostAddress::LocalHost);
+    for (const QHostAddress &address: QNetworkInterface::allAddresses()) {
+        if (address.protocol() == QAbstractSocket::IPv4Protocol && address != localhost) {
+            m_ipAddress = address.toString();
+            break;
+        }
+    }
+    ui->OpenInBrowserButton->setVisible(false);
+    ui->IpAddress->setVisible(false);
+}
+
+LocalKiwixServer::~LocalKiwixServer()
+{
+    delete ui;
+}
+
+void LocalKiwixServer::openInBrowser()
+{
+    QUrl url;
+    url.setScheme("http");
+    url.setHost(m_ipAddress);
+    url.setPort(m_port);
+    QDesktopServices::openUrl(url);
+}
+
+void LocalKiwixServer::runOrStopServer()
+{
+    if (!m_active) {
+        mp_server->run();
+        ui->IpAddress->setText(m_ipAddress + ":" + QString::number(m_port));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        if (!mp_server->isRunning()) {
+            QMessageBox messageBox;
+            messageBox.critical(0,"Error","An error has occured !");
+            return;
+        }
+        m_active = true;
+    } else {
+        mp_server->shutDown();
+        m_active = false;
+    }
+
+    if (m_active) {
+        ui->KiwixServerButton->setText("Stop Kiwix Server");
+        QUrl url("qrc:/texts/kiwixServerRunningText.html");
+        ui->KiwixServerText->setSource(url);
+        ui->OpenInBrowserButton->setVisible(true);
+        ui->IpAddress->setVisible(true);
+    } else {
+        ui->KiwixServerButton->setText("Start Kiwix Server");
+        QUrl url("qrc:/texts/kiwixServerText.html");
+        ui->KiwixServerText->setSource(url);
+        ui->OpenInBrowserButton->setVisible(false);
+        ui->IpAddress->setVisible(false);
+    }
+}

--- a/src/localkiwixserver.h
+++ b/src/localkiwixserver.h
@@ -1,0 +1,31 @@
+#ifndef LOCALKIWIXSERVER_H
+#define LOCALKIWIXSERVER_H
+
+#include <QDialog>
+#include <kiwix/kiwixserve.h>
+
+namespace Ui {
+class LocalKiwixServer;
+}
+
+class LocalKiwixServer : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit LocalKiwixServer(QWidget *parent = nullptr);
+    ~LocalKiwixServer();
+
+public slots:
+    void runOrStopServer();
+    void openInBrowser();
+
+private:
+    Ui::LocalKiwixServer *ui;
+    kiwix::KiwixServe* mp_server;
+    bool m_active = false;
+    QString m_ipAddress;
+    int m_port;
+};
+
+#endif // LOCALKIWIXSERVER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,7 +11,8 @@
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     mp_ui(new Ui::MainWindow),
-    mp_about(new About(this))
+    mp_about(new About(this)),
+    mp_localKiwixServer(new LocalKiwixServer(this))
 {
     mp_ui->setupUi(this);
     mp_ui->tabBar->setExpanding(false);
@@ -23,6 +24,8 @@ MainWindow::MainWindow(QWidget *parent) :
             this, &MainWindow::toggleFullScreen);
     connect(app->getAction(KiwixApp::AboutAction), &QAction::triggered,
             mp_about, &QDialog::show);
+    connect(app->getAction(KiwixApp::KiwixServeAction), &QAction::triggered,
+            mp_localKiwixServer, &QDialog::show);
     connect(app, &KiwixApp::currentTitleChanged, this, [=](const QString& title) {
         if (!title.isEmpty() && !title.startsWith("zim://"))
             setWindowTitle(title + " - Kiwix");

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -9,6 +9,7 @@
 #include "tocsidebar.h"
 #include "about.h"
 #include "contentmanagerside.h"
+#include "localkiwixserver.h"
 
 namespace Ui {
 class MainWindow;
@@ -33,7 +34,7 @@ protected slots:
 private:
     Ui::MainWindow *mp_ui;
     About     *mp_about;
-
+    LocalKiwixServer *mp_localKiwixServer;
 };
 
 #endif // MAINWINDOW_H

--- a/ui/localkiwixserver.ui
+++ b/ui/localkiwixserver.ui
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LocalKiwixServer</class>
+ <widget class="QDialog" name="LocalKiwixServer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>342</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Local Kiwix Server Settings</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0" colspan="2">
+    <widget class="QTextBrowser" name="KiwixServerText">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Local Kiwix server&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Starting a server allows other computers in the local network to access your Kiwix library with a standard web browser.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QPushButton" name="KiwixServerButton">
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string>Start Kiwix Server</string>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLineEdit" name="IpAddress">
+     <property name="frame">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="OpenInBrowserButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string>Open in browser</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
needs a merge of this pr before https://github.com/kiwix/kiwix-lib/pull/221

Display the "local kiwix server" option in the menu
This option opens a Qdialog with a "start kiwix server" button that set
the Qdialog's content and calls the "runServer()" method of Kiwixapp which
use its mp_server member that wraps kiwix-lib methods to execute the
kiwix-serve binary

Fixes #85