### PR TITLE
Only refresh library if some book has been added/removed in monitor dir

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -157,16 +157,19 @@ void Library::loadMonitorDir(QString monitorDir)
     QSet<QString> oldDir = QSet<QString>::fromList(oldDirEntries);
     QStringList addedZims = (newDir - oldDir).values();
     QStringList removedZims = (oldDir - newDir).values();
-    setMonitorDirZims(newDir.values());
     auto manipulator = LibraryManipulator(this);
     auto manager = kiwix::Manager(&manipulator);
+    bool needsRefresh = !removedZims.empty();
     for (auto book : addedZims) {
-        manager.addBookFromPath(book.toStdString());
+        needsRefresh |= manager.addBookFromPath(book.toStdString());
     }
     for (auto bookPath : removedZims) {
         removeBookFromLibraryById(QString::fromStdString(m_library.getBookByPath(bookPath.toStdString()).getId()));
     }
-    emit(booksChanged());
+    if (needsRefresh) {
+        setMonitorDirZims(newDir.values());
+        emit(booksChanged());
+    }
 }
 
 void Library::asyncLoadMonitorDir(QString dir)


### PR DESCRIPTION
This change leads to less refreshes if the monitor directory is same as download directory
Earlier, while downloading a file, it would send many refresh signals to file watcher leading to a bad user experience

Supersedes #803 