### PR TITLE
Increase type cast value

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -263,7 +263,7 @@ QString ContentManager::downloadBook(const QString &id)
     auto downloadPath = KiwixApp::instance()->getSettingsManager()->getDownloadDir();
     QStorageInfo storage(downloadPath);
     auto bytesAvailable = storage.bytesAvailable();
-    if (bytesAvailable == -1 || book.getSize() > (unsigned) bytesAvailable) {
+    if (bytesAvailable == -1 || book.getSize() > (unsigned long long) bytesAvailable) {
         return "storage_error";
     }
     auto booksList = mp_library->getBookIds();


### PR DESCRIPTION
b49ea7cbce83777d1c68d2ec4a8fae1e4df59fb1 introduced the unsigned type-cast for bytesAvailable to remove warnings of comparing different types.
But it caused a problem in downloads above 4GB as unsigned was too short. This changes it to unsigned long long
Fixes #854 