### PR TITLE
Partial fix of #540: do not emit others object signals.

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -338,6 +338,18 @@ void TabBar::fullScreenRequested(QWebEngineFullScreenRequest request)
     }
 }
 
+void TabBar::on_webview_titleChanged(const QString& title)
+{
+    ZimView* tab = qobject_cast<ZimView*>(sender()->parent());
+    if (! tab)
+        return;
+
+    setTitleOf(title, tab);
+
+    if (currentZimView() == tab)
+        emit currentTitleChanged(title);
+}
+
 void TabBar::mousePressEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::MiddleButton) {

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -14,8 +14,6 @@
 class TabBar : public QTabBar
 {
     Q_OBJECT
-    Q_PROPERTY(QString currentZimId READ currentZimId NOTIFY currentZimIdChanged)
-
 public:
     TabBar(QWidget* parent=nullptr);
     void setStackedWidget(QStackedWidget* widget);
@@ -54,13 +52,13 @@ protected:
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
     void libraryPageDisplayed(bool displayed);
-    void currentZimIdChanged(const QString& zimId);
     void currentTitleChanged(const QString& title);
 
 public slots:
     void closeTab(int index);
     void onCurrentChanged(int index);
     void fullScreenRequested(QWebEngineFullScreenRequest request);
+    void on_webview_titleChanged(const QString& title);
 
 private:
     QStackedWidget*     mp_stackedWidget;

--- a/src/zimview.cpp
+++ b/src/zimview.cpp
@@ -15,7 +15,7 @@ ZimView::ZimView(TabBar *tabBar, QWidget *parent)
     layout->addWidget(mp_findInPageBar);
     layout->setContentsMargins(0,0,0,0);
     layout->setSpacing(0);
-    setLayout(layout);
+    setLayout(layout); // now 'mp_webView' has 'this' as the parent QObject
     mp_findInPageBar->hide();
     auto app = KiwixApp::instance();
     connect(app->getAction(KiwixApp::ZoomInAction), &QAction::triggered,
@@ -44,23 +44,10 @@ ZimView::ZimView(TabBar *tabBar, QWidget *parent)
                 settingsManager->deleteSettings(key);
             });
     connect(mp_webView->page(), &QWebEnginePage::fullScreenRequested, mp_tabBar, &TabBar::fullScreenRequested);
-    connect(mp_webView, &WebView::titleChanged, this,
-            [=](const QString& str) {
-                mp_tabBar->setTitleOf(str, this);
-                if (mp_tabBar->currentZimView() != this) {
-                    return;
-                }
-                emit mp_tabBar->currentTitleChanged(str);
-            });
+    connect(mp_webView, &WebView::titleChanged, mp_tabBar, &TabBar::on_webview_titleChanged);
     connect(mp_webView, &WebView::iconChanged, this,
             [=](const QIcon& icon) { mp_tabBar->setIconOf(icon, this); });
-    connect(mp_webView, &WebView::zimIdChanged, this,
-            [=](const QString& zimId) {
-                if (mp_tabBar->currentZimView() != this) {
-                    return;
-                }
-                emit mp_tabBar->currentZimIdChanged(zimId);
-            });
+
     connect(mp_webView->page()->action(QWebEnginePage::Back), &QAction::changed,
             [=]() {
                 if (mp_tabBar->currentZimView() != this) {

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -17,13 +17,10 @@ public:
     FindInPageBar *getFindInPageBar() { return mp_findInPageBar; }
     void openFindInPageBar();
 
-signals:
-
 private:
     WebView *mp_webView;
     TabBar *mp_tabBar;
     FindInPageBar *mp_findInPageBar;
-
 };
 
 #endif // ZIMVIEW_H


### PR DESCRIPTION
This pull request fixes the codebase: signals should be emitted only by the object itself.

This is the "part 1" PR for #540:

* stop emitting TabBar::currentTitleChanged() from class ZimView
* stop emitting TabBar::currentZimIdChanged() from class ZimView - removed, not used anywhere