### PR TITLE
rename "Stack Exchange" to "Stackexchange" when getting category list

### DIFF
--- a/src/contentmanagerside.cpp
+++ b/src/contentmanagerside.cpp
@@ -267,3 +267,14 @@ void ContentManagerSide::setContentManager(ContentManager *contentManager)
                 mp_contentManager->setCurrentCategoryFilter(category);
     });
 }
+
+QStringList ContentManagerSide::getCategoryList()
+{
+    QStringList categories = m_categoryList;
+    for (auto& category:categories) {
+        if (category == "Stack Exchange") {
+            category = "Stackexchange";
+        }
+    }
+    return (categories);
+}

--- a/src/contentmanagerside.h
+++ b/src/contentmanagerside.h
@@ -19,7 +19,7 @@ public:
     ~ContentManagerSide();
 
     void setContentManager(ContentManager* contentManager);
-    QStringList getCategoryList() { return m_categoryList;};
+    QStringList getCategoryList();
 
 private:
     Ui::contentmanagerside *mp_ui;


### PR DESCRIPTION
rename "Stack Exchange" to "Stackexchange" when getting category list otherwise the "other" category include stackexchange file