### PR TITLE
remove the scheme warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,13 @@
 
 #include <QCommandLineParser>
 #include <iostream>
+#include <QWebEngineUrlScheme>
 
 int main(int argc, char *argv[])
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QWebEngineUrlScheme scheme("zim");
+    QWebEngineUrlScheme::registerScheme(scheme);
     KiwixApp a(argc, argv);
 
     QCommandLineParser parser;


### PR DESCRIPTION
remove the warning 
"Please register the custom scheme 'zim' via QWebEngineUrlScheme::registerScheme() before installing the custom scheme handler."

According to the Qt's doc : 
![image](https://user-images.githubusercontent.com/47149116/58258473-18a9c100-7d73-11e9-984c-3d7eb706e4c7.png)
