### PR TITLE
closing a tab keeps the scroll position of the right tab

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -252,11 +252,10 @@ void TabBar::closeTab(int index)
 
 void TabBar::setSelectionBehaviorOnRemove(int index)
 {
-    if (index == count() - 2)
-    {
-        QTabBar::setSelectionBehaviorOnRemove(QTabBar::SelectLeftTab);
+    if (index == count() - 2) {
+        setCurrentIndex(0);
     } else {
-        QTabBar::setSelectionBehaviorOnRemove(QTabBar::SelectRightTab);
+        setCurrentIndex(index + 1);
     }
 }
 


### PR DESCRIPTION
QTabBar::setSelectionBehaviorOnRemove seems to reset the scroll position of
the selected tab, set the current index manually keeps it.

fix #329 