### PR TITLE
don't display zim id in searchbar

### DIFF
--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -81,7 +81,11 @@ SearchBar::SearchBar(QWidget *parent) :
 
 void SearchBar::on_currentTitleChanged(const QString& title)
 {
-    setText(title);
+    if (!title.startsWith("zim://")) {
+        setText(title);
+    } else {
+        setText("");
+    }
     m_button.set_searchMode(title.isEmpty());
 }
 


### PR DESCRIPTION
Display the title if it doesn't start with "zim://"

fix #218 