### PR TITLE
Fix handleMetaRequest.

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -62,15 +62,18 @@ UrlSchemeHandler::handleMetaRequest(QWebEngineUrlRequestJob* request)
     auto zimId = parts[0];
     auto metaName = parts[1];
 
-    auto library = KiwixApp::instance()->getLibrary();
-    auto book = library->getBookById(zimId);
     if (metaName == "favicon") {
-        std::string content= book.getFavicon();
-        std::string mimeType = book.getFaviconMimeType();
-        QBuffer* buffer = new QBuffer;
-        buffer->setData(content.data(), content.size());
-        connect(request, &QObject::destroyed, buffer, &QObject::deleteLater);
-        request->reply(QByteArray::fromStdString(mimeType), buffer);
+        try {
+          auto library = KiwixApp::instance()->getLibrary();
+          auto book = library->getBookById(zimId);
+          std::string content= book.getFavicon();
+          std::string mimeType = book.getFaviconMimeType();
+          QBuffer* buffer = new QBuffer;
+          buffer->setData(content.data(), content.size());
+          connect(request, &QObject::destroyed, buffer, &QObject::deleteLater);
+          request->reply(QByteArray::fromStdString(mimeType), buffer);
+          return;
+        } catch (...) {}
     }
     request->fail(QWebEngineUrlRequestJob::UrlNotFound);
 }


### PR DESCRIPTION
The main fix is about to return after we reply the request and not do a
`request->fail` just after.
The try/catch is just here be safety.

It seems that depending of the version of Qt, doing a `reply` followed by
a `fail`, the request is replied (as with Qt packaged in fedora) or
failed (as with Qt packaged in ubuntu).

This should fix #239