### PR TITLE
scroll wheel click closes tab

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -196,7 +196,7 @@ void TabBar::triggerWebPageAction(QWebEnginePage::WebAction action, WebView *web
 
 void TabBar::closeTab(int index)
 {
-    if (index == 0)
+    if (index == 0 || index == this->count() - 1)
         return;
     setSelectionBehaviorOnRemove(index);
     auto webview = widget(index);
@@ -233,5 +233,12 @@ void TabBar::onCurrentChanged(int index)
         emit webActionEnabledChanged(QWebEnginePage::Forward, false);
         KiwixApp::instance()->setSideBar(KiwixApp::CONTENTMANAGER_BAR);
         QTimer::singleShot(0, [=](){emit currentTitleChanged("");});
+    }
+}
+
+void TabBar::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::MiddleButton) {
+        closeTab(this->tabAt(event->pos()));
     }
 }

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include "webview.h"
 #include "contentmanagerview.h"
+#include <QMouseEvent>
 
 class TabBar : public QTabBar
 {
@@ -35,6 +36,10 @@ public:
     QString currentArticleUrl();
     QString currentArticleTitle();
     virtual QSize tabSizeHint(int index) const;
+
+protected:
+    void mousePressEvent(QMouseEvent *event);
+
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
     void currentZimIdChanged(const QString& zimId);


### PR DESCRIPTION
add an event listener on the mouse click event, if it's the middle button
(the scroll wheel click) it closes the tab on which the cursor is.
In the closeTab() method, add a security to prevent closing the "new tab
button" tab.

fix #79 