### PR TITLE
With last version of libkiwix, Downloader now return shared_ptr<Download>.

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -173,7 +173,7 @@ QStringList ContentManager::updateDownloadInfos(QString id, const QStringList &k
         return values;
     }
     auto& b = mp_library->getBookById(id);
-    kiwix::Download* d;
+    std::shared_ptr<kiwix::Download> d;
     try {
         d = mp_downloader->getDownload(b.getDownloadId());
     } catch(...) {
@@ -270,7 +270,7 @@ QString ContentManager::downloadBook(const QString &id)
     for (auto b : booksList)
         if (b.toStdString() == book.getId())
             return "";
-    kiwix::Download *download;
+    std::shared_ptr<kiwix::Download> download;
     try {
         std::pair<std::string, std::string> downloadDir("dir", downloadPath.toStdString());
         const std::vector<std::pair<std::string, std::string>> options = { downloadDir };


### PR DESCRIPTION
Change appears in https://github.com/kiwix/libkiwix/pull/886

This is the minimum change to have kiwix-desktop compiling.
We probably have better to do to fully use the new api improvement but it will be made in #919 