### PR TITLE
Set book path valid at the end of download

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -127,6 +127,7 @@ QStringList ContentManager::updateDownloadInfos(QString id, const QStringList &k
         QString tmp(QString::fromStdString(d->getPath()));
         b.setPath(QDir::toNativeSeparators(tmp).toStdString());
         b.setDownloadId("");
+        b.setPathValid(true);
         mp_library->save();
         if (!m_local) {
             emit(oneBookChanged(id));


### PR DESCRIPTION
Without setting the path valid the book is not accepted by the filter in
the Library::listBookIds method

fix #240 