### PR TITLE
Move to c++17.

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -15,8 +15,8 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = kiwix-desktop
 TEMPLATE = app
 
-QMAKE_CXXFLAGS += -std=c++11
-QMAKE_LFLAGS +=  -std=c++11
+QMAKE_CXXFLAGS += -std=c++17
+QMAKE_LFLAGS +=  -std=c++17
 
 # Also change resources/org.kiwix.desktop.appdata.xml
 DEFINES += VERSION="2.3.1"


### PR DESCRIPTION
All our compilers should handle c++17. Let's move on.

Following of openzim/libzim#819
Fix openzim/libzim#757