### PR TITLE
FileDialog style and other efficiency fixes

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -67,7 +67,6 @@ void KiwixApp::init()
     setApplicationName("Kiwix");
     setDesktopFileName("kiwix.desktop");
 
-    setStyle(QStyleFactory::create("Windows"));
     QFile styleFile(":/css/style.css");
     styleFile.open(QIODevice::ReadOnly);
     auto byteContent = styleFile.readAll();

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -70,7 +70,6 @@ void KiwixApp::init()
     QFile styleFile(":/css/style.css");
     styleFile.open(QIODevice::ReadOnly);
     auto byteContent = styleFile.readAll();
-    styleFile.close();
     QString style(byteContent);
     setStyleSheet(style);
 
@@ -155,23 +154,26 @@ QString gt(const QString &key) {
 
 void KiwixApp::openZimFile(const QString &zimfile)
 {
-    QString _zimfile = zimfile;
-    if (_zimfile.isEmpty()) {
+    QString _zimfile;
+    if (zimfile.isEmpty()) {
         _zimfile = QFileDialog::getOpenFileName(
-            getMainWindow(),
-            gt("open-zim"),
-            QString(),
-            "ZimFile (*.zim*)");
+                    getMainWindow(),
+                    gt("open-zim"),
+                    QString(),
+                    "ZimFile (*.zim*)");
+
+        if (_zimfile.isEmpty()) {
+            return;
+        }
         _zimfile = QDir::toNativeSeparators(_zimfile);
     }
-    if (_zimfile.isEmpty()) {
-        return;
-    }
+
     QString zimId;
+    const auto &validZimFile = zimfile.isEmpty() ? _zimfile : zimfile;
     try {
-        zimId = m_library.openBookFromPath(_zimfile);
+        zimId = m_library.openBookFromPath(validZimFile);
     } catch (const std::exception& e) {
-        showMessage("Cannot open " + _zimfile + ": \n" + e.what());
+        showMessage("Cannot open " + validZimFile + ": \n" + e.what());
         return;
     }
     openUrl(QUrl("zim://"+zimId+".zim/"));


### PR DESCRIPTION
Setting windows style on non-windows platform makes FileDialog looks hideous. 
![Default style](https://user-images.githubusercontent.com/76819220/116892791-c95cb280-ac62-11eb-86d1-ece16de1fd89.png)
![After set the Windows style](https://user-images.githubusercontent.com/76819220/116892795-ca8ddf80-ac62-11eb-8949-ca6b13e533bb.png)

Note that "Windows" style is not what you usually want even if you like windows style. "QWindowsVistaStyle" is what people usually choose. 

Other changes include:
* Avoid extra copy on `KiwixApp::openZimFile`
* Remove `close()` on QFile because it close file in destructor, call it here you pay one more check on destructing (and extra line of code)