### PR TITLE
Add shortcuts for navigating tabs.

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -133,5 +133,7 @@
     "monitor-dir-dialog-msg":"The new monitor directory path will be:\n{{DIRECTORY}}",
     "monitor-clear-dir-dialog-title":"Are you sure you want to clear the monitor directory?",
     "monitor-clear-dir-dialog-msg":"This will stop checking the monitor directory for new ZIM files.",
-    "monitor-directory-tooltip":"All ZIM files in this directory will be automatically added to the library."
+    "monitor-directory-tooltip":"All ZIM files in this directory will be automatically added to the library.",
+    "next-tab":"Move to next tab",
+    "previous-tab":"Move to previous tab"
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -409,6 +409,10 @@ void KiwixApp::createAction()
 
     CREATE_ACTION_SHORTCUT(ZoomResetAction, gt("zoom-reset"), QKeySequence(Qt::CTRL+Qt::Key_0));
 
+    CREATE_ACTION_SHORTCUT(NextTabAction, gt("next-tab"), QKeySequence(Qt::CTRL + Qt::Key_Tab));
+
+    CREATE_ACTION_SHORTCUT(PreviousTabAction, gt("previous-tab"), QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab));
+
     CREATE_ACTION_SHORTCUT(HelpAction, gt("help"), QKeySequence::HelpContents);
     HIDE_ACTION(HelpAction);
 

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -47,6 +47,8 @@ public:
         ZoomInAction,
         ZoomOutAction,
         ZoomResetAction,
+        NextTabAction,
+        PreviousTabAction,
         HistoryBackAction,
         HistoryForwardAction,
         HelpAction,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -22,7 +22,9 @@ MainWindow::MainWindow(QWidget *parent) :
     mp_ui->tabBar->setStackedWidget(mp_ui->mainView);
 
     auto app = KiwixApp::instance();
-    addAction(KiwixApp::instance()->getAction(KiwixApp::ToggleFullscreenAction));
+    addAction(app->getAction(KiwixApp::ToggleFullscreenAction));
+    addAction(app->getAction(KiwixApp::NextTabAction));
+    addAction(app->getAction(KiwixApp::PreviousTabAction));
 
     connect(app->getAction(KiwixApp::ExitAction), &QAction::triggered,
             this, &QMainWindow::close);

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -127,6 +127,14 @@ void TabBar::setNewTabButton()
     setTabButton(idx, QTabBar::RightSide, Q_NULLPTR);
 }
 
+int TabBar::realTabCount() const
+{
+    // The last tab is "+" in TabBar, but that isn't a real tab which displays any content hence the real count is tab count - 1
+    if (count() < 1)
+        return 0;
+    return count() - 1;
+}
+
 ZimView* TabBar::createNewTab(bool setCurrent, bool adjacentToCurrentTab)
 {
     auto tab = new ZimView(this, this);
@@ -134,7 +142,7 @@ ZimView* TabBar::createNewTab(bool setCurrent, bool adjacentToCurrentTab)
     if(adjacentToCurrentTab) {
         index = currentIndex() + 1;
     } else {
-        index = count() - 1; // for New Tab Button
+        index = realTabCount(); // for New Tab Button
     }
     mp_stackedWidget->insertWidget(index, tab);
     index = insertTab(index, "");
@@ -255,7 +263,7 @@ void TabBar::closeTabsByZimId(const QString &id)
 void TabBar::closeTab(int index)
 {
     // the last tab is + button, cannot be closed
-    if (index == this->count() - 1)
+    if (index == this->realTabCount())
         return;
 
     setSelectionBehaviorOnRemove(index);
@@ -289,8 +297,8 @@ void TabBar::onCurrentChanged(int index)
         return;
 
     // if somehow the last tab (+ button) became active, switch to the previous
-    if (index >= (count() - 1)) {
-        setCurrentIndex(count() - 2);
+    if (index >= realTabCount()) {
+        setCurrentIndex(realTabCount() - 1);
         return;
     }
 

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -24,6 +24,8 @@ TabBar::TabBar(QWidget *parent) :
     connect(this, &QTabBar::currentChanged, this, &TabBar::onCurrentChanged, Qt::QueuedConnection);
     auto app = KiwixApp::instance();
 
+    connect(app->getAction(KiwixApp::NextTabAction), &QAction::triggered, this, &TabBar::moveToNextTab);
+    connect(app->getAction(KiwixApp::PreviousTabAction), &QAction::triggered, this, &TabBar::moveToPreviousTab);
     connect(app->getAction(KiwixApp::NewTabAction), &QAction::triggered,
             this, [=]() {
                 this->createNewTab(true, false);
@@ -133,6 +135,18 @@ int TabBar::realTabCount() const
     if (count() < 1)
         return 0;
     return count() - 1;
+}
+
+void TabBar::moveToNextTab()
+{
+    const int index = currentIndex();
+    setCurrentIndex(index == realTabCount() - 1 ? 0 : index + 1);
+}
+
+void TabBar::moveToPreviousTab()
+{
+    const int index = currentIndex();
+    setCurrentIndex(index <= 0 ? realTabCount() - 1 : index - 1);
 }
 
 ZimView* TabBar::createNewTab(bool setCurrent, bool adjacentToCurrentTab)

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -64,7 +64,10 @@ private:
     QScopedPointer<FullScreenWindow> m_fullScreenWindow;
 
     void setSelectionBehaviorOnRemove(int index);
-
+    // The "+" (new tab) button is implemented as a tab (that is always placed at the end).
+    // This function returns the count of real tabs.
+    int realTabCount() const;
+    
 private slots:
     void onTabMoved(int from, int to);
     void onCurrentChanged(int index);

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -58,6 +58,8 @@ public slots:
     void closeTab(int index);
     void fullScreenRequested(QWebEngineFullScreenRequest request);
     void on_webview_titleChanged(const QString& title);
+    void moveToNextTab();
+    void moveToPreviousTab();
 
 private:
     QStackedWidget*     mp_stackedWidget;


### PR DESCRIPTION
Added:
- CTRL + TAB shortcut for going to the next tab.
- CTRL + SHIFT + TAB shortcut for going to previous tab.

Fixes #866 