### PR TITLE
Fix for monitor directory on Windows

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -150,7 +150,7 @@ void Library::loadMonitorDir(QString monitorDir)
     const QDir dir(monitorDir);
     QStringList newDirEntries = dir.entryList({"*.zim"});
     for (auto &str : newDirEntries) {
-        str = monitorDir + QDir::separator() + str;
+        str = QDir::toNativeSeparators(monitorDir + "/" + str);
     }
     QSet<QString> newDir = QSet<QString>::fromList(newDirEntries);
     QStringList oldDirEntries = m_monitorDirZims;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -167,7 +167,6 @@ void Library::loadMonitorDir(QString monitorDir)
         removeBookFromLibraryById(QString::fromStdString(m_library.getBookByPath(bookPath.toStdString()).getId()));
     }
     emit(booksChanged());
-    save();
 }
 
 void Library::asyncLoadMonitorDir(QString dir)

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -75,6 +75,7 @@ void SettingsManager::setZoomFactor(qreal zoomFactor)
 
 void SettingsManager::setDownloadDir(QString downloadDir)
 {
+    downloadDir = QDir::toNativeSeparators(downloadDir);
     m_downloadDir = downloadDir;
     m_settings.setValue("download/dir", downloadDir);
     emit(downloadDirChanged(downloadDir));
@@ -82,6 +83,7 @@ void SettingsManager::setDownloadDir(QString downloadDir)
 
 void SettingsManager::setMonitorDir(QString monitorDir)
 {
+    monitorDir = QDir::toNativeSeparators(monitorDir);
     m_monitorDir = monitorDir;
     m_settings.setValue("monitor/dir", monitorDir);
     emit(monitorDirChanged(monitorDir));


### PR DESCRIPTION
Fixes #793

1. The books weren't changing (adding/removing) because of a mess in creating path. Specifically, I used QDir::separator(), while the path was unix based (on windows too), using QDir::separator() made the path like: `dir/subdir/sub-subdir\sub-sub-subdir`

2. The crash only happened when monitor directory was set in the same directory as a library.xml (download directory), this was because it was calling save() at end  (as rightly pointed by @veloman-yunkan in the issue), this would send a directoryChanged() signal whenever library.xml modified. Going in an infinite loop. Now, we don't call save(), it is already called in the library destructor() so not needed. Doesn't compromise any functionality in monitoring.

3. Whenever download or monitor directory was changed, we used UNIX styled paths, we now use paths with native separators in them

A build for testing is available at: http://tmp.kiwix.org/ci/juuz0_windows_build/2022-02-25/kiwix-desktop_windows_x64_2022-02-25.zip