### PR TITLE
[URGENT] quick fix tabbar navigation

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -240,5 +240,7 @@ void TabBar::mousePressEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::MiddleButton) {
         closeTab(this->tabAt(event->pos()));
+    } else {
+       QTabBar::mousePressEvent(event);
     }
 }


### PR DESCRIPTION
Add the execution of normal mousePressEvent() if it's not the middlebutton.
Without this the navigation between tab is impossible.