### PR TITLE
add alert if there is not enough storage to download

### DIFF
--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -78,6 +78,10 @@ function init() {
           contentManager.downloadBook(book.id, function(did)  {
             if (did.length == 0)
                 return;
+            if (did == "storage_error") {
+                alert("not enough storage available.");
+                return;
+            }
             book.downloadId = did;
             downloadUpdaters[book.id] = setInterval(function() { getDownloadInfo(book.id); }, 1000);
           });

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -9,6 +9,7 @@
 #include <QUrlQuery>
 #include <QUrl>
 #include <QDir>
+#include <QStorageInfo>
 
 ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, QObject *parent)
     : QObject(parent),
@@ -181,6 +182,10 @@ QString ContentManager::downloadBook(const QString &id)
             return mp_library->getBookById(id);
         }
     }();
+    QStorageInfo storage(QString::fromStdString(getDataDirectory()));
+    if (book.getSize() > storage.bytesAvailable()) {
+        return "storage_error";
+    }
     auto booksList = mp_library->getBookIds();
     for (auto b : booksList)
         if (b.toStdString() == book.getId())


### PR DESCRIPTION
Check the available storage before the start of a download thanks to
QStorageInfo::bytesAvailable(), if the book size is bigger than this value
an alert message appears.

fix #171 