### PR TITLE
Adapt to new api introduced in kiwix/libkiwix#991

### DIFF
--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -35,7 +35,7 @@ public:
 
 private:
     Library* mp_library;
-    kiwix::Library m_remoteLibrary;
+    kiwix::LibraryPtr mp_remoteLibrary;
     kiwix::Downloader* mp_downloader;
     OpdsRequestManager m_remoteLibraryManager;
     ContentManagerView* mp_view;

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -31,8 +31,8 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
       mp_downloader(nullptr),
       mp_manager(nullptr),
       mp_mainWindow(nullptr),
-      m_nameMapper(m_library.getKiwixLibrary(), false),
-      m_server(&m_library.getKiwixLibrary(), &m_nameMapper)
+      mp_nameMapper(std::make_shared<kiwix::UpdatableNameMapper>(m_library.getKiwixLibrary(), false)),
+      m_server(m_library.getKiwixLibrary(), mp_nameMapper)
 {
     try {
         m_translation.setTranslation(QLocale());
@@ -457,7 +457,7 @@ void KiwixApp::handleItemsState(TabType tabType)
 
 void KiwixApp::updateNameMapper()
 {
-  m_nameMapper.update();
+  mp_nameMapper->update();
 }
 
 void KiwixApp::printVersions(std::ostream& out) {

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -111,7 +111,7 @@ private:
     ContentManager* mp_manager;
     MainWindow* mp_mainWindow;
     QErrorMessage* mp_errorDialog;
-    kiwix::UpdatableNameMapper m_nameMapper;
+    std::shared_ptr<kiwix::UpdatableNameMapper> mp_nameMapper;
     kiwix::Server m_server;
     Translation m_translation;
     QFileSystemWatcher m_watcher;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -11,26 +11,26 @@
 class LibraryManipulator: public kiwix::LibraryManipulator {
   public:
     LibraryManipulator(Library* p_library)
-        : kiwix::LibraryManipulator(&p_library->getKiwixLibrary())
+        : kiwix::LibraryManipulator(p_library->getKiwixLibrary())
         , mp_library(p_library)
     {}
     virtual ~LibraryManipulator() {}
     bool addBookToLibrary(kiwix::Book book) {
-        auto ret = mp_library->m_library.addBook(book);
+        auto ret = mp_library->mp_library->addBook(book);
         emit(mp_library->booksChanged());
         return ret;
     }
     void addBookmarkToLibrary(kiwix::Bookmark bookmark) {
-        mp_library->m_library.addBookmark(bookmark);
+        mp_library->mp_library->addBookmark(bookmark);
     }
     Library* mp_library;
 };
 
 Library::Library(const QString& libraryDirectory)
-  : m_libraryDirectory(libraryDirectory)
+  : mp_library(kiwix::Library::create()),
+    m_libraryDirectory(libraryDirectory)
 {
-    auto manipulator = LibraryManipulator(this);
-    auto manager = kiwix::Manager(&manipulator);
+    auto manager = kiwix::Manager(LibraryManipulator(this));
     manager.readFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"), false);
     manager.readBookmarkFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.bookmarks.xml"));
     emit(booksChanged());
@@ -44,11 +44,11 @@ Library::~Library()
 QString Library::openBookFromPath(const QString &zimPath)
 {
     try {
-        auto& book = m_library.getBookByPath(zimPath.toStdString());
+        auto& book = mp_library->getBookByPath(zimPath.toStdString());
         return QString::fromStdString(book.getId());
     } catch(std::out_of_range& e) { }
 
-    kiwix::Manager manager(&m_library);
+    kiwix::Manager manager(mp_library);
     auto id =  manager.addBookFromPathAndGetId(zimPath.toStdString());
     if (id == "") {
         throw std::invalid_argument("invalid zim file");
@@ -60,18 +60,18 @@ QString Library::openBookFromPath(const QString &zimPath)
 
 std::shared_ptr<zim::Archive> Library::getArchive(const QString &zimId)
 {
-    return m_library.getArchiveById(zimId.toStdString());
+    return mp_library->getArchiveById(zimId.toStdString());
 }
 
 std::shared_ptr<zim::Searcher> Library::getSearcher(const QString &zimId)
 {
-    return m_library.getSearcherById(zimId.toStdString());
+    return mp_library->getSearcherById(zimId.toStdString());
 }
 
 QStringList Library::getBookIds() const
 {
     QStringList list;
-    for(auto& id: m_library.getBooksIds()) {
+    for(auto& id: mp_library->getBooksIds()) {
         list.append(QString::fromStdString(id));
     }
     return list;
@@ -80,8 +80,8 @@ QStringList Library::getBookIds() const
 QStringList Library::listBookIds(const kiwix::Filter& filter, kiwix::supportedListSortBy sortBy, bool ascending) const
 {
     QStringList list;
-    auto bookIds = m_library.filter(filter);
-    m_library.sort(bookIds, sortBy, ascending);
+    auto bookIds = mp_library->filter(filter);
+    mp_library->sort(bookIds, sortBy, ascending);
     for(auto& id: bookIds) {
         list.append(QString::fromStdString(id));
     }
@@ -90,29 +90,29 @@ QStringList Library::listBookIds(const kiwix::Filter& filter, kiwix::supportedLi
 
 void Library::addBookToLibrary(kiwix::Book &book)
 {
-    m_library.addBook(book);
+    mp_library->addBook(book);
 }
 
 void Library::removeBookFromLibraryById(const QString& id) {
-    m_library.removeBookById(id.toStdString());
+    mp_library->removeBookById(id.toStdString());
 }
 
 void Library::addBookmark(kiwix::Bookmark &bookmark)
 {
-    m_library.addBookmark(bookmark);
+    mp_library->addBookmark(bookmark);
     emit bookmarksChanged();
 }
 
 void Library::removeBookmark(const QString &zimId, const QString &url)
 {
-    m_library.removeBookmark(zimId.toStdString(), url.toStdString());
+    mp_library->removeBookmark(zimId.toStdString(), url.toStdString());
     emit bookmarksChanged();
 }
 
 void Library::save()
 {
-    m_library.writeToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"));
-    m_library.writeBookmarksToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(), "library.bookmarks.xml"));
+    mp_library->writeToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"));
+    mp_library->writeBookmarksToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(), "library.bookmarks.xml"));
 }
 
 void Library::setMonitorDirZims(QString monitorDir, QStringList zimList)
@@ -152,15 +152,14 @@ void Library::updateFromDir(QString monitorDir)
 #endif
     QStringList addedZims = (newDir - oldDir).values();
     QStringList removedZims = (oldDir - newDir).values();
-    auto manipulator = LibraryManipulator(this);
-    auto manager = kiwix::Manager(&manipulator);
+    auto manager = kiwix::Manager(LibraryManipulator(this));
     bool needsRefresh = !removedZims.empty();
     for (auto book : addedZims) {
         needsRefresh |= manager.addBookFromPath(book.toStdString());
     }
     for (auto bookPath : removedZims) {
         try {
-            removeBookFromLibraryById(QString::fromStdString(m_library.getBookByPath(bookPath.toStdString()).getId()));
+            removeBookFromLibraryById(QString::fromStdString(mp_library->getBookByPath(bookPath.toStdString()).getId()));
         } catch (...) {}
     }
     if (needsRefresh) {
@@ -178,5 +177,5 @@ void Library::asyncUpdateFromDir(QString dir)
 
 const kiwix::Book &Library::getBookById(QString id) const
 {
-    return m_library.getBookById(id.toStdString());
+    return mp_library->getBookById(id.toStdString());
 }

--- a/src/library.h
+++ b/src/library.h
@@ -33,7 +33,7 @@ public:
     std::shared_ptr<zim::Searcher> getSearcher(const QString& zimId);
     QStringList getBookIds() const;
     QStringList listBookIds(const kiwix::Filter& filter, kiwix::supportedListSortBy sortBy, bool ascending) const;
-    const std::vector<kiwix::Bookmark> getBookmarks(bool onlyValidBookmarks = false) const { return m_library.getBookmarks(onlyValidBookmarks); }
+    const std::vector<kiwix::Bookmark> getBookmarks(bool onlyValidBookmarks = false) const { return mp_library->getBookmarks(onlyValidBookmarks); }
     QStringList getLibraryZimsFromDir(QString dir) const;
     void setMonitorDirZims(QString monitorDir, QStringList zimList);
     void addBookToLibrary(kiwix::Book& book);
@@ -43,7 +43,7 @@ public:
     void save();
     void updateFromDir(QString dir);
     void asyncUpdateFromDir(QString dir);
-    kiwix::Library& getKiwixLibrary() { return m_library; }
+    kiwix::LibraryPtr getKiwixLibrary() { return mp_library; }
 public slots:
     const kiwix::Book& getBookById(QString id) const;
 
@@ -53,7 +53,7 @@ signals:
 
 private:
     QMutex m_updateFromDirMutex;
-    kiwix::Library m_library;
+    kiwix::LibraryPtr mp_library;
     QString m_libraryDirectory;
     QMap<QString, QStringList> m_knownZimsInDir;
 friend class LibraryManipulator;

--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -131,9 +131,11 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
         request->fail(QWebEngineUrlRequestJob::UrlInvalid);
         return;
     }
-    IdNameMapper nameMapper;
-    kiwix::SearchRenderer renderer(search->getResults(start, pageLength), &nameMapper, search->getEstimatedMatches(),
-                            start);
+    kiwix::SearchRenderer renderer(
+        search->getResults(start, pageLength),
+        std::make_shared<IdNameMapper>(),
+        search->getEstimatedMatches(),
+        start);
     renderer.setSearchPattern(searchQuery);
     renderer.setSearchBookQuery("content="+bookId.toStdString());
     renderer.setProtocolPrefix("zim://");

--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -133,7 +133,6 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     }
     kiwix::SearchRenderer renderer(
         search->getResults(start, pageLength),
-        std::make_shared<IdNameMapper>(),
         search->getEstimatedMatches(),
         start);
     renderer.setSearchPattern(searchQuery);
@@ -141,7 +140,8 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     renderer.setProtocolPrefix("zim://");
     renderer.setSearchProtocolPrefix("zim://" + host.toStdString() + "/");
     renderer.setPageLength(pageLength);
-    auto content = renderer.getHtml();
+    IdNameMapper mapper;
+    auto content = renderer.getHtml(mapper, nullptr);
     QBuffer *buffer = new QBuffer;
     buffer->setData(content.data(), content.size());
     connect(request, &QObject::destroyed, buffer, &QObject::deleteLater);


### PR DESCRIPTION
This is the following of https://github.com/kiwix/libkiwix/pull/991

`kiwix::Library` must be handle through a `shared_ptr` and cannot be created directly on the stack.