### PR TITLE
Restore the title tab when searchbar loses focus

### DIFF
--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -90,11 +90,13 @@ void SearchBar::on_currentTitleChanged(const QString& title)
         setText("");
     }
     m_button.set_searchMode(title.isEmpty());
+    m_title = title;
 }
 
 void SearchBar::focusInEvent( QFocusEvent* event)
 {
-    if (event->reason() == Qt::MouseFocusReason) {
+    setReadOnly(false);
+    if (event->reason() == Qt::MouseFocusReason && text() == m_title) {
         clear();
     }
     if (event->reason() == Qt::ActiveWindowFocusReason ||
@@ -104,6 +106,16 @@ void SearchBar::focusInEvent( QFocusEvent* event)
     }
     QLineEdit::focusInEvent(event);
     m_button.set_searchMode(true);
+}
+
+void SearchBar::focusOutEvent(QFocusEvent* event)
+{
+    setReadOnly(true);
+    if (event->reason() == Qt::MouseFocusReason && text().isEmpty()) {
+        m_button.set_searchMode(false);
+        setText(m_title);
+    }
+    return QLineEdit::focusInEvent(event);
 }
 
 void SearchBar::updateCompletion(const QString &text)

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -30,12 +30,14 @@ public slots:
     void on_currentTitleChanged(const QString &title);
 protected:
     virtual void focusInEvent(QFocusEvent *);
+    virtual void focusOutEvent(QFocusEvent *);
 private:
     QStringListModel m_completionModel;
     QCompleter m_completer;
     std::vector<std::string> m_urlList;
     QString m_currentZimId;
     SearchButton m_button;
+    QString m_title;
 
 private slots:
     void updateCompletion(const QString& text);


### PR DESCRIPTION
reimplement QLineEdit::focusInEvent(QFocusEvent* event)
use setReadOnly method to display/hide blinking cursor

fix #330 