### PR TITLE
Tooltip appears when a link has to be displayed

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -5,6 +5,7 @@
 #include <QTimer>
 #include <QWebEnginePage>
 #include <QToolButton>
+#include <QToolTip>
 
 #define QUITIFNULL(VIEW) if (nullptr==(VIEW)) { return; }
 #define QUITIFNOTCURRENT(VIEW) if((VIEW)!=currentWidget()) {return;}
@@ -121,6 +122,21 @@ WebView* TabBar::createNewTab(bool setCurrent)
             [=]() {
                 QUITIFNOTCURRENT(webView);
                 emit webActionEnabledChanged(QWebEnginePage::Forward, webView->isWebActionEnabled(QWebEnginePage::Forward));
+            });
+    connect(webView->page(), &QWebEnginePage::linkHovered, this, 
+            [=](const QString& url) {
+                auto tabbar = KiwixApp::instance()->getTabWidget();
+                if (url.isEmpty()) {
+                    QToolTip::hideText();
+                } else {
+                    auto link = url;
+                    if (url.startsWith("zim://")) {
+                        link = QUrl(url).path();
+                    }
+                    auto height = tabbar->currentWidget()->height() + 1;
+                    auto pos = tabbar->mapToGlobal(QPoint(-3, height));
+                    QToolTip::showText(pos, link);
+                }
             });
     // Ownership of webview is passed to the tabWidget
     auto index = count() - 1;

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "kiwixapp.h"
 #include "webpage.h"
+#include <QToolTip>
 
 WebView::WebView(QWidget *parent)
     : QWebEngineView(parent)
@@ -63,4 +64,14 @@ void WebView::wheelEvent(QWheelEvent *event) {
             KiwixApp::instance()->getAction(KiwixApp::ZoomOutAction)->activate(QAction::Trigger);
         }
     }
+}
+
+bool WebView::event(QEvent *event)
+{
+    if (event->type() == QEvent::ToolTip) {
+        return true;
+    } else {
+        return QWebEngineView::event(event);
+    }
+    return true;
 }

--- a/src/webview.h
+++ b/src/webview.h
@@ -31,6 +31,7 @@ signals:
 protected:
     virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type);
     void wheelEvent(QWheelEvent *event);
+    bool event(QEvent *event);
     
     QString m_currentZimId;
     QIcon m_icon;


### PR DESCRIPTION
The status bar is hidden at the start of the app, then when the mouse is
over a link, the status bar appears with the url displayed.
The event "linkHovered" returns an empty string when there is no url, so
the status bar become hidden when it happens

fix #209 