### PR TITLE
improve download error management

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ kiwix-desktop rc4
  * Support the default zoom level setting
  * Support zoom level per content
  * Remove page view source feature
+ * Stop crashing if a download fails
 
 kiwix-desktop rc3
 =================

--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -71,6 +71,12 @@ function getDownloadInfo(id) {
       clearInterval(downloadUpdaters[id]);
       Vue.delete(app.downloads, id);
       return;
+    } else if (d.status == "error") {
+      clearInterval(downloadUpdaters[id]);
+      Vue.delete(app.downloads, id);
+      alert("Error: download failed.");
+      contentManager.eraseBook(id);
+      return;
     }
     d["completedLengthInDegree"] = Math.trunc(d["completedLength"] * 180 / d["totalLength"]).toString() + "deg";
     Vue.set(app.downloads, id, d);
@@ -106,8 +112,10 @@ function init() {
         },
         downloadBook : function(book) {
           contentManager.downloadBook(book.id, function(did)  {
-            if (did.length == 0)
+            if (did.length == 0) {
+                alert("Error: this download is not available.");
                 return;
+            }
             if (did == "storage_error") {
                 alert("not enough storage available.");
                 return;

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -201,7 +201,12 @@ QString ContentManager::downloadBook(const QString &id)
     for (auto b : booksList)
         if (b.toStdString() == book.getId())
             return "";
-    auto download = mp_downloader->startDownload(book.getUrl());
+    kiwix::Download *download;
+    try {
+        download = mp_downloader->startDownload(book.getUrl());
+    } catch (std::exception& e) {
+        return "";
+    }
     book.setDownloadId(download->getDid());
     mp_library->addBookToLibrary(book);
     mp_library->save();


### PR DESCRIPTION
Display an error messsage if Download* Downloader::startDownload(const std::string& uri)
fails because aria2 doesn't succeed to start the download.

Display an error message if a download get the "error status".

fix #267 