### PR TITLE
Settings tab will now be activated if already opened.

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -50,6 +50,7 @@ TabBar::TabBar(QWidget *parent) :
     connect(app->getAction(KiwixApp::SettingAction), &QAction::triggered,
             this, [=]() {
                 if (KiwixApp::instance()->getSettingsManager()->isSettingsViewdisplayed()) {
+                    setCurrentIndex(m_settingsIndex);
                     return;
                 }
                 auto index = currentIndex() + 1;


### PR DESCRIPTION
Fix #545. The settings tab will now be activated as the current index will now change to the index of settings tab if it is already opened and a user opens settings from the three dot drop down menu.