### PR TITLE
fix fullscreen behavior

### DIFF
--- a/src/fullscreennotification.h
+++ b/src/fullscreennotification.h
@@ -2,21 +2,18 @@
 #define FULLSCREENNOTIFICATION_H
 
 #include <QLabel>
-
+class QSequentialAnimationGroup;
+class QGraphicsOpacityEffect;
 class FullScreenNotification : public QLabel
 {
     Q_OBJECT
 public:
     FullScreenNotification(QWidget *parent = nullptr);
-
-protected:
-    void showEvent(QShowEvent *event) override;
-
-signals:
-    void shown();
+    void show();
 
 private:
-    bool m_previouslyVisible;
+    QSequentialAnimationGroup *m_animations {nullptr};
+    QGraphicsOpacityEffect *m_effect {nullptr};
 };
 
 #endif // FULLSCREENNOTIFICATION_H

--- a/src/fullscreenwindow.cpp
+++ b/src/fullscreenwindow.cpp
@@ -2,36 +2,38 @@
 #include "kiwixapp.h"
 #include <QAction>
 
-FullScreenWindow::FullScreenWindow(QWebEngineView *oldView, QWidget *parent)
-    : QWidget(parent)
-    , m_view(new QWebEngineView(this))
+FullScreenWindow::FullScreenWindow()
+    : m_view(new QWebEngineView(this))
     , m_notification(new FullScreenNotification(this))
-    , m_oldView(oldView)
-    , m_oldGeometry(oldView->window()->geometry())
 {
     m_view->stackUnder(m_notification);
-
+    setMouseTracking(true);
     auto exitAction = new QAction(this);
     exitAction->setShortcut(Qt::Key_Escape);
     connect(exitAction, &QAction::triggered, []{
         KiwixApp::instance()->getAction(KiwixApp::ToggleFullscreenAction)->trigger();
     });
     addAction(exitAction);
-
-    m_view->setPage(m_oldView->page());
-    setGeometry(m_oldGeometry);
-    showFullScreen();
-    m_oldView->window()->hide();
 }
 
-FullScreenWindow::~FullScreenWindow()
+void FullScreenWindow::reset(QWebEngineView *oldView)
 {
-    m_oldView->setPage(m_view->page());
-    m_oldView->window()->setGeometry(m_oldGeometry);
-    m_oldView->window()->show();
-    hide();
+    m_oldView = oldView;
+    m_view->setPage(m_oldView->page());
+    showFullScreen();
+    m_notification->show();
 }
-
+void FullScreenWindow::exit()
+{
+    hide();
+    m_oldView->setPage(m_view->page());
+    m_oldView->window()->show();
+    m_oldView = nullptr;
+}
+bool FullScreenWindow::isFullScreen()
+{
+    return m_oldView;
+}
 void FullScreenWindow::resizeEvent(QResizeEvent *event)
 {
     QRect viewGeometry(QPoint(0, 0), size());

--- a/src/fullscreenwindow.cpp
+++ b/src/fullscreenwindow.cpp
@@ -1,4 +1,5 @@
 #include "fullscreenwindow.h"
+#include "kiwixapp.h"
 #include <QAction>
 
 FullScreenWindow::FullScreenWindow(QWebEngineView *oldView, QWidget *parent)
@@ -12,8 +13,8 @@ FullScreenWindow::FullScreenWindow(QWebEngineView *oldView, QWidget *parent)
 
     auto exitAction = new QAction(this);
     exitAction->setShortcut(Qt::Key_Escape);
-    connect(exitAction, &QAction::triggered, [this]() {
-        m_view->triggerPageAction(QWebEnginePage::ExitFullScreen);
+    connect(exitAction, &QAction::triggered, []{
+        KiwixApp::instance()->getAction(KiwixApp::ToggleFullscreenAction)->trigger();
     });
     addAction(exitAction);
 

--- a/src/fullscreenwindow.h
+++ b/src/fullscreenwindow.h
@@ -15,17 +15,21 @@ class FullScreenWindow : public QWidget
 {
     Q_OBJECT
 public:
-    explicit FullScreenWindow(QWebEngineView *oldView, QWidget *parent = nullptr);
-    ~FullScreenWindow();
-
+    static FullScreenWindow &instance() {
+        static FullScreenWindow singleton;
+        return singleton;
+    }
+    void reset(QWebEngineView *oldView);
+    void exit();
+    bool isFullScreen();
 protected:
     void resizeEvent(QResizeEvent *event) override;
 
 private:
-    QWebEngineView *m_view;
-    FullScreenNotification *m_notification;
-    QWebEngineView *m_oldView;
-    QRect m_oldGeometry;
+    FullScreenWindow();
+    QWebEngineView *m_view {nullptr};
+    FullScreenNotification *m_notification {nullptr};
+    QWebEngineView *m_oldView {nullptr};
 };
 
 #endif // FULLSCREENWINDOW_H

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -348,6 +348,7 @@ void KiwixApp::createAction()
 
     CREATE_ACTION_ICON(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"));
     SET_SHORTCUT(ToggleFullscreenAction, QKeySequence::FullScreen);
+    SET_SHORTCUT(ToggleFullscreenAction, {Qt::CTRL + Qt::Key_F11});
     connect(mpa_actions[ToggleFullscreenAction], &QAction::toggled,
             this, [=](bool checked) {
         auto action = mpa_actions[ToggleFullscreenAction];

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -10,7 +10,6 @@ KProfile::KProfile(QObject *parent) :
 {
     connect(this, &QWebEngineProfile::downloadRequested, this, &KProfile::startDownload);
     installUrlSchemeHandler("zim", &m_schemeHandler);
-    settings()->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, true);
 }
 
 void KProfile::startDownload(QWebEngineDownloadItem* download)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -23,8 +23,6 @@ MainWindow::MainWindow(QWidget *parent) :
     auto app = KiwixApp::instance();
     connect(app->getAction(KiwixApp::ExitAction), &QAction::triggered,
             this, &QMainWindow::close);
-    connect(app->getAction(KiwixApp::ToggleFullscreenAction), &QAction::triggered,
-            this, &MainWindow::toggleFullScreen);
     connect(app->getAction(KiwixApp::AboutAction), &QAction::triggered,
             mp_about, &QDialog::show);
     connect(app->getAction(KiwixApp::DonateAction), &QAction::triggered,
@@ -53,13 +51,6 @@ MainWindow::MainWindow(QWidget *parent) :
 MainWindow::~MainWindow()
 {
     delete mp_ui;
-}
-
-void MainWindow::toggleFullScreen() {
-    if (isFullScreen())
-        showNormal();
-    else
-        showFullScreen();
 }
 
 void MainWindow::keyPressEvent(QKeyEvent *event)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -28,7 +28,6 @@ public:
     ContentManagerSide* getSideContentManager();
 
 protected slots:
-    void toggleFullScreen();
     void keyPressEvent(QKeyEvent *event);
 
 private:

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -25,6 +25,13 @@ TabBar::TabBar(QWidget *parent) :
     connect(this, &QTabBar::currentChanged, this, &TabBar::onCurrentChanged, Qt::QueuedConnection);
     auto app = KiwixApp::instance();
 
+    connect(app->getAction(KiwixApp::ToggleFullscreenAction), &QAction::triggered,
+        [this]{
+        if (m_fullScreenWindow) {
+            m_fullScreenWindow.reset();
+        } else
+            m_fullScreenWindow.reset(new FullScreenWindow(this->currentWebView()));
+    });
     connect(app->getAction(KiwixApp::NewTabAction), &QAction::triggered,
             this, [=]() {
                 this->createNewTab(true);
@@ -320,21 +327,6 @@ void TabBar::onCurrentChanged(int index)
         Q_ASSERT(false);
         // In the future, other types of tabs can be added.
         // For example, About dialog, or Kiwix Server control panel.
-    }
-}
-
-void TabBar::fullScreenRequested(QWebEngineFullScreenRequest request)
-{
-    if (request.toggleOn()) {
-        if (m_fullScreenWindow)
-            return;
-        request.accept();
-        m_fullScreenWindow.reset(new FullScreenWindow(this->currentWebView()));
-    } else {
-        if (!m_fullScreenWindow)
-            return;
-        request.accept();
-        m_fullScreenWindow.reset();
     }
 }
 

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -29,8 +29,8 @@ TabBar::TabBar(QWidget *parent) :
         [this]{
         if (m_fullScreenWindow) {
             m_fullScreenWindow.reset();
-        } else
-            m_fullScreenWindow.reset(new FullScreenWindow(this->currentWebView()));
+        } else if (currentWebView())
+            m_fullScreenWindow.reset(new FullScreenWindow(currentWebView()));
     });
     connect(app->getAction(KiwixApp::NewTabAction), &QAction::triggered,
             this, [=]() {

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -1,5 +1,5 @@
 #include "tabbar.h"
-
+#include "fullscreenwindow.h"
 #include "kiwixapp.h"
 #include <QAction>
 #include <QTimer>
@@ -27,10 +27,11 @@ TabBar::TabBar(QWidget *parent) :
 
     connect(app->getAction(KiwixApp::ToggleFullscreenAction), &QAction::triggered,
         [this]{
-        if (m_fullScreenWindow) {
-            m_fullScreenWindow.reset();
+        auto &fullscreenWin = FullScreenWindow::instance();
+        if (fullscreenWin.isFullScreen()) {
+            fullscreenWin.exit();
         } else if (currentWebView())
-            m_fullScreenWindow.reset(new FullScreenWindow(currentWebView()));
+            fullscreenWin.reset(currentWebView());
     });
     connect(app->getAction(KiwixApp::NewTabAction), &QAction::triggered,
             this, [=]() {

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -7,7 +7,6 @@
 #include "webview.h"
 #include "zimview.h"
 #include "contentmanagerview.h"
-#include "fullscreenwindow.h"
 #include <QMouseEvent>
 #include <QWebEngineFullScreenRequest>
 
@@ -63,7 +62,6 @@ public slots:
 
 private:
     QStackedWidget*     mp_stackedWidget;
-    QScopedPointer<FullScreenWindow> m_fullScreenWindow;
 
     void setSelectionBehaviorOnRemove(int index);
 

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -60,7 +60,6 @@ signals:
 public slots:
     void closeTab(int index);
     void onCurrentChanged(int index);
-    void fullScreenRequested(QWebEngineFullScreenRequest request);
 
 private:
     QStackedWidget*     mp_stackedWidget;

--- a/src/zimview.cpp
+++ b/src/zimview.cpp
@@ -43,7 +43,6 @@ ZimView::ZimView(TabBar *tabBar, QWidget *parent)
                 auto key = mp_webView->zimId() + "/zoomFactor";
                 settingsManager->deleteSettings(key);
             });
-    connect(mp_webView->page(), &QWebEnginePage::fullScreenRequested, mp_tabBar, &TabBar::fullScreenRequested);
     connect(mp_webView, &WebView::titleChanged, this,
             [=](const QString& str) {
                 mp_tabBar->setTitleOf(str, this);


### PR DESCRIPTION
#571 

As I [proposed](https://github.com/kiwix/kiwix-desktop/pull/580#issuecomment-777429459), this removes fullscreen in mainwindow. And I also removed `fullscreenrequested` as well. Because according to [Qt](https://doc.qt.io/qt-5/qwebenginepage.html#fullScreenRequested), this is used for full screen web element. We don't support full screen web element (e.g. full screen an embedded video). Instead, all full screen and exit full screen requests are re-directed to KiwixApp's `toggleFullScreenAction`, which itself will trigger Tabbar's FullScreenWindow.