### PR TITLE
Fixes #592 Explicitly specify black font color by default

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,5 +1,6 @@
 QWidget {
     background-color: #EAECF0;
+    color: #000000;
 }
 
 


### PR DESCRIPTION
Fixes #592 Explicitly specify black font color by default
(like it is in light color themes).