### PR TITLE
add new tab button with basic css

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -134,6 +134,14 @@ QTabBar::close-button {
     subcontrol-position: right;
 }
 
+QTabBar::tab:last {
+    border: none;
+}
+
+QTabBar::tab:last QToolButton {
+    font-size: 30px;
+    margin-bottom: 5px;
+}
 
 /* -----------------------------------------
     TabWidget

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -88,6 +88,7 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
     mp_mainWindow = new MainWindow;
     mp_tabWidget = mp_mainWindow->getTabBar();
     mp_tabWidget->setContentManagerView(m_manager.getView());
+    mp_tabWidget->setNewTabButton();
     mp_mainWindow->getSideContentManager()->setContentManager(&m_manager);
     setSideBar(CONTENTMANAGER_BAR);
     postInit();

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -17,6 +17,7 @@ public:
     void setStackedWidget(QStackedWidget* widget);
 
     void     setContentManagerView(ContentManagerView* view);
+    void     setNewTabButton();
     WebView* createNewTab(bool setCurrent);
     WebView* widget(int index) { return (index != 0) ? static_cast<WebView*>(mp_stackedWidget->widget(index)) : nullptr; }
     WebView* currentWidget() { auto current = mp_stackedWidget->currentWidget();
@@ -46,6 +47,8 @@ public slots:
 private:
     ContentManagerView* mp_contentManagerView;
     QStackedWidget*     mp_stackedWidget;
+
+    void setSelectionBehaviorOnRemove(int index);
 
 };
 


### PR DESCRIPTION
add a new tab with a button inside at the start of the app. When this button
is pressed, it inserts a new tab just before this tab.
To avoid that this tab/button can be selected when a tab is closed, the
SelectionBehaviorOnRemove is set to select the left tab if it's the most
right before the tab/button and the right if not

Fix #36 