### PR TITLE
Emit the signal bookmarksChanged when deleting a book

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -234,6 +234,7 @@ void ContentManager::eraseBook(const QString& id)
     eraseBookFilesFromComputer(fileToRemove);
     mp_library->removeBookFromLibraryById(id);
     mp_library->save();
+    emit mp_library->bookmarksChanged();
     if (m_local) {
         emit(bookRemoved(id));
     } else {


### PR DESCRIPTION
It allows to refresh the reading list bar to avoid having bookmarks from a
deleted zim

fix #252 in addition to https://github.com/kiwix/kiwix-lib/pull/278