### PR TITLE
debian: Remove aria2 build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,7 @@ Build-Depends: debhelper-compat (= 13),
  pkg-config,
  qtbase5-dev,
  qtwebengine5-dev,
- libkiwix-dev (>= 9.3.0),
- aria2
+ libkiwix-dev (>= 9.3.0)
 Standards-Version: 4.5.0
 Homepage: https://www.kiwix.org/
 Rules-Requires-Root: no


### PR DESCRIPTION
The dependency is inherited from libkiwix, once
https://github.com/kiwix/kiwix-lib/pull/402 is merged.

Fixes #505.