### PR TITLE
Bind backward & forward mouse buttons to web history

### DIFF
--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -112,6 +112,16 @@ bool WebView::eventFilter(QObject *src, QEvent *e)
             QDesktopServices::openUrl(m_linkHovered);
             return true;
         }
+        if (me->button() == Qt::BackButton)
+        {
+            back();
+            return true;
+        }
+        if (me->button() == Qt::ForwardButton)
+        {
+            forward();
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
Spawned from #618 

Fixes #647 

It works with my own mouse. (Logitech MX518)