### PR TITLE
Fixed search results pagination

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -118,7 +118,7 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     renderer.setSearchPattern(searchQuery);
     renderer.setSearchBookQuery("content="+bookId.toStdString());
     renderer.setProtocolPrefix("zim://");
-    renderer.setSearchProtocolPrefix("zim://" + host.toStdString() + "/?");
+    renderer.setSearchProtocolPrefix("zim://" + host.toStdString() + "/");
     renderer.setPageLength(pageLength);
     auto content = renderer.getHtml();
     QBuffer *buffer = new QBuffer;


### PR DESCRIPTION
Fixes #843

kiwix/libkiwix#764 has eliminated the trailing "?" symbol from searchProtocolPrefix.