### PR TITLE
[Urgent]  Fix crash settings page

### DIFF
--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -24,7 +24,8 @@ public:
     WebView* createNewTab(bool setCurrent);
     WebView* widget(int index) { return (index != 0) ? static_cast<WebView*>(mp_stackedWidget->widget(index)) : nullptr; }
     WebView* currentWidget() { auto current = mp_stackedWidget->currentWidget();
-                               if (current == mp_contentManagerView) return nullptr;
+                               if (current == mp_contentManagerView ||
+                                   mp_stackedWidget->currentIndex() == m_settingsIndex) return nullptr;
                                return static_cast<WebView*>(current);
                              }
 


### PR DESCRIPTION
This PR https://github.com/kiwix/kiwix-desktop/pull/375 makes the settings page crash.
It's because it tries to get the zimId of the current widget but obviously the settings page doesn't have one.

To prevent this from happening again the Tabbar::currentWidget method returns a nullptr if the current widget is the settings page (like the content manager page does)