### PR TITLE
Removed RPATH from compiled binaries.

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -105,8 +105,6 @@ static {
 }
 
 unix {
-  QMAKE_LFLAGS += "-Wl,-rpath,\'\$$ORIGIN/../lib64\ '"
-
   desktop_file.path = $$PREFIX/share/applications/
   desktop_file.files = resources/org.kiwix.desktop.desktop
   INSTALLS += desktop_file


### PR DESCRIPTION
Rpath is not needed to run installed binaries. Most of GNU/Linux distributions strictly forbid it. Already removed from Kiwix Desktop's dependencies.

See also:

 * https://lintian.debian.org/tags/binary-or-shlib-defines-rpath.html
 * https://wiki.debian.org/RpathIssue
 * https://docs.fedoraproject.org/en-US/packaging-guidelines/#_beware_of_rpath