### PR TITLE
Remove Ubuntu Bionic from CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   Linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,33 +22,21 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:38
+
     steps:
-    - name: Extract branch name
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-    - name: Checkout code
-      shell: python
-      run: |
-        from subprocess import check_call
-        from os import environ
-        command = [
-          'git', 'clone',
-          'https://github.com/${{github.repository}}',
-          '--depth=1',
-          '--branch', '${{steps.extract_branch.outputs.branch}}'
-        ]
-        check_call(command, cwd=environ['HOME'])
-    - name: Install deps
-      shell: bash
-      run: |
-        ARCHIVE_NAME=deps2_focal_native_dyn_kiwix-desktop.tar.xz
-        wget -O- http://tmp.kiwix.org/ci/${ARCHIVE_NAME} | tar -xJ -C /home/runner
-    - name: Compile
-      shell: bash
-      run: |
-        cd $HOME/kiwix-desktop
-        qmake PREFIX=$HOME/BUILD_native_dyn/INSTALL
-        make
-      env:
-        PKG_CONFIG_PATH: "/home/runner/BUILD_native_dyn/INSTALL/lib/pkgconfig:/home/runner/BUILD_native_dyn/INSTALL/lib${{matrix.lib_postfix}}/pkgconfig"
+      - name: Install dependencies
+        shell: bash
+        run: |
+          ARCHIVE_NAME=deps2_focal_native_dyn_kiwix-desktop.tar.xz
+          wget -O- http://tmp.kiwix.org/ci/${ARCHIVE_NAME} | tar -xJ -C ${{env.HOME}}
+
+      - name: Retrieve source code
+        uses: actions/checkout@v3
+
+      - name: Compile source code
+        shell: bash
+        env:
+          PKG_CONFIG_PATH: "/home/runner/BUILD_native_dyn/INSTALL/lib/pkgconfig:/home/runner/BUILD_native_dyn/INSTALL/lib${{matrix.lib_postfix}}/pkgconfig"
+        run: |
+          qmake PREFIX=$HOME/BUILD_native_dyn/INSTALL
+          make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:38
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - bionic
+          - focal
         include:
-          - target: bionic
-            image_variant: bionic
+          - target: focal
+            image_variant: focal
             lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner
@@ -38,7 +38,7 @@ jobs:
     - name: Install deps
       shell: bash
       run: |
-        ARCHIVE_NAME=deps2_bionic_native_dyn_kiwix-desktop.tar.xz
+        ARCHIVE_NAME=deps2_focal_native_dyn_kiwix-desktop.tar.xz
         wget -O- http://tmp.kiwix.org/ci/${ARCHIVE_NAME} | tar -xJ -C /home/runner
     - name: Compile
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       HOME: /home/runner
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:36
+      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:38
     steps:
     - name: Extract branch name
       shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,12 @@
 name: Packages
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
 
 jobs:
   build-deb:
@@ -65,7 +72,6 @@ jobs:
 
       - uses: legoktm/gh-action-dput@master
         name: Upload dev package
-        # Only upload on pushes to git default branch
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && startswith(matrix.distro, 'ubuntu-')
         with:
           gpg_key: ${{ secrets.LAUNCHPAD_GPG }}
@@ -74,8 +80,7 @@ jobs:
 
       - uses: legoktm/gh-action-dput@master
         name: Upload release package
-        # Only upload on pushes to master or tag
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && startswith(matrix.distro, 'ubuntu-')
+        if: github.event_name == 'release' && startswith(matrix.distro, 'ubuntu-')
         with:
           gpg_key: ${{ secrets.LAUNCHPAD_GPG }}
           repository: ppa:kiwixteam/release

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -47,7 +47,6 @@ jobs:
         with:
           args: --no-sign
           ppa: ${{ steps.ppa.outputs.ppa }}
-
 
       - uses: legoktm/gh-action-build-deb@ubuntu-jammy
         if: matrix.distro == 'ubuntu-jammy'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,6 @@ jobs:
           - ubuntu-kinetic
           - ubuntu-jammy
           - ubuntu-focal
-          - ubuntu-bionic
     steps:
       - uses: actions/checkout@v3
 
@@ -55,14 +54,6 @@ jobs:
         if: matrix.distro == 'ubuntu-focal'
         name: Build package for ubuntu-focal
         id: build-ubuntu-focal
-        with:
-          args: --no-sign
-          ppa: ${{ steps.ppa.outputs.ppa }}
-
-      - uses: legoktm/gh-action-build-deb@ubuntu-bionic
-        if: matrix.distro == 'ubuntu-bionic'
-        name: Build package for ubuntu-bionic
-        id: build-ubuntu-bionic
         with:
           args: --no-sign
           ppa: ${{ steps.ppa.outputs.ppa }}


### PR DESCRIPTION
* Removal of Ubuntu Bionic 19.04 because we supports now from Ubuntu Focal 20.04.
* Use latest versin of compilation container image
* Better triggering of CI/CD events
* Use appropriate action to checkout the code