### PR TITLE
Fixes #358 - fade-out instead elide text (trim with...) in tabs

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -135,7 +135,9 @@ QTabBar::tab {
 }
 
 QTabBar::tab:selected {
+    /* please keep it in sync with 'selected_tab_bg_color' in src/tabbar.cpp */
     background-color: white;
+
     border-bottom: 2px solid white;
 }
 

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -49,6 +49,7 @@ public:
 
 protected:
     void mousePressEvent(QMouseEvent *event);
+    void paintEvent(QPaintEvent *);
 
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);


### PR DESCRIPTION
Fixes #358 - fade-out instead elide text (trim with...) in tabs

This is how it looks like with the change:
![Screenshot from 2020-11-21 21-38-03](https://user-images.githubusercontent.com/5078434/99879979-19126900-2c43-11eb-8df1-5f91b80ac515.png)
