### PR TITLE
Added attribute to show tooltips even when the window is unfocused.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -17,6 +17,7 @@ MainWindow::MainWindow(QWidget *parent) :
     mp_about(new About(this)),
     mp_localKiwixServer(new LocalKiwixServer(this))
 {
+    QWidget::setAttribute(Qt::WA_AlwaysShowToolTips);
     mp_ui->setupUi(this);
     mp_ui->tabBar->setExpanding(false);
     mp_ui->tabBar->setStackedWidget(mp_ui->mainView);


### PR DESCRIPTION
Fixes #666 

The attribute of QWidget : Qt::WA_AlwaysShowToolTips  is added.