### PR TITLE
hidden tags aren't display

### DIFF
--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -21,9 +21,6 @@ function getIndexById(id) {
 function createDict(keys, values) {
     var d = {}
     for(var i=0; i<keys.length; i++) {
-      if (keys[i] == "tags") {
-          values[i] = values[i].replace(/;/g, " ");
-      }
       d[keys[i]] = values[i];
     }
     return d;

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -68,7 +68,6 @@ QStringList ContentManager::getBookInfos(QString id, const QStringList &keys)
         ADD_V("date", getDate);
         ADD_V("url", getUrl);
         ADD_V("name", getName);
-        ADD_V("tags", getTags);
         ADD_V("origId", getOrigId);
         ADD_V("faviconMimeType", getFaviconMimeType);
         ADD_V("downloadId", getDownloadId);
@@ -85,6 +84,12 @@ QStringList ContentManager::getBookInfos(QString id, const QStringList &keys)
         }
         if (key == "mediaCount") {
             values.append(QString::number(b->getMediaCount()));
+        }
+        if (key == "tags") {
+            QStringList tagList = QString::fromStdString(b->getTags()).split(';');
+            tagList = tagList.filter(QRegExp("^(?!_).*"));
+            QString s = tagList.join(" ");
+            values.append(s);
         }
     }
     return values;


### PR DESCRIPTION
Split the tags into a stringlist to remove tags that start with "_" and then
join them into one string with a space as separator.
Remove the replacement of the commoda points by spaces from the js file
because we do not need it anymore.

fix #227 