### PR TITLE
set a default filename to the filepicker

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -25,8 +25,9 @@ bool WebPage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::Navigatio
 
 void WebPage::startDownload(QWebEngineDownloadItem* download)
 {
+    QString defaultFileName = QString::fromStdString(getLastPathElement(download->url().toString().toStdString()));
     QString fileName = QFileDialog::getSaveFileName(KiwixApp::instance()->getMainWindow(),
-                                                       tr("Save File as"));
+                                                       tr("Save File as"), defaultFileName);
     if (fileName.isEmpty()) {
         return;
     }


### PR DESCRIPTION
Note: in Qt 5.14, this method [QString QWebEngineDownloadItem::downloadFileName() const](https://doc.qt.io/qt-5/qwebenginedownloaditem.html#downloadFileName) gives directly the filename

fix #369 