### PR TITLE
Ctrl + Click on external link doesn't open a new empty tab

### DIFF
--- a/src/webview.h
+++ b/src/webview.h
@@ -36,6 +36,7 @@ protected:
 
     QString m_currentZimId;
     QIcon m_icon;
+    QString m_linkHovered;
 };
 
 #endif // WEBVIEW_H


### PR DESCRIPTION
Connect the &QWebEnginePage::linkHovered signal to set the m_linkHovered
member.
The Ctrl + Click event is intercepted to directly open the m_linkHovered
variable if it's an external link

fix #326 