### PR TITLE
Correctly set the "acceptTags" when we filter by tags.

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -396,6 +396,7 @@ QStringList ContentManager::getBookIds()
     std::vector<std::string> tags;
     if (m_categoryFilter != "all" && m_categoryFilter != "other") {
         tags.push_back("_category:"+m_categoryFilter.toStdString());
+        filter.acceptTags(tags);
     }
     if (m_categoryFilter == "other") {
         for (auto& category: S_CATEGORIES) {
@@ -416,7 +417,6 @@ QStringList ContentManager::getBookIds()
         }
     }
 
-    filter.acceptTags(tags);
     filter.query(m_searchQuery.toStdString());
     if (m_currentLanguage != "*")
         filter.lang(m_currentLanguage.toStdString());


### PR DESCRIPTION
In case of "other" filter, we were setting the filter with
`filter.rejectTags(tags)` and `filter.acceptTags(tags)` in the same time.
Which obviously return 0 results.

We must call `filter.acceptTags(tags)` only if we use a specific category,
not all the time (including with "other" category).

Fix #786