### PR TITLE
disable useless menu-item on library page

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -392,5 +392,17 @@ void KiwixApp::postInit() {
             mp_mainWindow->getTopWidget(), &TopWidget::handleWebActionEnabledChanged);
     connect(mp_tabWidget, &TabBar::currentTitleChanged, this,
             [=](const QString& title) { emit currentTitleChanged(title); });
+    connect(mp_tabWidget, &TabBar::libraryPageDisplayed, this, &KiwixApp::disableItemsOnLibraryPage);
     emit(m_library.booksChanged());
+    disableItemsOnLibraryPage(true);
+}
+
+void KiwixApp::disableItemsOnLibraryPage(bool libraryDisplayed)
+{
+    KiwixApp::instance()->getAction(KiwixApp::ToggleReadingListAction)->setDisabled(libraryDisplayed);
+    KiwixApp::instance()->getAction(KiwixApp::CloseTabAction)->setDisabled(libraryDisplayed);
+    KiwixApp::instance()->getAction(KiwixApp::FindInPageAction)->setDisabled(libraryDisplayed);
+    KiwixApp::instance()->getAction(KiwixApp::ZoomInAction)->setDisabled(libraryDisplayed);
+    KiwixApp::instance()->getAction(KiwixApp::ZoomOutAction)->setDisabled(libraryDisplayed);
+    KiwixApp::instance()->getAction(KiwixApp::ZoomResetAction)->setDisabled(libraryDisplayed);
 }

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -89,6 +89,7 @@ public slots:
     void setSideBar(SideBarType type);
     void toggleSideBar(KiwixApp::SideBarType type);
     void printPage();
+    void disableItemsOnLibraryPage(bool displayed);
 
 protected:
     void createAction();

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -226,11 +226,13 @@ void TabBar::onCurrentChanged(int index)
         auto view = widget(index);
         emit webActionEnabledChanged(QWebEnginePage::Back, view->isWebActionEnabled(QWebEnginePage::Back));
         emit webActionEnabledChanged(QWebEnginePage::Forward, view->isWebActionEnabled(QWebEnginePage::Forward));
+        emit libraryPageDisplayed(false);        
         KiwixApp::instance()->setSideBar(KiwixApp::NONE);
         QTimer::singleShot(0, [=](){emit currentTitleChanged(view->title());});
     } else {
         emit webActionEnabledChanged(QWebEnginePage::Back, false);
         emit webActionEnabledChanged(QWebEnginePage::Forward, false);
+        emit libraryPageDisplayed(true);
         KiwixApp::instance()->setSideBar(KiwixApp::CONTENTMANAGER_BAR);
         QTimer::singleShot(0, [=](){emit currentTitleChanged("");});
     }

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -42,6 +42,7 @@ protected:
 
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
+    void libraryPageDisplayed(bool displayed);
     void currentZimIdChanged(const QString& zimId);
     void currentTitleChanged(const QString& title);
 


### PR DESCRIPTION
disable :
-readinglist action
-closetab action
-findinpage action
-zoomin action
-zoomout action
-zoomresetaction

fix #247 