### PR TITLE
Remove padding from QSpinbox

### DIFF
--- a/resources/css/_settingsManager.css
+++ b/resources/css/_settingsManager.css
@@ -7,7 +7,11 @@ QPushButton,
 QSpinBox {
     font-size: 16px;
     line-height: 24px;
-    padding: 8px;
+}
+
+QLabel,
+QPushButton {
+    padding: 12px 8px;
 }
 
 QFrame[frameShape="4"] {


### PR DESCRIPTION
This removes an explicit padding from QSpinbox. QSpinbox will now have the default padding (if any) for QSpinbox.
Helps the text to not disappear at some systems/configurations
To keep the previous design changes QLabel padding to 12px (top and bottom) and 8px (right and left)

Before:
![image](https://user-images.githubusercontent.com/26814569/155713447-c6bdf2a4-dd94-4af6-84c1-0ed40bbc8798.png)

After:
![image](https://user-images.githubusercontent.com/26814569/155713520-2a37070a-7a24-4717-9ce3-8bc46ffdede7.png)


I experienced this after trying on a different OS