### PR TITLE
QWebEngineUrlScheme exists only since 5.12.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,20 @@
+#include <QtGlobal>
+
 #include "kiwixapp.h"
 
 #include <QCommandLineParser>
 #include <iostream>
-#include <QWebEngineUrlScheme>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+  #include <QWebEngineUrlScheme>
+#endif
 
 int main(int argc, char *argv[])
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     QWebEngineUrlScheme scheme("zim");
     QWebEngineUrlScheme::registerScheme(scheme);
+#endif
     KiwixApp a(argc, argv);
 
     QCommandLineParser parser;


### PR DESCRIPTION
As we are compiling using 5.11 on windows ci, we need to do conditional
compiling.