### PR TITLE
Do not delete twice mp_errorDialog.

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -107,7 +107,6 @@ KiwixApp::~KiwixApp()
         delete mp_downloader;
     }
     delete mp_manager;
-    delete mp_errorDialog;
     delete mp_mainWindow;
 }
 


### PR DESCRIPTION
The mp_errorDialog is created as a child of mp_mainWindow.
It means that is is deleted by mp_mainWindow when we delete it, so
we must not delete mp_errorDialog.

May fix #123