### PR TITLE
Auto completion search bar

### DIFF
--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -65,13 +65,8 @@ SearchBar::SearchBar(QWidget *parent) :
     m_completer.setCaseSensitivity(Qt::CaseInsensitive);
     setCompleter(&m_completer);
     connect(this, &QLineEdit::textEdited, this, &SearchBar::updateCompletion);
-#if 0 //The `activated` signal seems to not be emitted if user navigate in the page.
-      // Something is broken here .. :/
     connect(&m_completer, QOverload<const QModelIndex &>::of(&QCompleter::activated),
             this, &SearchBar::openCompletion);
-#else
-    connect(this, &QLineEdit::returnPressed, this, &SearchBar::openTitle);
-#endif
     connect(KiwixApp::instance(), &KiwixApp::currentTitleChanged,
             this, &SearchBar::on_currentTitleChanged);
 }
@@ -114,33 +109,6 @@ void SearchBar::updateCompletion(const QString &text)
         m_urlList.push_back(url);
     }
     m_completionModel.setStringList(wordList);
-}
-
-void SearchBar::openTitle()
-{
-    QString title = text();
-    clear();
-    auto tabWidget = KiwixApp::instance()->getTabWidget();
-    auto zimId = tabWidget->currentZimId();
-    auto reader = KiwixApp::instance()->getLibrary()->getReader(zimId);
-    if ( reader == nullptr) {
-        return;
-    }
-    std::string path;
-    try {
-        auto entry = reader->getEntryFromTitle(title.toStdString());
-        path = entry.getPath();
-    } catch (kiwix::NoEntry& e)
-    {
-        return;
-    }
-
-    QUrl qurl;
-    qurl.setScheme("zim");
-    qurl.setHost(zimId+".zim");
-    qurl.setPath("/" + QString::fromStdString(path));
-    QTimer::singleShot(0, [=](){KiwixApp::instance()->openUrl(qurl, false);});
-    clearFocus();
 }
 
 void SearchBar::openCompletion(const QModelIndex &index)

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -62,6 +62,7 @@ SearchBar::SearchBar(QWidget *parent) :
 {
     setPlaceholderText(tr("Search"));
     m_completer.setCompletionMode(QCompleter::UnfilteredPopupCompletion);
+    m_completer.setCaseSensitivity(Qt::CaseInsensitive);
     setCompleter(&m_completer);
     connect(this, &QLineEdit::textEdited, this, &SearchBar::updateCompletion);
 #if 0 //The `activated` signal seems to not be emitted if user navigate in the page.

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -40,7 +40,6 @@ private:
 private slots:
     void updateCompletion(const QString& text);
     void openCompletion(const QModelIndex& index);
-    void openTitle();
 };
 
 #endif // SEARCHBAR_H


### PR DESCRIPTION
fix #80 

open article by pressing enter : 
Set the completer case insensitive to match with the suggestion's list
Re-use the connect with openCompletion method that works fine to handle mouse
click and enter key press to open article
Remove the openTitle method that is no longer usefull.