### PR TITLE
Hide top widget and tabbar in fullscreen

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,11 +27,14 @@ public:
 
 protected:
     void keyPressEvent(QKeyEvent *event);
+    bool eventFilter(QObject* object, QEvent* event) override;
 
 private slots:
     void toggleFullScreen();
     void when_ReadingList_toggled(bool state);
     void when_libraryPageDisplayed(bool showed);
+    void hideTabAndTop();
+    void showTabAndTop();
 
 private:
     Ui::MainWindow *mp_ui;


### PR DESCRIPTION
This change hides the topwidget and tabbar when fullscreen shortcut/button is pressed.
If the mouse is taken to the top of screen, they are shown till the time it is there.
Fixes #571 