### PR TITLE
Fix crash when trying to open non existing file

### DIFF
--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -43,6 +43,8 @@ void WebView::onUrlChanged(const QUrl& url) {
         emit zimIdChanged(m_currentZimId);
         auto app = KiwixApp::instance();
         auto reader = app->getLibrary()->getReader(m_currentZimId);
+        if (!reader)
+            return;
         std::string favicon, _mimetype;
         reader->getFavicon(favicon, _mimetype);
         QPixmap pixmap;


### PR DESCRIPTION
if the reader is null because the file doesn't exist, it returns

fixes #150