### PR TITLE
Back/Forward buttons now have menus with history items

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -50,10 +50,6 @@ SearchBar > QPushButton {
     width: 32px;
 }
 
-/* ----------------------------------------
-   Menu
-*/
-
 TopWidget QToolButton:pressed,
 TopWidget QToolButton::hover {
     border: 1px solid #3366CC;
@@ -70,17 +66,25 @@ TopWidget QToolButton::menu-arrow {
     image: none;
 }
 
-TopWidget QToolButton#leftHistoryButton {
-    margin-left: 4px;
+TopWidget QToolButton::menu-indicator {
+    width: 0px; /* it can be hidden at all by setting 0px */
+    height: 0px;
+    subcontrol-origin: padding;
 }
 
-TopWidget QToolButton#rightHistoryButton {
-    margin-right: 4px;
+TopWidget QToolButton#backButton {
+    margin-left: 6px;  /* see also: void WebViewBackMenu::showEvent(QShowEvent *) { geo.setX(geo.x() + 6); } */
 }
 
 TopWidget QToolButton#fullScreenButton {
     margin-right: 6px;
 }
+
+
+
+/* ----------------------------------------
+   Menu
+*/
 
 QMenu {
     border: none;
@@ -92,7 +96,7 @@ QMenu::item {
     min-height: 40px;
     max-height: 40px;
     border: 1px solid transparent;
-    padding: 2px 12px 2px 40px;
+    padding: 2px 12px 2px 40px;     /* top right bottom left */
 }
 
 QMenu::icon {
@@ -105,11 +109,22 @@ QMenu::item:selected {
     border: 1px solid #3366CC;
 }
 
-QMenu::indicator {
+
+MainMenu::indicator {
     color: #666666;
     width: 13px;
     height: 13px;
 }
+
+WebViewForwardMenu::item, WebViewBackMenu::item {
+    padding: 2px 12px;
+}
+
+WebViewForwardMenu::icon, WebViewBackMenu::icon {
+    min-width: 2px;
+    min-height: 2px;
+}
+
 
 /* -----------------------------------------
     TabWidget

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -6,7 +6,6 @@
 #include "mainwindow.h"
 #include "kiwix/downloader.h"
 #include <kiwix/kiwixserve.h>
-#include "tabbar.h"
 #include "kprofile.h"
 #include "urlschemehandler.h"
 #include "settingsmanager.h"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -49,6 +49,9 @@ MainWindow::MainWindow(QWidget *parent) :
     }
     QWindowsWindowFunctions::setHasBorderInFullScreen(window, true);
 #endif
+
+    connect(mp_ui->tabBar, &QTabBar::currentChanged,
+            mp_ui->mainToolBar, &TopWidget::updateBackForwardButtons);
 }
 
 MainWindow::~MainWindow()

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -90,6 +90,7 @@ SearchBar::SearchBar(QWidget *parent) :
     });
     connect(this, &QLineEdit::textChanged, this,
             [=](const QString &text) {
+                Q_UNUSED(text)
                 if (m_returnPressed) {
                     this->setText(m_searchbarInput);
                 }

--- a/src/topwidget.h
+++ b/src/topwidget.h
@@ -4,6 +4,7 @@
 #include <QToolBar>
 #include <QLineEdit>
 #include <QWebEnginePage>
+#include <QScopedPointer>
 
 #include "searchbar.h"
 
@@ -15,19 +16,24 @@ public:
     virtual ~TopWidget();
 
     SearchBar &getSearchBar() { return m_searchEntry; };
+
+public slots:
+    void handleWebActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
+    void updateBackForwardButtons();
+
 protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
 
 private:
     SearchBar m_searchEntry;
-    QAction* mp_historyBackAction;
-    QAction* mp_historyForwardAction;
     QPoint m_cursorPos;
     ulong m_timestamp;
+    QScopedPointer<QMenu, QScopedPointerDeleteLater> back_menu;
+    QScopedPointer<QMenu, QScopedPointerDeleteLater> forward_menu;
 
-public slots:
-    void handleWebActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
+    QToolButton* getBackButton() const;
+    QToolButton* getForwardButton() const;
 };
 
 #endif // TOPWIDGET_H

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -1,14 +1,45 @@
 #include "webview.h"
 
 #include <QDesktopServices>
-#include <QMenu>
 #include <QAction>
 #include <iostream>
 #include "kiwixapp.h"
 #include "webpage.h"
 #include <QToolTip>
 #include <QWebEngineSettings>
+#include <QWebEngineHistory>
 #include <QVBoxLayout>
+
+
+void WebViewBackMenu::showEvent(QShowEvent *)
+{
+    /* In Qt 5.12 CSS options for shifting this menu didn't work.
+     * In particular:
+     *   - toolbar->setContentsMargins(0,0,0,0);
+     *   - toolbar->layout()->setContentsMargins(0,0,0,0);
+     *   - QToolBar {   padding-left: }
+     *   - QToolBar {   margin-left; }
+     *   - QToolBar {   padding: 5px 12px 5px 12px; }
+     *   - QToolBar::separator:first { width: 10px; }
+     *  (that was attempts to set some spacing on left and right in toolbar
+     *  so back button will be shifted right.
+     *  If in Qt 6.x QToolButton shows its menu in the right position
+     *  this code can be removed.
+     */
+
+    QRect geo = geometry();
+    geo.moveLeft(geo.left() + 6);  // see also: style.css: QToolButton#backButton { margin-left: 6px; }
+    geo.moveTop(geo.top() + 2);
+    setGeometry(geo);
+}
+
+void WebViewForwardMenu::showEvent(QShowEvent *)
+{
+    QRect geo = geometry();
+    geo.moveTop(geo.top() + 2);
+    setGeometry(geo);
+}
+
 
 WebView::WebView(QWidget *parent)
     : QWebEngineView(parent)
@@ -27,6 +58,60 @@ bool WebView::isWebActionEnabled(QWebEnginePage::WebAction webAction) const
 {
     return page()->action(webAction)->isEnabled();
 }
+
+QMenu* WebView::getHistoryBackMenu() const
+{
+    QWebEngineHistory *h = history();
+
+    const int cur = h->currentItemIndex();
+    if (cur <= 0) {
+        return Q_NULLPTR;
+    }
+
+    auto ret = new WebViewBackMenu();
+    for (int i = cur - 1 ; i >= 0 ; i--) {
+        addHistoryItemAction(ret, h->itemAt(i), i);
+    }
+    return ret;
+}
+
+QMenu* WebView::getHistoryForwardMenu() const
+{
+    QWebEngineHistory *h = history();
+
+    const int cur = h->currentItemIndex();
+    if (cur + 1 >= h->count()) {
+        return Q_NULLPTR;
+    }
+
+    auto ret = new WebViewForwardMenu();
+    for (int i = cur + 1 ; i < h->count() ; i++) {
+        addHistoryItemAction(ret, h->itemAt(i), i);
+    }
+    return ret;
+}
+
+void WebView::addHistoryItemAction(QMenu *menu, const QWebEngineHistoryItem &item, int n) const
+{
+    QAction *a = menu->addAction(item.title());
+    a->setData(QVariant::fromValue(n));
+    connect(a, &QAction::triggered, this, &WebView::gotoTriggeredHistoryItemAction);
+}
+
+void WebView::gotoTriggeredHistoryItemAction()
+{
+    QAction *a = qobject_cast<QAction*>(QObject::sender());
+    if (!a)
+        return;
+
+    int n = a->data().toInt();
+    QWebEngineHistory *h = history();
+    if (n < 0 || n >= h->count())
+        return;
+
+    h->goToItem(h->itemAt(n));
+}
+
 
 QWebEngineView* WebView::createWindow(QWebEnginePage::WebWindowType type)
 {

--- a/src/webview.h
+++ b/src/webview.h
@@ -4,9 +4,30 @@
 #include <QWebEngineView>
 #include <QIcon>
 #include <QWheelEvent>
+#include <QMenu>
 
 #include <kiwix/reader.h>
 #include "findinpagebar.h"
+
+class QWebEngineHistoryItem;
+
+
+class WebViewBackMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    WebViewBackMenu(QWidget* parent=nullptr) : QMenu(parent) {}
+    void showEvent(QShowEvent *);
+};
+
+class WebViewForwardMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    WebViewForwardMenu(QWidget* parent=nullptr) : QMenu(parent) {}
+    void showEvent(QShowEvent *);
+};
+
 
 class WebView : public QWebEngineView
 {
@@ -21,6 +42,9 @@ public:
     bool isWebActionEnabled(QWebEnginePage::WebAction webAction) const;
     const QIcon &icon() { return m_icon; }
     const QString &zimId() { return m_currentZimId; }
+
+    QMenu* getHistoryBackMenu() const;
+    QMenu* getHistoryForwardMenu() const;
 
 public slots:
     void onUrlChanged(const QUrl& url);
@@ -39,6 +63,12 @@ protected:
     QString m_currentZimId;
     QIcon m_icon;
     QString m_linkHovered;
+
+private slots:
+    void gotoTriggeredHistoryItemAction();
+
+private:
+    void addHistoryItemAction(QMenu *menu, const QWebEngineHistoryItem &item, int n) const;
 };
 
 #endif // WEBVIEW_H

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -2,10 +2,10 @@
 #define ZIMVIEW_H
 
 #include <QWidget>
-#include "webview.h"
 #include "findinpagebar.h"
 
 class TabBar;
+class WebView;
 
 class ZimView : public QWidget
 {


### PR DESCRIPTION
Issue #3: Back/Forward buttons now have menus with history items

To see this change in action:
* open any zim file. See Back/Forward buttons: they are disabled, no submenu
* click on any link in opened document. Back button became active, long press on it will show the title of previously visited page (but don't select any item this time)
* click on any link again.  Long press on Back button. This time submenu will have two  items
* click on Back button. Forward button should be activated, long press on Forward button will show the title of document which had be just seen
* click on Back button again. Back button will be disabled. Forward button menu will contain two items.
