### PR TITLE
Align vertically the library's content when the window is too small

### DIFF
--- a/resources/css/_contentManager.css
+++ b/resources/css/_contentManager.css
@@ -62,6 +62,7 @@ html, body {
     flex-basis: 60px;
     flex-grow: 0;
     flex-shrink: 0;
+
 }
 .tablerow > .cell1 {
     font-weight: bold;
@@ -77,6 +78,12 @@ html, body {
 .cell5 {
     flex-grow: 1;
     margin: 0px 10px;
+}
+
+.cell2,
+.cell3,
+.cell4 {
+    overflow: hidden;
 }
 
 .cell5 {


### PR DESCRIPTION
To align vertically the flexboxes of the same column when the window is too
small, set the flexbox property "overflow" to "hidden" allows all these flexboxes
to have the same width no matter what its content