### PR TITLE
Windows download hang

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -53,6 +53,7 @@ SOURCES += \
     src/mainmenu.cpp \
     src/webpage.cpp \
     src/about.cpp \
+    src/backgrounddownloader.cpp \
     src/contentmanager.cpp \
     src/contentmanagerview.cpp \
     src/tabbar.cpp \
@@ -86,6 +87,7 @@ HEADERS += \
     src/mainmenu.h \
     src/webpage.h \
     src/about.h \
+    src/backgrounddownloader.h \
     src/contentmanager.h \
     src/contentmanagerview.h \
     src/tabbar.h \

--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -82,11 +82,11 @@ function getDownloadInfo(id) {
 
 function displayLoadIcon(display) {
     if (display) {
-        document.getElementById("load-icon").classList.remove("do-not-display")  
-        document.getElementById("bookList").classList.add("do-not-display");  
+        document.getElementById("load-icon").classList.remove("do-not-display")
+        document.getElementById("bookList").classList.add("do-not-display");
     } else {
         document.getElementById("load-icon").classList.add("do-not-display");
-        document.getElementById("bookList").classList.remove("do-not-display")      
+        document.getElementById("bookList").classList.remove("do-not-display")
     }
 }
 const TRANSLATION_KEYS = ["search-files",
@@ -123,18 +123,26 @@ function init() {
         openBook : function(book) {
           contentManager.openBook(book.id, function() {});
         },
-        downloadBook : function(book) {
-          contentManager.downloadBook(book.id, function(did)  {
-            if (did.length == 0) {
-                alert("Error: this download is not available.");
-                return;
-            }
-            if (did == "storage_error") {
+        startDownloadBook : function(book) {
+          contentManager.startDownloadBook(book.id, function(status)  {
+            if (status == "storage_error") {
                 alert("not enough storage available.");
                 return;
             }
-            book.downloadId = did;
+            if (status != "") {
+                alert("unknown error: " + status);
+                return;
+            }
             downloadUpdaters[book.id] = setInterval(function() { getDownloadInfo(book.id); }, 1000);
+          });
+        },
+        downloadBook : function(book) {
+          contentManager.downloadBook(book.id, function(did)  {
+            if (did.length == 0) {
+              alert("Error: this download is not available.");
+              return;
+            }
+            book.downloadId = did;
           });
         },
         eraseBook : function(book) {

--- a/resources/js/_contentManager.js
+++ b/resources/js/_contentManager.js
@@ -157,10 +157,10 @@ function init() {
                 contentManager.resumeBook(book.id);
             }
         },
-        cancelBook : function(book) {
+        startCancelBook : function(book) {
             contentManager.pauseBook(book.id);
             if (confirm("Are you sure you want to abort the download of '" + book.title + "' ?")) {
-                contentManager.cancelBook(book.id);
+                contentManager.startCancelBook(book.id);
                 clearInterval(downloadUpdaters[book.id]);
                 Vue.delete(app.downloads, book.id);
             } else {

--- a/resources/texts/_contentManager.html
+++ b/resources/texts/_contentManager.html
@@ -31,7 +31,7 @@
         <ul class="menu-options">
           <li v-on:click="openBook(getBookFromMousePosition())" class="menu-option local-option">{{ gt("open") }}</li>
           <li v-on:click="eraseBook(getBookFromMousePosition())" class="menu-option local-option">{{ gt("delete") }}</li>
-          <li v-on:click="downloadBook(getBookFromMousePosition())" class="menu-option download-option">{{ gt("download") }}</li>
+          <li v-on:click="startDownloadBook(getBookFromMousePosition())" class="menu-option download-option">{{ gt("download") }}</li>
           <li v-on:click="resumeBook(getBookFromMousePosition())" class="menu-option resume-option">{{ gt("resume") }}</li>
           <li v-on:click="pauseBook(getBookFromMousePosition())" class="menu-option pause-option">{{ gt("pause") }}</li>
           <li v-on:click="cancelBook(getBookFromMousePosition())" class="menu-option cancel-option">{{ gt("cancel") }}</li>
@@ -62,7 +62,7 @@
               </span>
             </template>
             <button v-if="book.path" v-on:click="openBook(book)" class="line">Open</button>
-            <button v-if="!book.path && !downloads[book.id]" v-on:click="downloadBook(book)" class="">Download</button>
+            <button v-if="!book.path && !downloads[book.id]" v-on:click="startDownloadBook(book)" class="">Download</button>
 
             <!-- round download progress bar -->
             <template v-if="downloads[book.id]" class="line">

--- a/resources/texts/_contentManager.html
+++ b/resources/texts/_contentManager.html
@@ -34,7 +34,7 @@
           <li v-on:click="startDownloadBook(getBookFromMousePosition())" class="menu-option download-option">{{ gt("download") }}</li>
           <li v-on:click="resumeBook(getBookFromMousePosition())" class="menu-option resume-option">{{ gt("resume") }}</li>
           <li v-on:click="pauseBook(getBookFromMousePosition())" class="menu-option pause-option">{{ gt("pause") }}</li>
-          <li v-on:click="cancelBook(getBookFromMousePosition())" class="menu-option cancel-option">{{ gt("cancel") }}</li>
+          <li v-on:click="startCancelBook(getBookFromMousePosition())" class="menu-option cancel-option">{{ gt("cancel") }}</li>
         </ul>
       </div>
       <details v-for="book in displayedBooks(books, displayedBooksNb)" class="book">
@@ -83,7 +83,7 @@
             </template>
             <!-- end  -->
 
-            <img class="cancel-button" v-if="downloads[book.id]" v-on:click.stop.prevent="cancelBook(book)" src="qrc:///icons/cancel-button.png">
+            <img class="cancel-button" v-if="downloads[book.id]" v-on:click.stop.prevent="startCancelBook(book)" src="qrc:///icons/cancel-button.png">
           </span>
         </summary>
         <p class="content">

--- a/src/backgrounddownloader.cpp
+++ b/src/backgrounddownloader.cpp
@@ -1,0 +1,39 @@
+#include "backgrounddownloader.h"
+
+#include <iostream>
+#include <QString>
+
+BackgroundDownloader::BackgroundDownloader(kiwix::Downloader* downloader)
+    :  mp_downloader(downloader)
+{
+    m_thread.reset(new QThread); // no parent
+    moveToThread(m_thread.get());
+    m_thread->start();
+}
+
+BackgroundDownloader::~BackgroundDownloader() {
+    QMetaObject::invokeMethod(this, "cleanup");
+    m_thread->wait();
+}
+
+void BackgroundDownloader::cleanup() {
+    // TODO: delete resources
+
+    m_thread->quit();
+}
+
+void BackgroundDownloader::startDownload(const QString& bookId, const QString& uri, const QString& downloadPath) {
+    QMutexLocker ml(&m_mutex);
+
+    kiwix::Download *download;
+    try {
+        std::pair<std::string, std::string> downloadDir("dir", downloadPath.toStdString());
+        const std::vector<std::pair<std::string, std::string>> options = { downloadDir };
+        download = mp_downloader->startDownload(uri.toStdString(), options);
+        std::cerr << "got download with id " << download->getDid() << '\n';
+        emit(confirmStartDownload(bookId, QString::fromStdString(download->getDid())));
+    } catch (std::exception& e) {
+        // Download failed, ignore
+        std::cerr << "got exception " << e.what() << '\n';
+    }
+}

--- a/src/backgrounddownloader.cpp
+++ b/src/backgrounddownloader.cpp
@@ -2,12 +2,21 @@
 
 #include <iostream>
 #include <QString>
+#include <QTimer>
+#include <QDebug>
 
 BackgroundDownloader::BackgroundDownloader(kiwix::Downloader* downloader)
     :  mp_downloader(downloader)
 {
-    m_thread.reset(new QThread); // no parent
+    QThread* newThread = new QThread(); // no parent
+    m_thread.reset(newThread);
     moveToThread(m_thread.get());
+
+    // the timer causes updateStatus() to be called once per second on this thread's event loop
+    mp_timer = new QTimer(newThread);
+    connect(mp_timer, SIGNAL(timeout()), this, SLOT(updateStatus()));
+    mp_timer->start(1000);
+
     m_thread->start();
 }
 
@@ -22,18 +31,122 @@ void BackgroundDownloader::cleanup() {
     m_thread->quit();
 }
 
-void BackgroundDownloader::startDownload(const QString& bookId, const QString& uri, const QString& downloadPath) {
-    QMutexLocker ml(&m_mutex);
+// getDownloadStatus returns the status map for this downloadId. May be called from a separate thread
+QMap<std::string, std::string> BackgroundDownloader::getDownloadStatus(const std::string did)
+{
+    m_rwlock.lockForRead();
+    QMap<std::string, std::string> map = m_status.value(did);
+    m_rwlock.unlock();
+    return map;
+}
 
+void BackgroundDownloader::startDownload(const QString& bookId, const QString& uri, const QString& downloadPath)
+{
     kiwix::Download *download;
     try {
         std::pair<std::string, std::string> downloadDir("dir", downloadPath.toStdString());
         const std::vector<std::pair<std::string, std::string>> options = { downloadDir };
+        m_rwlock.lockForWrite();
         download = mp_downloader->startDownload(uri.toStdString(), options);
+        m_rwlock.unlock();
         std::cerr << "got download with id " << download->getDid() << '\n';
         emit(confirmStartDownload(bookId, QString::fromStdString(download->getDid())));
     } catch (std::exception& e) {
         // Download failed, ignore
         std::cerr << "got exception " << e.what() << '\n';
     }
+}
+
+// Cancel the download if it is running, then remove from the m_status map
+void BackgroundDownloader::completeDownload(const QString& did)
+{
+    kiwix::Download* download = mp_downloader->getDownload(did.toStdString());
+
+    m_rwlock.lockForWrite();
+    QMap<std::string, std::string> map = m_status.value(did.toStdString());
+    m_status.remove(did.toStdString());
+    download->cancelDownload();
+    m_rwlock.unlock();
+}
+
+void BackgroundDownloader::pauseDownload(const QString& did)
+{
+    kiwix::Download* download = mp_downloader->getDownload(did.toStdString());
+    if (download->getStatus() == kiwix::Download::K_ACTIVE) {
+        m_rwlock.lockForWrite();
+        download->pauseDownload();
+        m_rwlock.unlock();
+    }
+}
+
+void BackgroundDownloader::resumeDownload(const QString& did)
+{
+    kiwix::Download* download = mp_downloader->getDownload(did.toStdString());
+    if (download->getStatus() == kiwix::Download::K_PAUSED) {
+        m_rwlock.lockForWrite();
+        download->resumeDownload();
+        m_rwlock.unlock();
+    }
+}
+
+void BackgroundDownloader::cancelDownload(const QString& bookId, const QString& did)
+{
+    qInfo() << "canceling download for book = " << bookId;
+    kiwix::Download* download = mp_downloader->getDownload(did.toStdString());
+
+    m_rwlock.lockForWrite();
+    QMap<std::string, std::string> map = m_status.value(did.toStdString());
+    m_status.remove(did.toStdString());
+    download->cancelDownload();
+    m_rwlock.unlock();
+
+    emit(confirmCancelDownload(bookId, QString::fromStdString(map.value("path"))));
+}
+
+void BackgroundDownloader::updateStatus()
+{
+    for (auto& did : mp_downloader->getDownloadIds()) {
+        qInfo() << "updating status for did " << did.c_str();
+        kiwix::Download* download = mp_downloader->getDownload(did);
+        download->updateStatus(true);
+
+        m_rwlock.lockForWrite();
+        auto status = m_status.value(did);
+        status.insert("id", download->getDid());
+        status.insert("followed_by", download->getFollowedBy());
+        status.insert("path", download->getPath());
+        status.insert("totalLength", std::to_string(download->getTotalLength()));
+        status.insert("completedLength", std::to_string(download->getCompletedLength()));
+        status.insert("downloadSpeed", std::to_string(download->getDownloadSpeed()));
+        status.insert("verifiedLength", std::to_string(download->getVerifiedLength()));
+        status.insert("status", convertStatusResult(download->getStatus()));
+        m_status.insert(did, status);
+        m_rwlock.unlock();
+    }
+    int mapSize = 0;
+    for (auto it = m_status.begin(); it != m_status.end(); ++it) {
+        mapSize++;
+    }
+
+    qInfo() << "finished updating status with downloads length = " << mapSize;
+}
+
+std::string BackgroundDownloader::convertStatusResult(kiwix::Download::StatusResult result) {
+    switch(result){
+    case kiwix::Download::K_ACTIVE:
+        return "active";
+    case kiwix::Download::K_WAITING:
+        return "waiting";
+    case kiwix::Download::K_PAUSED:
+        return "paused";
+    case kiwix::Download::K_ERROR:
+        return "error";
+    case kiwix::Download::K_COMPLETE:
+        return "completed";
+    case kiwix::Download::K_REMOVED:
+        return "removed";
+    case kiwix::Download::K_UNKNOWN:
+        return "unknown";
+    }
+    return "unknown";
 }

--- a/src/backgrounddownloader.h
+++ b/src/backgrounddownloader.h
@@ -1,0 +1,33 @@
+#ifndef BACKGROUNDDOWNLOADER_H
+#define BACKGROUNDDOWNLOADER_H
+
+#include <QObject>
+#include <QThread>
+#include <QMutex>
+#include <memory>
+#include <kiwix/downloader.h>
+
+class BackgroundDownloader : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit BackgroundDownloader(kiwix::Downloader* downloader);
+    virtual ~BackgroundDownloader();
+
+signals:
+    void confirmStartDownload(const QString& bookID, const QString& did);
+
+public slots:
+    void startDownload(const QString& bookId, const QString& uri, const QString& downloadDir);
+
+private slots:
+    void cleanup();
+
+private:
+    std::unique_ptr<QThread> m_thread;
+    QMutex m_mutex;
+    kiwix::Downloader* mp_downloader;
+};
+
+#endif // BACKGROUNDDOWNLOADER_H

--- a/src/backgrounddownloader.h
+++ b/src/backgrounddownloader.h
@@ -3,7 +3,9 @@
 
 #include <QObject>
 #include <QThread>
-#include <QMutex>
+#include <QTimer>
+#include <QMap>
+#include <QReadWriteLock>
 #include <memory>
 #include <kiwix/downloader.h>
 
@@ -15,18 +17,33 @@ public:
     explicit BackgroundDownloader(kiwix::Downloader* downloader);
     virtual ~BackgroundDownloader();
 
+    QMap<std::string, std::string> getDownloadStatus(const std::string did);
+
 signals:
     void confirmStartDownload(const QString& bookID, const QString& did);
+    void confirmCancelDownload(const QString& bookId, const QString& path);
 
 public slots:
     void startDownload(const QString& bookId, const QString& uri, const QString& downloadDir);
+    void completeDownload(const QString& did);
+    void pauseDownload(const QString& did);
+    void resumeDownload(const QString& did);
+    void cancelDownload(const QString& bookId, const QString& did);
+
+    void updateStatus();
 
 private slots:
     void cleanup();
 
 private:
+    std::string convertStatusResult(kiwix::Download::StatusResult result);
+
     std::unique_ptr<QThread> m_thread;
-    QMutex m_mutex;
+    QReadWriteLock m_rwlock;
+    QTimer* mp_timer;
+
+    // m_status contains the status of all downloads by download ID
+    QMap<std::string, QMap<std::string, std::string>> m_status;
     kiwix::Downloader* mp_downloader;
 };
 

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -8,6 +8,7 @@
 #include <kiwix/downloader.h>
 #include "opdsrequestmanager.h"
 #include "contenttypefilter.h"
+#include "backgrounddownloader.h"
 
 class ContentManager : public QObject
 {
@@ -31,6 +32,7 @@ private:
     Library* mp_library;
     kiwix::Library m_remoteLibrary;
     kiwix::Downloader* mp_downloader;
+    BackgroundDownloader* mp_background_downloader;
     OpdsRequestManager m_remoteLibraryManager;
     ContentManagerView* mp_view;
     bool m_local = true;
@@ -53,12 +55,15 @@ signals:
     void currentLangChanged();
     void pendingRequest(const bool);
 
+    void backgroundStartDownload(const QString&, const QString&, const QString&);
+
 public slots:
     QStringList getTranslations(const QStringList &keys);
     QStringList getBookInfos(QString id, const QStringList &keys);
     void openBook(const QString& id);
     QStringList updateDownloadInfos(QString id, const QStringList& keys);
-    QString downloadBook(const QString& id);
+    QString startDownloadBook(const QString& id);
+    QString downloadBook(const QString& bookId, const QString& did);
     void updateLibrary();
     void setSearch(const QString& search);
     void setSortBy(const QString& sortBy, const bool sortOrderAsc);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -2,6 +2,7 @@
 #define CONTENTMANAGER_H
 
 #include <QObject>
+#include <QMap>
 #include <math.h>
 #include "library.h"
 #include "contentmanagerview.h"
@@ -56,6 +57,10 @@ signals:
     void pendingRequest(const bool);
 
     void backgroundStartDownload(const QString&, const QString&, const QString&);
+    void backgroundCompleteDownload(const QString&);
+    void backgroundPauseDownload(const QString&);
+    void backgroundResumeDownload(const QString&);
+    void backgroundCancelDownload(const QString&, const QString&);
 
 public slots:
     QStringList getTranslations(const QStringList &keys);
@@ -71,7 +76,8 @@ public slots:
     void updateRemoteLibrary(const QString& content);
     void pauseBook(const QString& id);
     void resumeBook(const QString& id);
-    void cancelBook(const QString& id);
+    void startCancelBook(const QString& id);
+    void completeCancelBook(const QString& bookId, const QString& path);
 };
 
 #endif // CONTENTMANAGER_H


### PR DESCRIPTION
Overall, the high level design is something like:

* Run a new QThread using the BackgroundDownloader. Any slots invoked on the BackgroundDownloader are run on this new thread (not the UI thread)
* The ContentManager sends signals from the UI thread to the BackgroundDownloader thread.
* When needed, the BackgroundDownloader sends signals back to the ContentManager to confirm operations, such as starting or canceling a download
* The BackgroundDownloader::updateStatus() is invoked once per second by a QTimer, and updates the internal m_status map with information about the download
* The BackgroundDownloader:: getDownloadStatus() method can be called from the ContentManager on the UI thread to get the status of any particular download
* Since BackgroundDownloader can be called from two different threads, reading from the m_status map is protected by a ReadWrite lock

Fixes #87 