### PR TITLE
Fix bug signal activated not emitted

### DIFF
--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -73,8 +73,6 @@ SearchBar::SearchBar(QWidget *parent) :
     m_completer.popup()->setStyleSheet(style);
 
     connect(this, &QLineEdit::textEdited, this, &SearchBar::updateCompletion);
-    connect(&m_completer, QOverload<const QModelIndex &>::of(&QCompleter::activated),
-            this, &SearchBar::openCompletion);
     connect(KiwixApp::instance(), &KiwixApp::currentTitleChanged,
             this, &SearchBar::on_currentTitleChanged);
 }
@@ -87,8 +85,11 @@ void SearchBar::on_currentTitleChanged(const QString& title)
 
 void SearchBar::focusInEvent( QFocusEvent* event)
 {
-    if (event->reason() == Qt::MouseFocusReason)
+    if (event->reason() == Qt::MouseFocusReason) {
         clear();
+        connect(&m_completer, QOverload<const QModelIndex &>::of(&QCompleter::activated),
+        this, &SearchBar::openCompletion);
+    }
     QLineEdit::focusInEvent(event);
     m_button.set_searchMode(true);
 }


### PR DESCRIPTION
Qt seems to disconnect every signal handlers (signal emitted by QCompleter)
of QLineEdit (the SearchBar) every time the QLineEdit loses the focus,
so it has to be connected every time it gains the focus with the mouse.