### PR TITLE
Part 2 to fix #540: don't emit tabbar signal from zimview

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -400,8 +400,6 @@ void KiwixApp::createAction()
 void KiwixApp::postInit() {
     connect(getTabWidget(), &TabBar::webActionEnabledChanged,
             mp_mainWindow->getTopWidget(), &TopWidget::handleWebActionEnabledChanged);
-    connect(getTabWidget(), &TabBar::currentTitleChanged, this,
-            [=](const QString& title) { emit currentTitleChanged(title); });
     connect(getTabWidget(), &TabBar::libraryPageDisplayed,
             this, &KiwixApp::disableItemsOnLibraryPage);
     emit(m_library.booksChanged());

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -81,9 +81,8 @@ void KiwixApp::init()
 
     createAction();
     mp_mainWindow = new MainWindow;
-    mp_tabWidget = mp_mainWindow->getTabBar();
-    mp_tabWidget->setContentManagerView(mp_manager->getView());
-    mp_tabWidget->setNewTabButton();
+    getTabWidget()->setContentManagerView(mp_manager->getView());
+    getTabWidget()->setNewTabButton();
     postInit();
     mp_errorDialog = new QErrorMessage(mp_mainWindow);
     setActivationWindow(mp_mainWindow);
@@ -186,14 +185,14 @@ void KiwixApp::openZimFile(const QString &zimfile)
 
 void KiwixApp::printPage()
 {
-    if(!mp_tabWidget->currentZimView())
+    if(!getTabWidget()->currentZimView())
         return;
     QPrinter* printer = new QPrinter();
     QPrintDialog printDialog(printer, mp_mainWindow);
     printDialog.setStyle(nullptr);
     printDialog.setStyleSheet("");
     if (printDialog.exec() == QDialog::Accepted) {
-        auto webview = mp_tabWidget->currentWebView();
+        auto webview = getTabWidget()->currentWebView();
         if(!webview)
             return;
         webview->page()->print(printer, [=](bool success) {
@@ -210,12 +209,12 @@ void KiwixApp::openUrl(const QString &url, bool newTab) {
 }
 
 void KiwixApp::openUrl(const QUrl &url, bool newTab) {
-    mp_tabWidget->openUrl(url, newTab);
+    getTabWidget()->openUrl(url, newTab);
 }
 
 void KiwixApp::openRandomUrl(bool newTab)
 {
-    auto zimId = mp_tabWidget->currentZimId();
+    auto zimId = getTabWidget()->currentZimId();
     if (zimId.isEmpty()) {
         return;
     }
@@ -354,7 +353,7 @@ void KiwixApp::createAction()
     CREATE_ACTION(FindInPageAction, gt("find-in-page"));
     mpa_actions[FindInPageAction]->setShortcuts({QKeySequence::Find, Qt::Key_F3});
     connect(mpa_actions[FindInPageAction], &QAction::triggered,
-            this, [=]() { mp_tabWidget->openFindInPageBar(); });
+            this, [=]() { getTabWidget()->openFindInPageBar(); });
 
     CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"),  QKeySequence::FullScreen);
     connect(mpa_actions[ToggleFullscreenAction], &QAction::toggled,
@@ -399,11 +398,11 @@ void KiwixApp::createAction()
 }
 
 void KiwixApp::postInit() {
-    connect(mp_tabWidget, &TabBar::webActionEnabledChanged,
+    connect(getTabWidget(), &TabBar::webActionEnabledChanged,
             mp_mainWindow->getTopWidget(), &TopWidget::handleWebActionEnabledChanged);
-    connect(mp_tabWidget, &TabBar::currentTitleChanged, this,
+    connect(getTabWidget(), &TabBar::currentTitleChanged, this,
             [=](const QString& title) { emit currentTitleChanged(title); });
-    connect(mp_tabWidget, &TabBar::libraryPageDisplayed,
+    connect(getTabWidget(), &TabBar::libraryPageDisplayed,
             this, &KiwixApp::disableItemsOnLibraryPage);
     emit(m_library.booksChanged());
     connect(&m_library, &Library::booksChanged, this, &KiwixApp::updateNameMapper);

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -398,8 +398,6 @@ void KiwixApp::createAction()
 }
 
 void KiwixApp::postInit() {
-    connect(getTabWidget(), &TabBar::webActionEnabledChanged,
-            mp_mainWindow->getTopWidget(), &TopWidget::handleWebActionEnabledChanged);
     connect(getTabWidget(), &TabBar::libraryPageDisplayed,
             this, &KiwixApp::disableItemsOnLibraryPage);
     emit(m_library.booksChanged());

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -82,9 +82,6 @@ public:
 
     bool isCurrentArticleBookmarked();
 
-signals:
-    void currentTitleChanged(const QString& title);
-
 public slots:
     void openZimFile(const QString& zimfile="");
     void openUrl(const QString& url, bool newTab=true);

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -7,7 +7,6 @@
 #include "kiwix/downloader.h"
 #include <kiwix/kiwixserve.h>
 #include "kprofile.h"
-#include "urlschemehandler.h"
 #include "settingsmanager.h"
 #include "translation.h"
 

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -74,7 +74,7 @@ public:
     MainWindow* getMainWindow() { return mp_mainWindow; }
     ContentManager* getContentManager() { return mp_manager; }
     kiwix::Downloader* getDownloader() { return mp_downloader; }
-    TabBar* getTabWidget() { return mp_tabWidget; }
+    TabBar* getTabWidget() { return getMainWindow()->getTabBar(); }
     QAction* getAction(Actions action);
     QString getLibraryDirectory() { return m_libraryDirectory; };
     kiwix::Server* getLocalServer() { return &m_server; }
@@ -108,7 +108,6 @@ private:
     kiwix::Downloader* mp_downloader;
     ContentManager* mp_manager;
     MainWindow* mp_mainWindow;
-    TabBar* mp_tabWidget;
     QErrorMessage* mp_errorDialog;
     kiwix::UpdatableNameMapper m_nameMapper;
     kiwix::Server m_server;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -38,7 +38,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(app->getAction(KiwixApp::KiwixServeAction), &QAction::triggered,
             mp_localKiwixServer, &QDialog::show);
 
-    connect(app, &KiwixApp::currentTitleChanged, this, [=](const QString& title) {
+    connect(mp_ui->tabBar, &TabBar::currentTitleChanged, this, [=](const QString& title) {
         if (!title.isEmpty() && !title.startsWith("zim://"))
             setWindowTitle(title + " - Kiwix");
         else
@@ -63,6 +63,14 @@ MainWindow::MainWindow(QWidget *parent) :
             mp_ui->mainToolBar, &TopWidget::updateBackForwardButtons);
     connect(mp_ui->tabBar, &TabBar::libraryPageDisplayed,
             this, &MainWindow::when_libraryPageDisplayed);
+
+    connect(mp_ui->tabBar, &TabBar::currentTitleChanged,
+            &(mp_ui->mainToolBar->getSearchBar()), &SearchBar::on_currentTitleChanged);
+
+    // This signal emited more often than the history really updated
+    // but for now we have no better signal for it.
+    connect(mp_ui->tabBar, &TabBar::currentTitleChanged,
+            mp_ui->mainToolBar, &TopWidget::updateBackForwardButtons);
 
     mp_ui->contentmanagerside->setContentManager(app->getContentManager());
     mp_ui->sideBar->setCurrentWidget(mp_ui->contentmanagerside);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -72,6 +72,9 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(mp_ui->tabBar, &TabBar::currentTitleChanged,
             mp_ui->mainToolBar, &TopWidget::updateBackForwardButtons);
 
+    connect(mp_ui->tabBar, &TabBar::webActionEnabledChanged,
+            mp_ui->mainToolBar, &TopWidget::handleWebActionEnabledChanged);
+
     mp_ui->contentmanagerside->setContentManager(app->getContentManager());
     mp_ui->sideBar->setCurrentWidget(mp_ui->contentmanagerside);
 }

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -80,8 +80,7 @@ SearchBar::SearchBar(QWidget *parent) :
 
     qRegisterMetaType<QVector<QUrl>>("QVector<QUrl>");
     connect(mp_typingTimer, &QTimer::timeout, this, &SearchBar::updateCompletion);
-    connect(KiwixApp::instance(), &KiwixApp::currentTitleChanged,
-            this, &SearchBar::on_currentTitleChanged);
+
     connect(this, &QLineEdit::textEdited, this,
             [=](const QString &text) {
                 m_searchbarInput = text;

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -144,6 +144,10 @@ ZimView* TabBar::createNewTab(bool setCurrent, bool adjacentToCurrentTab)
     if (setCurrent) {
         setCurrentIndex(index);
     }
+
+    connect(tab, &ZimView::webActionEnabledChanged,
+            this, &TabBar::onWebviewHistoryActionChanged);
+
     return tab;
 }
 
@@ -341,6 +345,16 @@ void TabBar::on_webview_titleChanged(const QString& title)
 
     if (currentZimView() == tab)
         emit currentTitleChanged(title);
+}
+
+void TabBar::onWebviewHistoryActionChanged(QWebEnginePage::WebAction action, bool enabled)
+{
+    ZimView *zv = qobject_cast<ZimView*>(sender());
+
+    if (!zv || zv != this->currentZimView())
+        return;
+
+    emit webActionEnabledChanged(action, enabled);
 }
 
 void TabBar::mousePressEvent(QMouseEvent *event)

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -68,6 +68,7 @@ private:
 private slots:
     void onTabMoved(int from, int to);
     void onCurrentChanged(int index);
+    void onWebviewHistoryActionChanged(QWebEnginePage::WebAction action, bool enabled);
 };
 
 #endif // TABWIDGET_H

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -56,7 +56,6 @@ signals:
 
 public slots:
     void closeTab(int index);
-    void onCurrentChanged(int index);
     void fullScreenRequested(QWebEngineFullScreenRequest request);
     void on_webview_titleChanged(const QString& title);
 
@@ -68,6 +67,7 @@ private:
 
 private slots:
     void onTabMoved(int from, int to);
+    void onCurrentChanged(int index);
 };
 
 #endif // TABWIDGET_H

--- a/src/topwidget.cpp
+++ b/src/topwidget.cpp
@@ -53,11 +53,6 @@ TopWidget::TopWidget(QWidget *parent) :
     addAction(menuAction);
     setContextMenuPolicy( Qt::PreventContextMenu );
 
-    // This signal emited more often than the history really updated
-    // but for now we have no better signal for it.
-    connect(KiwixApp::instance(), &KiwixApp::currentTitleChanged,
-            this, &TopWidget::updateBackForwardButtons);
-
 #if !SYSTEMTITLEBAR
     addAction(QIcon(":/icons/minimize.svg"), "minimize", parent, SLOT(showMinimized()));
 #endif

--- a/src/zimview.cpp
+++ b/src/zimview.cpp
@@ -62,18 +62,12 @@ ZimView::ZimView(TabBar *tabBar, QWidget *parent)
             [=](const QIcon& icon) { mp_tabBar->setIconOf(icon, this); });
 
     connect(mp_webView->page()->action(QWebEnginePage::Back), &QAction::changed,
-            [=]() {
-                if (mp_tabBar->currentZimView() != this) {
-                    return;
-                }
-                emit mp_tabBar->webActionEnabledChanged(QWebEnginePage::Back, mp_webView->isWebActionEnabled(QWebEnginePage::Back));
+            [this]() {
+                emit webActionEnabledChanged(QWebEnginePage::Back, this->mp_webView->isWebActionEnabled(QWebEnginePage::Back));
             });
     connect(mp_webView->page()->action(QWebEnginePage::Forward), &QAction::changed,
-            [=]() {
-                if (mp_tabBar->currentZimView() != this) {
-                    return;
-                }
-                emit mp_tabBar->webActionEnabledChanged(QWebEnginePage::Forward, mp_webView->isWebActionEnabled(QWebEnginePage::Forward));
+            [this]() {
+                emit webActionEnabledChanged(QWebEnginePage::Forward, this->mp_webView->isWebActionEnabled(QWebEnginePage::Forward));
             });
     connect(mp_webView->page(), &QWebEnginePage::linkHovered, this,
             [=](const QString& url) {

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -3,8 +3,8 @@
 
 #include <QWidget>
 #include <QWebEnginePage>
-#include "findinpagebar.h"
 
+class FindInPageBar;
 class TabBar;
 class WebView;
 

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -2,6 +2,7 @@
 #define ZIMVIEW_H
 
 #include <QWidget>
+#include <QWebEnginePage>
 #include "findinpagebar.h"
 
 class TabBar;
@@ -16,6 +17,9 @@ public:
     WebView *getWebView() { return mp_webView; }
     FindInPageBar *getFindInPageBar() { return mp_findInPageBar; }
     void openFindInPageBar();
+
+signals:
+    void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
 
 private:
     WebView *mp_webView;


### PR DESCRIPTION
Partial fix #540: stop emitting TabBar::webActionEnabledChanged from ZimView
as it's bad practice according to QObject documentation.

Dismiss way-round signal passing through KiwixApp::currentTitleChanged
Now it's local to MainWindow and its siblings (TabBar, ZimViews, TopWidget).

TabBar, TopWidget, SideBar- connect signals in MainWindow constructor
after MainWindow mp_ui->setupUi() completed.
