### PR TITLE
Fixes #693: Draw tab title with gradient to fade-out

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -136,9 +136,7 @@ QTabBar::tab {
 }
 
 QTabBar::tab:selected {
-    /* please keep it in sync with 'selected_tab_bg_color' in src/tabbar.cpp */
     background-color: white;
-
     border-bottom: 2px solid white;
 }
 


### PR DESCRIPTION
This is reworked approach of tab title fade-out:
Take away tab title from QTabBar and draw it on our own, with gradient if need.

Tested with text in both directions (English and Arabic):

![Screenshot from 2021-10-16 17-25-12](https://user-images.githubusercontent.com/5078434/137583930-0d9fa3a6-4f56-45e5-a7cc-dd9d7c6991a1.png)
