### PR TITLE
PPA: Remove kiwix-tools dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Package: kiwix
 Architecture: any
 Depends: ${shlibs:Depends},
  ${misc:Depends}
-Recommends: kiwix-tools
 Description: offline Wikipedia reader
  Kiwix allows you to read and search through offline content
  as they were online. Similar to a browser, Kiwix works with


### PR DESCRIPTION
The HTTP daemon is now started directly via libkiwix instead of 
using kiwix-serve as of bbfbf2b.

Also see the discussion on #477.