### PR TITLE
Add check for QT version when using deprecated functions

### DIFF
--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -25,7 +25,11 @@ void KProfile::startDownload(QWebEngineDownloadItem* download)
     if (!fileName.endsWith(extension)) {
         fileName.append(extension);
     }
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     download->setPath(fileName);
+#else
+    download->setDownloadFileName(fileName);
+#endif
     connect(download, &QWebEngineDownloadItem::finished, this, &KProfile::downloadFinished);
     download->accept();
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -139,12 +139,18 @@ void Library::loadMonitorDir(QString monitorDir)
     QMutexLocker locker(&mutex);
     const QDir dir(monitorDir);
     QStringList newDirEntries = dir.entryList({"*.zim"});
+    QStringList oldDirEntries = m_monitorDirZims;
     for (auto &str : newDirEntries) {
         str = QDir::toNativeSeparators(monitorDir + "/" + str);
     }
-    QSet<QString> newDir = QSet<QString>::fromList(newDirEntries);
-    QStringList oldDirEntries = m_monitorDirZims;
-    QSet<QString> oldDir = QSet<QString>::fromList(oldDirEntries);
+    QSet<QString> newDir, oldDir;
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    newDir = QSet<QString>::fromList(newDirEntries);
+    oldDir = QSet<QString>::fromList(oldDirEntries);
+#else
+    newDir = QSet<QString>(newDirEntries.begin(), newDirEntries.end());
+    oldDir = QSet<QString>(oldDirEntries.begin(), oldDirEntries.end());
+#endif
     QStringList addedZims = (newDir - oldDir).values();
     QStringList removedZims = (oldDir - newDir).values();
     auto manipulator = LibraryManipulator(this);


### PR DESCRIPTION
The following functions are deprecated in QT 5.15+
QWebEngineDownloadItem::setPath
QSet<T>::fromList(const QList<T>&)
Now a check is added to support both legacy method call and modern method call, no more deprecated messages
Fixes #851 