### PR TITLE
Code clean up: illiminate KiwixApp::SideBarType property

### DIFF
--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -23,7 +23,6 @@
 class KiwixApp : public QtSingleApplication
 {
     Q_OBJECT
-    Q_PROPERTY(SideBarType currentSideType MEMBER m_currentSideType NOTIFY currentSideTypeChanged)
 
 public:
     enum Actions {
@@ -59,11 +58,6 @@ public:
         ExitAction,
         MAX_ACTION
     };
-    enum SideBarType {
-        CONTENTMANAGER_BAR,
-        READINGLIST_BAR,
-        NONE
-    };
 
     KiwixApp(int& argc, char *argv[]);
     virtual ~KiwixApp();
@@ -77,27 +71,24 @@ public:
     KProfile* getProfile() { return &m_profile; }
     Library* getLibrary() { return &m_library; }
     MainWindow* getMainWindow() { return mp_mainWindow; }
+    ContentManager* getContentManager() { return mp_manager; }
     kiwix::Downloader* getDownloader() { return mp_downloader; }
     TabBar* getTabWidget() { return mp_tabWidget; }
     QAction* getAction(Actions action);
     QString getLibraryDirectory() { return m_libraryDirectory; };
     kiwix::Server* getLocalServer() { return &m_server; }
     SettingsManager* getSettingsManager() { return &m_settingsManager; };
-    SideBarType getSideType() { return m_currentSideType; }
     QString getText(const QString &key) { return m_translation.getText(key); };
 
     bool isCurrentArticleBookmarked();
 
 signals:
     void currentTitleChanged(const QString& title);
-    void currentSideTypeChanged(SideBarType type);
 
 public slots:
     void openZimFile(const QString& zimfile="");
     void openUrl(const QString& url, bool newTab=true);
     void openUrl(const QUrl& url, bool newTab=true);
-    void setSideBar(SideBarType type);
-    void toggleSideBar(KiwixApp::SideBarType type);
     void printPage();
     void disableItemsOnLibraryPage(bool displayed);
     void updateNameMapper();
@@ -117,7 +108,6 @@ private:
     ContentManager* mp_manager;
     MainWindow* mp_mainWindow;
     TabBar* mp_tabWidget;
-    SideBarType m_currentSideType;
     QErrorMessage* mp_errorDialog;
     kiwix::UpdatableNameMapper m_nameMapper;
     kiwix::Server m_server;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,12 +24,15 @@ public:
 
     TabBar*   getTabBar();
     TopWidget* getTopWidget();
-    QStackedWidget* getSideDockWidget();
-    ContentManagerSide* getSideContentManager();
 
-protected slots:
-    void toggleFullScreen();
+protected:
     void keyPressEvent(QKeyEvent *event);
+
+private slots:
+    void toggleFullScreen();
+    void when_ReadingList_toggled(bool state);
+    void when_libraryPageDisplayed(bool showed);
+
 private:
     Ui::MainWindow *mp_ui;
     About     *mp_about;

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -64,7 +64,6 @@ TabBar::TabBar(QWidget *parent) :
                 int index = currentIndex() + 1;
                 mp_stackedWidget->insertWidget(index, view);
                 insertTab(index,QIcon(":/icons/settings.svg"), gt("settings"));
-                KiwixApp::instance()->setSideBar(KiwixApp::SideBarType::NONE);
                 QToolButton *tb = new QToolButton(this);
                 tb->setDefaultAction(KiwixApp::instance()->getAction(KiwixApp::CloseTabAction));
                 setTabButton(index, QTabBar::RightSide, tb);
@@ -296,22 +295,17 @@ void TabBar::onCurrentChanged(int index)
         emit webActionEnabledChanged(QWebEnginePage::Back, false);
         emit webActionEnabledChanged(QWebEnginePage::Forward, false);
         emit libraryPageDisplayed(false);
-        KiwixApp::instance()->setSideBar(KiwixApp::NONE);
         QTimer::singleShot(0, [=](){emit currentTitleChanged("");});
     } else if (auto zv = qobject_cast<ZimView*>(w)) {
         auto view = zv->getWebView();
         emit webActionEnabledChanged(QWebEnginePage::Back, view->isWebActionEnabled(QWebEnginePage::Back));
         emit webActionEnabledChanged(QWebEnginePage::Forward, view->isWebActionEnabled(QWebEnginePage::Forward));
         emit libraryPageDisplayed(false);
-        if (KiwixApp::instance()->getSideType() == KiwixApp::CONTENTMANAGER_BAR) {
-            KiwixApp::instance()->setSideBar(KiwixApp::NONE);
-        }
         QTimer::singleShot(0, [=](){emit currentTitleChanged(view->title());});
     } else if (qobject_cast<ContentManagerView*>(w)) {
         emit webActionEnabledChanged(QWebEnginePage::Back, false);
         emit webActionEnabledChanged(QWebEnginePage::Forward, false);
         emit libraryPageDisplayed(true);
-        KiwixApp::instance()->setSideBar(KiwixApp::CONTENTMANAGER_BAR);
         QTimer::singleShot(0, [=](){emit currentTitleChanged("");});
     }
     else {


### PR DESCRIPTION
While working on #540 I discovered it difficult to understand why do we need KiwixApp::currentSideType  QObject property, and all the complicated logic around it:

* QObject property which can be accessed via JS / QML Script  KiwixApp::currentSide  (but it's not used from JS code)
* three-state enum KiwixApp::SideBarType
* KiwixApp::setSideBar(type)
* KiwixApp::toggleSideBar(type)
* signal  KiwixApp::currentSideTypeChanged
* Tabbar::onCurrentChanged(tab index) used these methods above

Actually, it's MainWindow who owns TabBar and SideBar, should know what to do with them. But it didn't.

Fixed by this PR.

Instead of complicated three-state logic straight-forward (and much shorter) code is written in MainWindow.

The behavior is the same as was before:
* ContentList is shown with the library tab
* after switching back to Settings or Zim document tab  Reading list hides if it was shown before.

If we don't like the current behavior it's better to change it by creating a new issue.
This PR doesn't change the behavior, just clean up the code.

The approach used by CREATE_ACTION_ONOFF_ICON_SHORTCUT  can be extended to ToggleFullscreenAction action also: QIcon may have state: https://doc.qt.io/qt-5/qicon.html#State-enum
and the action icon is chosen appropriately to its state, no need to manually change the icon every time QAction is toggled.
