### PR TITLE
close every empty tab when opening a external link

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -17,6 +17,12 @@ WebPage::WebPage(QObject *parent) :
 bool WebPage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::NavigationType type, bool isMainFrame)
 {
     if (url.scheme() != "zim") {
+        auto tabWidget = KiwixApp::instance()->getTabWidget();
+        for (auto i = 1; i < tabWidget->count() - 1; i++) {
+            if (tabWidget->widget(i)->url().isEmpty()) {
+                tabWidget->closeTab(i);
+            }
+        }
         QDesktopServices::openUrl(url);
         return false;
     }


### PR DESCRIPTION
fix #326 

Probably not the best way to do it. I wanted to prevent the application from opening a tab instead of close it manually but didn't find a way to do it