### PR TITLE
Don't update completion if Settings Page opened

### DIFF
--- a/src/suggestionlistworker.cpp
+++ b/src/suggestionlistworker.cpp
@@ -14,6 +14,8 @@ void SuggestionListWorker::run()
     QVector<QUrl> urlList;
 
     auto currentWidget = KiwixApp::instance()->getTabWidget()->currentWebView();
+    if(!currentWidget)
+        return;
     auto qurl = currentWidget->url();
     auto currentZimId = qurl.host().split(".")[0];
     auto reader = KiwixApp::instance()->getLibrary()->getReader(currentZimId);

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -25,7 +25,8 @@ public:
     ZimView* createNewTab(bool setCurrent);
     ZimView* widget(int index) { return (index != 0) ? static_cast<ZimView*>(mp_stackedWidget->widget(index)) : nullptr; }
     WebView* currentWebView() { auto current = mp_stackedWidget->currentWidget();
-                               if (mp_stackedWidget->currentIndex() == 0) return nullptr;
+                               if (mp_stackedWidget->currentIndex() == 0 ||
+                                   mp_stackedWidget->currentIndex() == m_settingsIndex) return nullptr;
                                return static_cast<ZimView*>(current)->getWebView();
                              }
     ZimView* currentWidget() { auto current = mp_stackedWidget->currentWidget();


### PR DESCRIPTION
Fix https://github.com/kiwix/kiwix-desktop/issues/541
Can't find a way that is both elegant and doesn't require rewritten half of the logic. Check if Settings Page is open first. So far Settings Page is the only widget that can't be converted to WebView. This PR doesn't fix the root issue.