### PR TITLE
Fixes #604 - Prepend / to an article path to make QUrl parser happy

### DIFF
--- a/src/suggestionlistworker.cpp
+++ b/src/suggestionlistworker.cpp
@@ -26,7 +26,8 @@ void SuggestionListWorker::run()
         kiwix::SuggestionsList_t suggestions;
         reader->searchSuggestionsSmart(m_text.toStdString(), 15, suggestions);
         for (auto& suggestion: suggestions) {
-            url.setPath(QString::fromStdString(suggestion[1]));
+            QString path = QString("/") + QString::fromStdString(suggestion[1]);
+            url.setPath(path);
             suggestionList.append(QString::fromStdString(suggestion[0]));
             urlList.append(url);
         }


### PR DESCRIPTION
Fixes #604 - Prepend / to an article path to make QUrl parser happy

QUrl::setPath() should be called with an absolute path, starting with /

See my findings in https://github.com/kiwix/kiwix-desktop/issues/604#issuecomment-786147789 and https://github.com/kiwix/kiwix-desktop/issues/604#issuecomment-786158804

But don't be hurry to merge it, it may be not in line with the current architecture. Probably this starting / should be added at 'kiwix-lib' layer, not in 'kiwix-desktop', see my comment  
https://github.com/kiwix/kiwix-desktop/issues/604#issuecomment-786181829