### PR TITLE
PPA: Temporarily disable Impish builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - ubuntu-impish
+          # - ubuntu-impish
           - ubuntu-hirsute
           - ubuntu-focal
           - ubuntu-bionic
@@ -34,13 +34,14 @@ jobs:
           email: release+launchpad@kiwix.org
           distro: ${{ matrix.distro }}
 
-      - uses: legoktm/gh-action-build-deb@ubuntu-impish
-        if: matrix.distro == 'ubuntu-impish'
-        name: Build package for ubuntu-impish
-        id: build-ubuntu-impish
-        with:
-          args: --no-sign
-          ppa: ${{ steps.ppa.outputs.ppa }}
+      # Temporarily disabled, Impish keeps changing and breaking the build
+      #- uses: legoktm/gh-action-build-deb@ubuntu-impish
+      #  if: matrix.distro == 'ubuntu-impish'
+      #  name: Build package for ubuntu-impish
+      #  id: build-ubuntu-impish
+      #  with:
+      #    args: --no-sign
+      #    ppa: ${{ steps.ppa.outputs.ppa }}
 
       - uses: legoktm/gh-action-build-deb@ubuntu-hirsute
         if: matrix.distro == 'ubuntu-hirsute'


### PR DESCRIPTION
Impish is in active development and builds keep randomly failing for different reasons. I think we can re-enable this in a few months when Impish is closer to release and much more stable.