### PR TITLE
Fixed #544 : Crash on closing empty tab after Settings opened

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -176,6 +176,7 @@ void TabBar::triggerWebPageAction(QWebEnginePage::WebAction action, ZimView *wid
 
 void TabBar::closeTab(int index)
 {
+    setSelectionBehaviorOnRemove(index);
     if (index == 0 || index == this->count() - 1)
         return;
     if (index == m_settingsIndex) {
@@ -184,7 +185,6 @@ void TabBar::closeTab(int index)
     if (index < m_settingsIndex) {
         m_settingsIndex--;
     }
-    setSelectionBehaviorOnRemove(index);
     auto webview = widget(index);
     mp_stackedWidget->removeWidget(webview);
     webview->setParent(nullptr);


### PR DESCRIPTION
Just one little change was needed, the setSelectionBehaviorOnRemove() function was to be executed before comparing the index with m_settingsIndex. So I just shifted that line of code before the if conditions. This fixes the issue #544 