### PR TITLE
Move asyncLoadMonitorDir in ContentManager

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -35,6 +35,9 @@ void ContentManager::setLocal(bool local) {
         return;
     }
     m_local = local;
+    if (m_local) {
+        asyncLoadMonitorDir(KiwixApp::instance()->getSettingsManager()->getMonitorDir());
+    }
     emit(filterParamsChanged());
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include <QStorageInfo>
 #include <QMessageBox>
+#include <QtConcurrent/QtConcurrentRun>
 
 ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, QObject *parent)
     : QObject(parent),
@@ -36,6 +37,16 @@ void ContentManager::setLocal(bool local) {
     m_local = local;
     emit(filterParamsChanged());
 }
+
+void ContentManager::asyncLoadMonitorDir(QString dir)
+{
+    if (m_local) {
+        QtConcurrent::run( [=]() {
+            mp_library->loadMonitorDir(dir);
+        });
+    }
+}
+
 
 QStringList ContentManager::getTranslations(const QStringList &keys)
 {

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -26,6 +26,7 @@ public:
     void setCurrentLanguage(QString language);
     void setCurrentCategoryFilter(QString category);
     void setCurrentContentTypeFilter(QList<ContentTypeFilter*>& contentTypeFilter);
+    void asyncLoadMonitorDir(QString dir);
 
 private:
     Library* mp_library;

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -102,13 +102,13 @@ void KiwixApp::init()
         }
     });
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, [=](QString monitorDir) {
-        m_library.asyncLoadMonitorDir(monitorDir);
+        mp_manager->asyncLoadMonitorDir(monitorDir);
     });
     QString monitorDir = m_settingsManager.getMonitorDir();
     if (monitorDir != "") {
         m_library.setMonitorDirZims(m_library.getLibraryZimsFromDir(monitorDir));
         m_watcher.addPath(monitorDir);
-        m_library.asyncLoadMonitorDir(monitorDir);
+        mp_manager->asyncLoadMonitorDir(monitorDir);
     }
 }
 
@@ -290,7 +290,7 @@ void KiwixApp::setMonitorDir(const QString &dir) {
     }
     if (dir != "") {
         m_watcher.addPath(dir);
-        m_library.asyncLoadMonitorDir(dir);
+        mp_manager->asyncLoadMonitorDir(dir);
     }
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -5,7 +5,6 @@
 #include <kiwix/tools.h>
 
 #include <QtDebug>
-#include <QtConcurrent/QtConcurrentRun>
 
 
 class LibraryManipulator: public kiwix::LibraryManipulator {
@@ -167,13 +166,6 @@ void Library::loadMonitorDir(QString monitorDir)
         removeBookFromLibraryById(QString::fromStdString(m_library.getBookByPath(bookPath.toStdString()).getId()));
     }
     emit(booksChanged());
-}
-
-void Library::asyncLoadMonitorDir(QString dir)
-{
-    QtConcurrent::run( [=]() {
-        loadMonitorDir(dir);
-    });
 }
 
 const kiwix::Book &Library::getBookById(QString id) const

--- a/src/library.h
+++ b/src/library.h
@@ -41,7 +41,6 @@ public:
     void removeBookmark(const QString& zimId, const QString& url);
     void save();
     void loadMonitorDir(QString dir);
-    void asyncLoadMonitorDir(QString dir);
     kiwix::Library& getKiwixLibrary() { return m_library; }
 public slots:
     const kiwix::Book& getBookById(QString id) const;


### PR DESCRIPTION
This gives it the ability to use m_local and only make changes when local library is in use.
Not causing repeated refreshes while downloading - if the monitor directory is set same as download directory


The problem this fixes is:
- Put monitor directory same as download directory.
- Go to "All files"
- Download a large enough file
- There should be many re-freshes

Because, while downloading, file is changing a lot and causes file watcher to detect causing many calls of loadMonitorDir() leading to emitBooksChanged()

Solution:

Don't do any monitoring while we are using remote library, the "Download" function already adds books, shouldn't interfere in that


