### PR TITLE
Correctly handle redirection in zim file.

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -42,10 +42,16 @@ UrlSchemeHandler::handleContentRequest(QWebEngineUrlRequestJob *request)
             return;
         }
     }
-    try {
-        entry = entry.getFinalEntry();
-    } catch (kiwix::NoEntry&) {
-        request->fail(QWebEngineUrlRequestJob::UrlNotFound);
+    if (entry.isRedirect()) {
+        try {
+            entry = entry.getFinalEntry();
+        } catch (kiwix::NoEntry&) {
+            request->fail(QWebEngineUrlRequestJob::UrlNotFound);
+            return;
+        }
+        auto path = QString("/") + QString::fromStdString(entry.getPath());
+        qurl.setPath(path);
+        request->redirect(qurl);
         return;
     }
     BlobBuffer* buffer = new BlobBuffer(entry.getBlob());


### PR DESCRIPTION
Sotoki zim file use redirection to article not in the same "directory".
So it breaks relative urls.

Instead of providing the content of the target entry, we must redirect
to the target entry. So, relative url are not broken.

Fix #384