### PR TITLE
add "open link in web browser" action in context menu

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -110,5 +110,6 @@
     "details":"Full article",
     "yes":"yes",
     "no":"no",
-    "no-filter":"no filter"
+    "no-filter":"no filter",
+    "open-link-in-web-browser":"Open link in web browser"
 }

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -1,6 +1,7 @@
 #include "webview.h"
 
 #include <QDesktopServices>
+#include <QMenu>
 #include <QAction>
 #include <iostream>
 #include "kiwixapp.h"
@@ -70,6 +71,29 @@ void WebView::wheelEvent(QWheelEvent *event) {
         }
     }
 }
+
+
+void WebView::contextMenuEvent(QContextMenuEvent *event)
+{
+    auto menu = this->page()->createStandardContextMenu();
+    pageAction(QWebEnginePage::OpenLinkInNewWindow)->setVisible(false);
+    if (!m_linkHovered.isEmpty()) {
+        if (!m_linkHovered.startsWith("zim://")) {
+            pageAction(QWebEnginePage::OpenLinkInNewTab)->setVisible(false);
+            auto openLinkInWebBrowserAction = new QAction(gt("open-link-in-web-browser"));
+            menu->insertAction(pageAction(QWebEnginePage::DownloadLinkToDisk) , openLinkInWebBrowserAction);
+            connect(menu, &QObject::destroyed, openLinkInWebBrowserAction, &QObject::deleteLater);
+            connect(openLinkInWebBrowserAction, &QAction::triggered, this, [=](bool checked) {
+                Q_UNUSED(checked);
+                QDesktopServices::openUrl(m_linkHovered);
+            });
+        } else {
+            pageAction(QWebEnginePage::OpenLinkInNewTab)->setVisible(true);
+        }
+    }
+    menu->exec(event->globalPos());
+}
+
 
 bool WebView::eventFilter(QObject *src, QEvent *e)
 {

--- a/src/webview.h
+++ b/src/webview.h
@@ -34,6 +34,7 @@ protected:
     void wheelEvent(QWheelEvent *event);
     bool event(QEvent *event);
     bool eventFilter(QObject *src, QEvent *e);
+    void contextMenuEvent(QContextMenuEvent *event);
 
     QString m_currentZimId;
     QIcon m_icon;


### PR DESCRIPTION
reimplement the contextMenuEvent : if the link hovered is an external link
it removes from the standard context menu the "openLinkinNewTab" action and
and add the "open link in web browser"

fix #326 