### PR TITLE
Library fonts changed to sans serif and homogenized

### DIFF
--- a/resources/css/_contentManager.css
+++ b/resources/css/_contentManager.css
@@ -57,6 +57,7 @@ html, body {
 }
 .tablecell{
     flex-basis:20%;
+    font-family: sans-serif;
 }
 
 .sortable:hover {
@@ -135,16 +136,22 @@ button {
   border: 0px;
 }
 .tablerow button {
-  color: blue;
-  font-weight: bold;
-  font-size: 14px;
+  /* color: blue; */
+  color:#555;
+  /* font-weight: bold; */
+  font-size: 16px;
   border: 0px;
   background: transparent;
   border-radius: 2px;
 }
+.tablerow button::first-letter {
+  text-transform: uppercase;
+}
 .tablerow button:hover {
-  color: white;
-  background: blue;
+  /* color: white;
+  background: blue; */
+  cursor: pointer;
+  font-weight: bold;
 }
 details:hover {
   background-color: #d9e9ff;


### PR DESCRIPTION
I've modified the **Library list items font-style to sans serif and homogenized the css properties of list items**. 
For more background, refer ticket :  **#406** .

These modifications homogenizes the font-style of every library list item to sans serif and has changed the color of the reset sort button. The reset sort button now gets bold when a user clicks on it, same as the other list items and when a user hovers on the reset sort button, cursor changes to pointer.  The modifications are implemented by adding and editing the code of **_contentManager.css file**. 

**Before:**  

![Screenshot from 2020-07-22 14-23-57](https://user-images.githubusercontent.com/54095062/88159877-8a0d2a00-cc2b-11ea-8ec1-3aef234577b7.png)

**After:**

![Screenshot from 2020-07-22 14-59-54](https://user-images.githubusercontent.com/54095062/88160910-f0467c80-cc2c-11ea-9aab-8a743f36728b.png)





