### PR TITLE
Aria2 crash fix

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -251,6 +251,9 @@ void ContentManager::eraseBook(const QString& id)
 
 void ContentManager::pauseBook(const QString& id)
 {
+    if (!mp_downloader) {
+        return;
+    }
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_ACTIVE)
@@ -259,6 +262,9 @@ void ContentManager::pauseBook(const QString& id)
 
 void ContentManager::resumeBook(const QString& id)
 {
+    if (!mp_downloader) {
+        return;
+    }
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_PAUSED)
@@ -267,6 +273,9 @@ void ContentManager::resumeBook(const QString& id)
 
 void ContentManager::cancelBook(const QString& id)
 {
+    if (!mp_downloader) {
+        return;
+    }
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() != kiwix::Download::K_COMPLETE) {

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -105,7 +105,7 @@ private:
     QString m_libraryDirectory;
     Library m_library;
     kiwix::Downloader* mp_downloader;
-    ContentManager m_manager;
+    ContentManager* mp_manager;
     MainWindow* mp_mainWindow;
     TabBar* mp_tabWidget;
     SideBarType m_currentSideType;


### PR DESCRIPTION
display aria2 launch cmd that doesn't crash

The program crashes because it tries to use mp_downloader->getAria2LaunchCmd() but the mp_downloader is null if the aria2 launch command fail.
Now the program displays an error message to warn users that all download fct will not working.

This PR https://github.com/kiwix/kiwix-lib/pull/306 is needed in order to display the aria2 launch cmd.

fix #272 