### PR TITLE
Fix printsupport in .pro file

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -6,6 +6,7 @@
 
 QT       += core gui network
 QT       += webenginewidgets
+QT       += printsupport
 
 CONFIG += link_pkgconfig
 


### PR DESCRIPTION
This may be required to avoid errors like:

    src/kiwixapp.cpp:12:10: fatal error: QPrinter: No such file or directory

Fixes #556.