### PR TITLE
New version 2.3.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+kiwix-destkop 2.3.1
+===================
+
+ * Fix the AppImage packaging. Now published AppImages work correctly on recent
+   distrubution (@mgautierfr #905)
+ * Improve zim file picker (@kelson42 #886)
+ * Do not show ServiceWorker zim file from the remote catalog (@kelson42 #887)
+
 kiwix-desktop 2.3.0
 ===================
 

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -19,7 +19,7 @@ QMAKE_CXXFLAGS += -std=c++11
 QMAKE_LFLAGS +=  -std=c++11
 
 # Also change resources/org.kiwix.desktop.appdata.xml
-DEFINES += VERSION="2.3.0"
+DEFINES += VERSION="2.3.1"
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings
@@ -154,12 +154,12 @@ unix {
   INSTALLS += mime_file
 }
 
-PKGCONFIG_CFLAGS = $$system(pkg-config --cflags $$PKGCONFIG_OPTION \"kiwix >= 11.0.0 libzim >= 8.0.0\")
+PKGCONFIG_CFLAGS = $$system(pkg-config --cflags $$PKGCONFIG_OPTION \"kiwix >= 12.0.0 libzim >= 8.0.0\")
 
 QMAKE_CXXFLAGS += $$PKGCONFIG_CFLAGS
 QMAKE_CFLAGS += $$PKGCONFIG_CFLAGS
 
-LIBS += $$system(pkg-config --libs $$PKGCONFIG_OPTION \"kiwix >= 11.0.0 libzim >= 8.0.0\")
+LIBS += $$system(pkg-config --libs $$PKGCONFIG_OPTION \"kiwix >= 12.0.0 libzim >= 8.0.0\")
 
 RESOURCES += \
     resources/kiwix.qrc \

--- a/resources/org.kiwix.desktop.appdata.xml
+++ b/resources/org.kiwix.desktop.appdata.xml
@@ -13,7 +13,7 @@
     </p>
   </description>
   <releases>
-    <release version="2.3.0" date="2022-09-07" />
+    <release version="2.3.1" date="2022-11-30" />
   </releases>
   <content_rating type="oars-1.0" />
   <launchable type="desktop-id">org.kiwix.desktop.desktop</launchable>


### PR DESCRIPTION
 * Fix the AppImage packaging. Now published AppImages work correctly on recent distrubution (@mgautierfr #905)
 * Improve zim file picker (@kelson42 #886)
 * Do not show ServiceWorker zim file from the remote catalog (@kelson42 #887)