### PR TITLE
fix searchbar that doesn't search after switching from another app

### DIFF
--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -93,6 +93,9 @@ void SearchBar::focusInEvent( QFocusEvent* event)
 {
     if (event->reason() == Qt::MouseFocusReason) {
         clear();
+    }
+    if (event->reason() == Qt::ActiveWindowFocusReason ||
+        event->reason() == Qt::MouseFocusReason) {
         connect(&m_completer, QOverload<const QModelIndex &>::of(&QCompleter::activated),
         this, &SearchBar::openCompletion);
     }


### PR DESCRIPTION
Same problem as this problem https://github.com/kiwix/kiwix-desktop/pull/180

The openCompletion has to be connected every time the searchbar gains the focus.

fix #287 