### PR TITLE
Hide ZIMIt books from library

### DIFF
--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -24,11 +24,13 @@ function setTranslations(translations) {
 
 const BOOK_KEYS = ["id", "name", "path", "url", "size", "description", "title", "tags", "date", "faviconUrl", "faviconMimeType", "downloadId"];
 function addBook(values) {
-  var b = createDict(BOOK_KEYS, values);
-  if (b.downloadId && !downloadUpdaters.hasOwnProperty(b.id)) {
-    downloadUpdaters[b.id] = setInterval(function() { getDownloadInfo(b.id); }, 1000);
+  if (values.length > 0) {
+    var b = createDict(BOOK_KEYS, values);
+    if (b.downloadId && !downloadUpdaters.hasOwnProperty(b.id)) {
+      downloadUpdaters[b.id] = setInterval(function() { getDownloadInfo(b.id); }, 1000);
+    }
+    app.books.push(b);
   }
-  app.books.push(b);
 }
 function onBooksChanged () {
   app.books = [];

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -134,6 +134,8 @@ QStringList ContentManager::getBookInfos(QString id, const QStringList &keys)
             if (displayTagMap["_videos"]) displayTagList << tr("Videos");
             if (displayTagMap["_pictures"]) displayTagList << tr("Pictures");
             if (!displayTagMap["_details"]) displayTagList << tr("Introduction only");
+            // Temporary: Hide ZIMIt books (they contain a _sw tag)
+            if (displayTagMap["_sw"]) return QStringList();
             QString s = displayTagList.join(", ");
             values.append(s);
         }


### PR DESCRIPTION
This change hides books which contain a _sw tag (created by ZIMIt).
This is a temporary fix until support of SW based ZIMs is added.
Fixes #780 