### PR TITLE
Pause book's download while dialog to cancel is open

### DIFF
--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -100,10 +100,13 @@ function init() {
             }
         },
         cancelBook : function(book) {
+            contentManager.pauseBook(book.id);
             if (confirm("Are you sure you want to abort the download of '" + book.title + "' ?")) {
                 contentManager.cancelBook(book.id);
                 clearInterval(downloadUpdaters[book.id]);
                 Vue.delete(app.downloads, book.id);
+            } else {
+                contentManager.resumeBook(book.id);
             }
         },
         displayedBooks : function(books, nb) {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -237,7 +237,9 @@ void ContentManager::cancelBook(const QString& id)
 {
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());
-    download->cancelDownload();
+    if (download->getStatus() != kiwix::Download::K_COMPLETE) {
+        download->cancelDownload();
+    }
     QString fileToRemove = QString::fromUtf8(getLastPathElement(download->getPath()).c_str()) + "*";
     eraseBookFilesFromComputer(fileToRemove);
     mp_library->removeBookFromLibraryById(id);


### PR DESCRIPTION
When the download of a book finishes while the cancel's dialog is opened
and then that the user confirms the deletion of the book, the app crashes
because aria2 can't find the active download (which is already complete).
Pause the download before opening the dialog and check the download's status
before cancel it avoid this crash.

fix #192 