### PR TITLE
Fix right-to-left layout in SearchBar

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -32,23 +32,14 @@ QToolButton {
 
 SearchBar {
     background-color: white;
-    padding: 2px 2px 2px 40px;
+    padding: 2px;
     max-height: 38px;
-    margin: 2px 5px;
     color: #666;
     font-size: 16px;
     border: 1px solid #ccc;
     border-radius: 3px;
 }
 
-SearchBar > QPushButton {
-    margin: 8px 0px 8px 12px;
-    padding: 0;
-    border: 0 solid #fff;
-    background-color: white;
-    height: 32px;
-    width: 32px;
-}
 
 TopWidget QToolButton:pressed,
 TopWidget QToolButton::hover {

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -5,23 +5,10 @@
 #include <QStringListModel>
 #include <QCompleter>
 #include <QIcon>
-#include <QPushButton>
 #include <QUrl>
 #include <QTimer>
 #include <QThread>
 
-class SearchButton : public QPushButton {
-    Q_OBJECT
-public:
-    SearchButton(QWidget *parent = nullptr);
-
-public slots:
-    void set_searchMode(bool searchMode);
-    void on_buttonClicked();
-
-protected:
-    bool m_searchMode;
-};
 
 class SearchBar : public QLineEdit
 {
@@ -41,17 +28,20 @@ private:
     QStringListModel m_completionModel;
     QCompleter m_completer;
     QVector<QUrl> m_urlList;
-    SearchButton m_button;
+    QAction *m_action;
     QString m_title;
     QString m_searchbarInput;
     bool m_returnPressed = false;
     QTimer* mp_typingTimer;
     int m_token;
+    void set_searchMode(bool searchMode);
+    bool m_searchMode;
 
 private slots:
     void updateCompletion();
     void openCompletion(const QModelIndex& index);
     void openCompletion(const QString& text, int index);
+    void on_action_triggered();
 };
 
 #endif // SEARCHBAR_H


### PR DESCRIPTION
There was a hacky implementation which created QPushButton as a child of QLineEdit, but without using any Layout (actually, QLineEdit has no documented facilities to contain any other widget).
So, somehow in old implementation Qt placed QPushButton in the left side of QLineEdit. QLineEdit itself didn't knew about it, so in CSS left padding 40px; was needed. With '-reverse' CLI option (right-to-left layout) padding 40px remained to be on the left. Also, depending on which text we enter in QLineEdit (English or Arabic) the text can also be started from the left or the right side of text area in QLineEdit, so otherwise we had to detect text layout and update CSS paddings on the fly.

The new implementation is more elegant and uses the documented facility of QLineEdit to contain an QAction. So no hacks with CSS padding is need. Also, because QPushButton was a separate QWidget, clicking on it didn't pass the focus into QLineEdit, but clicking on QAction icon does focusIn. So focus interation code also has to be changed.

Fixes: #594