### PR TITLE
Change tab title ellipsis (...)

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -113,15 +113,27 @@ void TabBar::openUrl(const QUrl& url, bool newTab)
     webView->setUrl(url);
 }
 
+QString TabBar::textWithoutEllipsis(QString text)
+{
+    auto elidedText = this->fontMetrics().elidedText(text, Qt::ElideRight, 145);
+    if (text.size() != elidedText.size()) {
+        elidedText.remove(elidedText.size() - 1, 1);
+    }
+    qInfo() << elidedText;
+    return elidedText;
+}
+
 void TabBar::setTitleOf(const QString& title, ZimView* tab)
 {
     CURRENTIFNULL(tab);
+    QString text;
     if (title.startsWith("zim://")) {
         auto url = QUrl(title);
-        setTabText(mp_stackedWidget->indexOf(tab), url.path());
+        text = textWithoutEllipsis(url.path());
     } else {
-        setTabText(mp_stackedWidget->indexOf(tab), title);
+        text = textWithoutEllipsis(title);
     }
+    setTabText(mp_stackedWidget->indexOf(tab), text);
 }
 
 void TabBar::setIconOf(const QIcon &icon, ZimView *tab)

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -49,6 +49,9 @@ public:
 protected:
     void mousePressEvent(QMouseEvent *event);
 
+private:
+    QString textWithoutEllipsis(QString text);
+
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
     void libraryPageDisplayed(bool displayed);


### PR DESCRIPTION
I don't find a way to apply a fade out effect when the title is too long to fit in the tab, I just succeed to remove the 3 dots ellipsis but even this solution isn't great :
It uses the `fontMetrics().elidedText(QString text, Qt::ElideRight, int width)` method to get the elided string, if the string has the ellipsis '...', it removes it. But this method has an `int width` parameter that represent the space in pixel for the text, I don't find a proper way to have it for a tab, so it's hard coded now, which is bad.

Without the fade out effect, the result looks more like a bug :
![image](https://user-images.githubusercontent.com/47149116/83022798-58f9ea00-a02c-11ea-8206-cbd6d6b41f2d.png)

What we have currently:
![image](https://user-images.githubusercontent.com/47149116/83022933-8cd50f80-a02c-11ea-82ba-f483b6e103d7.png)
 
#358 

