### PR TITLE
Fix fullscreen icon position in menu

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -319,14 +319,15 @@ void KiwixApp::createAction()
 
     CREATE_ACTION_ICON(ToggleFullscreenAction, "full-screen-enter", tr("Set fullScreen"));
     SET_SHORTCUT(ToggleFullscreenAction, QKeySequence::FullScreen);
-    connect(mpa_actions[ToggleFullscreenAction], &QAction::toggled,
-            this, [=](bool checked) {
+    connect(mpa_actions[ToggleFullscreenAction], &QAction::triggered,
+            this, [=]() {
         auto action = mpa_actions[ToggleFullscreenAction];
+        bool fullScreen = action->iconText() == "fullScreen" ? true : false;
         action->setIcon(
-            QIcon(checked ? ":/icons/full-screen-exit.svg" : ":/icons/full-screen-enter.svg"));
-        action->setText(checked ? tr("Quit fullScreen") : tr("Set fullScreen"));
+            QIcon(fullScreen ? ":/icons/full-screen-enter.svg" : ":/icons/full-screen-exit.svg"));
+        action->setText(fullScreen ? tr("Set fullScreen") : tr("Quit fullScreen"));
+        action->setIconText(fullScreen ?  "" : "fullScreen");
     });
-    mpa_actions[ToggleFullscreenAction]->setCheckable(true);
 
     CREATE_ACTION(ToggleTOCAction, tr("Table of content"));
     SET_SHORTCUT(ToggleTOCAction, QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_1));


### PR DESCRIPTION
The "setCheckable(true)" method adds a check mark in the menu that shifts
the fullscreen icon.
To avoid this behaviour, the action is not checkable anymore. When it is
triggered, it uses the iconText property to display either or those.

fix #176 