### PR TITLE
apply language filter to local library

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -406,6 +406,8 @@ QStringList ContentManager::getBookIds()
 
     filter.acceptTags(tags);
     filter.query(m_searchQuery.toStdString());
+    if (m_currentLanguage != "*")
+        filter.lang(m_currentLanguage.toStdString());
 
     if (m_local) {
         filter.local(true);


### PR DESCRIPTION
related: #498

Apply language filter to local library.
In the process, I found that not all language supported by Kiwix is included in static_content.cpp. For instance, Abkhaz language(abk in Kiwix) isn't included. One solution would be generating static_content.cpp on compile time with kiwix header file. Another thing is the default language isn't set to All so not all local books are displayed as default. Probably better to set default language to All.

I forgot about this PR and force pushed to my fork, thus unintentionally closed the [previous](https://github.com/kiwix/kiwix-desktop/pull/574) PR. My apologies.