### PR TITLE
Fix pagination by setting pageLength properly

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -101,10 +101,12 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     int temp = query.queryItemValue("start").toInt(&ok);
     if (ok)
       start = temp;
-    int end = 25;
-    temp = query.queryItemValue("end").toInt(&ok);
+    int pageLength = 25;
+    temp = query.queryItemValue("pageLength").toInt(&ok);
     if (ok)
-      end = temp;
+      pageLength = temp;
+
+    auto end = start + pageLength;
 
     auto searcher = app->getLibrary()->getSearcher(bookId);
     searcher->search(searchQuery, start, end);
@@ -115,6 +117,7 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     renderer.setSearchContent(bookId.toStdString());
     renderer.setProtocolPrefix("zim://");
     renderer.setSearchProtocolPrefix("zim://" + host.toStdString() + "/?");
+    renderer.setPageLength(pageLength);
     auto content = renderer.getHtml();
     QBuffer *buffer = new QBuffer;
     buffer->setData(content.data(), content.size());


### PR DESCRIPTION
Fixes #617 

The `pageLength` parameter of `kiwix::SearchRenderer` is not set properly which causes it to take an arbitrarily large value, breaking pagination.

The solution is to use the same convention as kiwix-serve. Try to read the `pageLength` from `query` if found, else use a default value of 25. Use this `pageLength` to find `end`. Use `renderer.setPageLength()` method to set the `pageLength` properly.

The changes included in this PR are:
- Find `pageLength` from the query, fall back to a default value of 25
- Use this `pageLength` to find `end`
- Set the `pageLength` in the renderer