### PR TITLE
Don't monitor files while in All files view.

### DIFF
--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -26,6 +26,7 @@ public:
     void setCurrentLanguage(QString language);
     void setCurrentCategoryFilter(QString category);
     void setCurrentContentTypeFilter(QList<ContentTypeFilter*>& contentTypeFilter);
+    bool isLocalLibrary() const { return m_local; }
 
 private:
     Library* mp_library;

--- a/src/contentmanagerside.cpp
+++ b/src/contentmanagerside.cpp
@@ -22,6 +22,13 @@ ContentManagerSide::ContentManagerSide(QWidget *parent) :
     connect(mp_ui->localFileButton, &QRadioButton::toggled,
             this, [=](bool checked) { mp_ui->localFileButton->setStyleSheet(
                     checked ?"*{font-weight: bold}" : "");});
+    connect(mp_ui->localFileButton, &QRadioButton::toggled,
+            this, [=](bool checked) {
+        if (checked) {
+            QString monitorDir = KiwixApp::instance()->getSettingsManager()->getMonitorDir();
+            KiwixApp::instance()->getLibrary()->asyncLoadMonitorDir(monitorDir);
+        }
+    });
     mp_ui->localFileButton->setStyleSheet("*{font-weight: bold}");
 
     mp_ui->allFileButton->setText(gt("all-files"));

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -102,7 +102,8 @@ void KiwixApp::init()
         }
     });
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, [=](QString monitorDir) {
-        m_library.asyncLoadMonitorDir(monitorDir);
+        if (getContentManager()->isLocalLibrary())
+            m_library.asyncLoadMonitorDir(monitorDir);
     });
     QString monitorDir = m_settingsManager.getMonitorDir();
     if (monitorDir != "") {


### PR DESCRIPTION
When downloading a file, with monitor directory set same as download directory, the changes in fs may send a double booksChanged signal leading to:
![image](https://user-images.githubusercontent.com/26814569/180614971-f490fa70-0fc8-418d-878b-453326b2100b.png)

The first is due to adding/removing books while the second is the explicit booksChanged.
This change stops monitoring while in All files view.
To save the edge case when the user themselves adds books in monitor directory (while Kiwix is in All files view), a connection is added to Local Files button - to call loadMonitorDir().