### PR TITLE
open a filedialog to download files

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1,11 +1,14 @@
 #include "webpage.h"
 
 #include <QDesktopServices>
+#include <QFileDialog>
+#include "kiwixapp.h"
+#include <QWebEngineProfile>
 
 WebPage::WebPage(QObject *parent) :
     QWebEnginePage(parent)
 {
-
+    connect(QWebEngineProfile::defaultProfile(), &QWebEngineProfile::downloadRequested, this, &WebPage::startDownload);
 }
 
 bool WebPage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::NavigationType type, bool isMainFrame)
@@ -15,5 +18,19 @@ bool WebPage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::Navigatio
         return false;
     }
     return true;
+}
 
+void WebPage::startDownload(QWebEngineDownloadItem* download)
+{
+    QString fileName = QFileDialog::getSaveFileName(KiwixApp::instance()->getMainWindow(),
+                                                       tr("Save File as"));
+    if (fileName.isEmpty()) {
+        return;
+    }
+    QString extension = "." + download->url().url().section('.', -1);
+    if (!fileName.endsWith(extension)) {
+        fileName.append(extension);
+    }
+    download->setPath(fileName);
+    download->accept();
 }

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -2,6 +2,7 @@
 
 #include <QDesktopServices>
 #include <QFileDialog>
+#include <QMessageBox>
 #include "kiwixapp.h"
 #include <QWebEngineProfile>
 
@@ -32,5 +33,13 @@ void WebPage::startDownload(QWebEngineDownloadItem* download)
         fileName.append(extension);
     }
     download->setPath(fileName);
+    connect(download, &QWebEngineDownloadItem::finished, this, &WebPage::downloadFinished);
     download->accept();
+}
+
+void WebPage::downloadFinished()
+{
+    QMessageBox msgBox;
+    msgBox.setText(tr("The document has been downloaded."));
+    msgBox.exec();
 }

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -15,6 +15,7 @@ protected:
 signals:
 
 public slots:
+    void startDownload(QWebEngineDownloadItem*);
 };
 
 #endif // WEBPAGE_H

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -16,6 +16,7 @@ signals:
 
 public slots:
     void startDownload(QWebEngineDownloadItem*);
+    void downloadFinished();
 };
 
 #endif // WEBPAGE_H


### PR DESCRIPTION
In the UrlSchemeHandler::handleContentRequest method if the mime type indicates an epub file it opens a filedialog to choose the path (and the filename).
If the filename chosen doesn't end with ".epub" it appends it at the end. The data is then written in this file.

fix #26 

This pr only handles epub. For every other cases that will not display a filepicker in the future, the issue has to be reopen to add this specific case.