### PR TITLE
Fix contentmanager/mainWindow initialisation on windows.

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -16,6 +16,9 @@
 #include <QPrintDialog>
 #include <thread>
 #include <QMessageBox>
+#ifdef Q_OS_WIN
+#include <QtPlatformHeaders\QWindowsWindowFunctions>
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // KiwixApp
@@ -87,6 +90,12 @@ void KiwixApp::init()
     mp_errorDialog = new QErrorMessage(mp_mainWindow);
     setActivationWindow(mp_mainWindow);
     mp_mainWindow->show();
+#ifdef Q_OS_WIN
+    QWindow *window = mp_mainWindow->windowHandle();
+    if (window) {
+        QWindowsWindowFunctions::setHasBorderInFullScreen(window, true);
+    }
+#endif
     connect(this, &QtSingleApplication::messageReceived, this, [=](const QString &message) {
         if (!message.isEmpty()) {
             this->openZimFile(message);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7,9 +7,7 @@
 #include "kconstants.h"
 
 #include <QDesktopServices>
-#ifdef Q_OS_WIN
-#include <QtPlatformHeaders\QWindowsWindowFunctions>
-#endif
+
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -49,14 +47,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
 #if !SYSTEMTITLEBAR
     setWindowFlags(Qt::Window | Qt::CustomizeWindowHint);
-#endif
-
-#ifdef Q_OS_WIN
-    QWindow *window = windowHandle();
-    if (!window) {
-        return;
-    }
-    QWindowsWindowFunctions::setHasBorderInFullScreen(window, true);
 #endif
 
     connect(mp_ui->tabBar, &QTabBar::currentChanged,


### PR DESCRIPTION
- The (pretty old) PR https://github.com/kiwix/kiwix-desktop/pull/368 set the full screen window border on windows.
But it has a test if the native window is null and return if yes. This is somehow buggy as the native window exists only if the widget has been shown and it is not the case.
- The PR https://github.com/kiwix/kiwix-desktop/pull/680 add a history on back/forward buttons but connect the mainWindow signal *after* the previous check. Because of the early return on windows, the signal was never set on Windows. It was already a bug, but not a crash as the bug was simply that the buttons were not updated.
- The PR https://github.com/kiwix/kiwix-desktop/pull/746 cleanup the code and move the `setContentManager` add the end of the previous code. On windows it was never called and as soon as we try to use it (by clicking on "All files" (https://github.com/kiwix/kiwix-desktop/blob/master/src/contentmanagerside.cpp#L16)) kiwix-desktop crash.

This PR "simply" move the configuration of the fullscreen border at the correct position (after the widget is shown) and remove the early exit in the constructor. Every thing is configured correctly.
A build of this PR is available here : http://tmp.kiwix.org/ci/fix_windows_contentmanager/kiwix-desktop_windows_x64_2022-02-07.zip
Fix #775 