### PR TITLE
Fluid suggestions list UX

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -43,6 +43,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 SOURCES += \
     src/contenttypefilter.cpp \
     src/findinpagebar.cpp \
+    src/suggestionlistworker.cpp \
     src/translation.cpp \
     src/main.cpp \
     src/mainwindow.cpp \
@@ -75,6 +76,7 @@ SOURCES += \
 HEADERS += \
     src/contenttypefilter.h \
     src/findinpagebar.h \
+    src/suggestionlistworker.h \
     src/translation.h \
     src/mainwindow.h \
     src/kiwixapp.h \

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -7,6 +7,8 @@
 #include <QIcon>
 #include <QPushButton>
 #include <QUrl>
+#include <QTimer>
+#include <QThread>
 
 class SearchButton : public QPushButton {
     Q_OBJECT
@@ -26,9 +28,12 @@ class SearchBar : public QLineEdit
     Q_OBJECT
 public:
     SearchBar(QWidget *parent = nullptr);
+    void hideSuggestions();
 
 public slots:
     void on_currentTitleChanged(const QString &title);
+    void clearSuggestions();
+
 protected:
     virtual void focusInEvent(QFocusEvent *);
     virtual void focusOutEvent(QFocusEvent *);
@@ -40,10 +45,13 @@ private:
     QString m_title;
     QString m_searchbarInput;
     bool m_returnPressed = false;
+    QTimer* mp_typingTimer;
+    int m_token;
 
 private slots:
-    void updateCompletion(const QString& text);
+    void updateCompletion();
     void openCompletion(const QModelIndex& index);
+    void openCompletion(const QString& text, int index);
 };
 
 #endif // SEARCHBAR_H

--- a/src/suggestionlistworker.cpp
+++ b/src/suggestionlistworker.cpp
@@ -1,0 +1,50 @@
+#include "suggestionlistworker.h"
+#include "kiwixapp.h"
+
+SuggestionListWorker::SuggestionListWorker(const QString& text, int token, QObject *parent)
+: QThread(parent),
+  m_text(text),
+  m_token(token)
+{
+}
+
+void SuggestionListWorker::run()
+{
+    QStringList suggestionList;
+    QVector<QUrl> urlList;
+
+    auto currentWidget = KiwixApp::instance()->getTabWidget()->currentWebView();
+    auto qurl = currentWidget->url();
+    auto currentZimId = qurl.host().split(".")[0];
+    auto reader = KiwixApp::instance()->getLibrary()->getReader(currentZimId);
+    QUrl url;
+    url.setScheme("zim");
+    if (reader) {
+        url.setHost(currentZimId + ".zim");
+        reader->searchSuggestionsSmart(m_text.toStdString(), 15);
+        std::string title, path;
+        while (reader->getNextSuggestion(title, path)) {
+            url.setPath(QString::fromStdString(path));
+            suggestionList.append(QString::fromStdString(title));
+            urlList.append(url);
+        }
+    }
+    QUrlQuery query;
+    url.setPath("");
+    if (reader) {
+        // The host is used to determine the currentZimId
+        // The content query item is used to know in which zim search (as for kiwix-serve)
+        url.setHost(currentZimId + ".search");
+        query.addQueryItem("content", currentZimId);
+    } else {
+        // We do not allow multi zim search for now.
+        // We don't have a correct UI to select on which zim search,
+        // how to display results, ...
+        //url.setHost("library.search");
+    }
+    query.addQueryItem("pattern", m_text);
+    url.setQuery(query);
+    suggestionList.append(m_text + " (" + gt("fulltext-search") + ")");
+    urlList.append(url);
+    emit(searchFinished(suggestionList, urlList, m_token));
+}

--- a/src/suggestionlistworker.h
+++ b/src/suggestionlistworker.h
@@ -1,0 +1,23 @@
+#ifndef SUGGESTIONLISTWORKER_H
+#define SUGGESTIONLISTWORKER_H
+
+#include <QUrl>
+#include <QVector>
+#include <QThread>
+
+class SuggestionListWorker : public QThread
+{
+    Q_OBJECT
+public:
+    SuggestionListWorker(const QString& text, int token, QObject *parent = nullptr);
+    void run() override;
+
+signals:
+    void searchFinished(const QStringList& suggestions, const QVector<QUrl>& urlList, int token);
+
+private:
+    QString m_text;
+    int m_token = 0;
+};
+
+#endif // SUGGESTIONLISTWORKER_H

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -27,7 +27,11 @@ TabBar::TabBar(QWidget *parent) :
     connect(app->getAction(KiwixApp::NewTabAction), &QAction::triggered,
             this, [=]() {
                 this->createNewTab(true);
-                KiwixApp::instance()->getMainWindow()->getTopWidget()->getSearchBar().setFocus(Qt::MouseFocusReason);
+                auto topWidget = KiwixApp::instance()->getMainWindow()->getTopWidget();
+                topWidget->getSearchBar().setFocus(Qt::MouseFocusReason);
+                topWidget->getSearchBar().clear();
+                topWidget->getSearchBar().clearSuggestions();
+                topWidget->getSearchBar().hideSuggestions();
           });
     connect(app->getAction(KiwixApp::CloseTabAction), &QAction::triggered,
             this, [=]() {


### PR DESCRIPTION
- add a delay before searching suggestions
  A timer of 100ms is started each time the text is edited, if the timer
  time-outs the suggestion's search is executed.

- execute the search in another thread
  The suggestion's search is handled by the worker "SuggestionListWorker" in dedicated thread.
  The semaphore ensures that there is only one worker at a time.
  The "m_actualSearch" is updated by the main thread with the last search requested. Its access is 
  protected by a mutex.
  The "checkAbort" method is called many times to cancel the search if a new one has been 
  launched meanwhile :
    if the original text (given in parameter) is different from "m_actualSearch", it means that a new 
    search has been launched meanwhile.
  The worker sends the suggestions list and the corresponding urls list to the main thread.
  The main thread displays them.

fix #265
and fix #428 too