### PR TITLE
PPA: Fix libkiwix-dev dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 13),
  pkg-config,
  qtbase5-dev,
  qtwebengine5-dev,
- libkiwix-dev (>= 10.0.0)
+ libkiwix-dev (>= 10.0.0~)
 Standards-Version: 4.5.0
 Homepage: https://www.kiwix.org/
 Rules-Requires-Root: no


### PR DESCRIPTION
```
Our libkiwix packages are "10.0.0~focal" but the ~ means that "10.0.0" is greater than
"10.0.0~focal" so the dependency can't be satisfied. Depending on "10.0.0~" will
allow "10.0.0~focal" to satisfy the dependency.
```