### PR TITLE
A couple of bugfixes in Download management

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -137,7 +137,7 @@
     "monitor-directory-tooltip":"All ZIM files in this directory will be automatically added to the library.",
     "next-tab":"Move to next tab",
     "previous-tab":"Move to previous tab",
-    "cancel-download": "Cancel Download",
+    "cancel-download": "Cancel download",
     "cancel-download-text": "Are you sure you want to cancel the download of <b>{{ZIM}}</b>?",
     "delete-book": "Delete book",
     "delete-book-text": "Are you sure you want to delete <b>{{ZIM}}</b>?",

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -107,8 +107,8 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
     QAction menuCancelBook(gt("cancel-download"), this);
     QAction menuOpenFolder(gt("open-folder"), this);
 
-    if (bookNode->isDownloading()) {
-        if (bookNode->getDownloadInfo().paused) {
+    if (DownloadState* download = bookNode->getDownloadState()) {
+        if (download->getDownloadInfo().paused) {
             contextMenu.addAction(&menuResumeBook);
         } else {
             contextMenu.addAction(&menuPauseBook);

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -77,10 +77,10 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     setLanguages();
 }
 
-QList<QMap<QString, QVariant>> ContentManager::getBooksList()
+ContentManager::BookInfoList ContentManager::getBooksList()
 {
     const auto bookIds = getBookIds();
-    QList<QMap<QString, QVariant>> bookList;
+    BookInfoList bookList;
     QStringList keys = {"title", "tags", "date", "id", "size", "description", "faviconUrl"};
     QIcon bookIcon;
     for (auto bookId : bookIds) {
@@ -216,9 +216,9 @@ void ContentManager::setLanguages()
 }
 
 #define ADD_V(KEY, METH) {if(key==KEY) values.insert(key, QString::fromStdString((b->METH())));}
-QMap<QString, QVariant> ContentManager::getBookInfos(QString id, const QStringList &keys)
+ContentManager::BookInfo ContentManager::getBookInfos(QString id, const QStringList &keys)
 {
-    QMap<QString, QVariant> values;
+    BookInfo values;
     const kiwix::Book* b = [=]()->const kiwix::Book* {
         try {
             return &mp_library->getBookById(id);

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -681,13 +681,13 @@ void ContentManager::updateLibrary() {
     } catch (std::runtime_error&) {}
 }
 
-#define CATALOG_URL "library.kiwix.org"
 void ContentManager::updateRemoteLibrary(const QString& content) {
     QtConcurrent::run([=]() {
         QMutexLocker locker(&remoteLibraryLocker);
         mp_remoteLibrary = kiwix::Library::create();
         kiwix::Manager manager(mp_remoteLibrary);
-        manager.readOpds(content.toStdString(), CATALOG_URL);
+        const auto catalogUrl = m_remoteLibraryManager.getCatalogHost();
+        manager.readOpds(content.toStdString(), catalogUrl.toStdString());
         emit(this->booksChanged());
         emit(this->pendingRequest(false));
     });

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -107,7 +107,7 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
     QAction menuCancelBook(gt("cancel-download"), this);
     QAction menuOpenFolder(gt("open-folder"), this);
 
-    if (DownloadState* download = bookNode->getDownloadState()) {
+    if (const auto download = bookNode->getDownloadState()) {
         if (download->getDownloadInfo().paused) {
             contextMenu.addAction(&menuResumeBook);
         } else {

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -17,9 +17,13 @@ class ContentManager : public QObject
     Q_PROPERTY(QStringList downloadIds READ getDownloadIds NOTIFY downloadsChanged)
     Q_PROPERTY(bool isLocal MEMBER m_local READ isLocal WRITE setLocal NOTIFY localChanged)
 
-public:
+public: // types
     typedef QList<QPair<QString, QString>> LanguageList;
     typedef QList<QPair<QString, QString>> FilterList;
+    typedef ContentManagerModel::BookInfo     BookInfo;
+    typedef ContentManagerModel::BookInfoList BookInfoList;
+
+public: // functions
     explicit ContentManager(Library* library, kiwix::Downloader *downloader, QObject *parent = nullptr);
     virtual ~ContentManager() {}
 
@@ -51,7 +55,7 @@ private:
 
     QStringList getBookIds();
     void eraseBookFilesFromComputer(const QString dirPath, const QString filename, const bool moveToTrash);
-    QList<QMap<QString, QVariant>> getBooksList();
+    BookInfoList getBooksList();
     ContentManagerModel *managerModel;
     QMutex remoteLibraryLocker;
     void setCategories();
@@ -71,7 +75,7 @@ signals:
 
 public slots:
     QStringList getTranslations(const QStringList &keys);
-    QMap<QString, QVariant> getBookInfos(QString id, const QStringList &keys);
+    BookInfo getBookInfos(QString id, const QStringList &keys);
     void openBook(const QString& id);
     QMap<QString, QVariant> updateDownloadInfos(QString id, const QStringList& keys);
     QString downloadBook(const QString& id);

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -177,8 +177,8 @@ void ContentManagerDelegate::paint(QPainter *painter, const QStyleOptionViewItem
     }
     QStyleOptionViewItem eOpt = option;
     if (index.column() == 5) {
-        if (node->isDownloading()) {
-            auto downloadInfo = node->getDownloadInfo();
+        if (DownloadState* downloadState = node->getDownloadState()) {
+            auto downloadInfo = downloadState->getDownloadInfo();
             showDownloadProgress(painter, r, downloadInfo);
         }
         else {
@@ -244,8 +244,8 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
     int x = r.left();
     int w = r.width();
 
-    if (node->isDownloading()) {
-        if (node->getDownloadInfo().paused) {
+    if (DownloadState* downloadState = node->getDownloadState()) {
+        if (downloadState->getDownloadInfo().paused) {
             if (clickX < (x + w/2)) {
                 KiwixApp::instance()->getContentManager()->cancelBook(id, index);
             } else {

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -177,7 +177,7 @@ void ContentManagerDelegate::paint(QPainter *painter, const QStyleOptionViewItem
     }
     QStyleOptionViewItem eOpt = option;
     if (index.column() == 5) {
-        if (DownloadState* downloadState = node->getDownloadState()) {
+        if (const auto downloadState = node->getDownloadState()) {
             auto downloadInfo = downloadState->getDownloadInfo();
             showDownloadProgress(painter, r, downloadInfo);
         }
@@ -244,7 +244,7 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
     int x = r.left();
     int w = r.width();
 
-    if (DownloadState* downloadState = node->getDownloadState()) {
+    if (const auto downloadState = node->getDownloadState()) {
         if (downloadState->getDownloadInfo().paused) {
             if (clickX < (x + w/2)) {
                 KiwixApp::instance()->getContentManager()->cancelBook(id, index);

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -102,7 +102,7 @@ QVariant ContentManagerModel::headerData(int section, Qt::Orientation orientatio
     }
 }
 
-void ContentManagerModel::setBooksData(const QList<QMap<QString, QVariant>>& data)
+void ContentManagerModel::setBooksData(const BookInfoList& data)
 {
     m_data = data;
     rootNode = std::shared_ptr<RowNode>(new RowNode({tr("Icon"), tr("Name"), tr("Date"), tr("Size"), tr("Content Type"), tr("Download")}, "", std::weak_ptr<RowNode>()));
@@ -124,7 +124,7 @@ QString convertToUnits(QString size)
     return preciseBytes + " " + units[unitIndex];
 }
 
-std::shared_ptr<RowNode> ContentManagerModel::createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap) const
+std::shared_ptr<RowNode> ContentManagerModel::createNode(BookInfo bookItem, QMap<QString, QByteArray> iconMap) const
 {
     auto faviconUrl = "https://" + bookItem["faviconUrl"].toString();
     QString id = bookItem["id"].toString();

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -242,7 +242,7 @@ void ContentManagerModel::startDownload(QModelIndex index)
     node->setDownloadState(new DownloadState);
     QTimer *timer = node->getDownloadState()->getDownloadUpdateTimer();
     connect(timer, &QTimer::timeout, this, [=]() {
-        node->getDownloadState()->updateDownloadStatus(node->getBookId());
+        node->getDownloadState()->update(node->getBookId());
         emit dataChanged(index, index);
     });
 }
@@ -250,14 +250,14 @@ void ContentManagerModel::startDownload(QModelIndex index)
 void ContentManagerModel::pauseDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    node->getDownloadState()->pauseDownload();
+    node->getDownloadState()->pause();
     emit dataChanged(index, index);
 }
 
 void ContentManagerModel::resumeDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    node->getDownloadState()->resumeDownload();
+    node->getDownloadState()->resume();
     emit dataChanged(index, index);
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -265,7 +265,6 @@ void ContentManagerModel::cancelDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
     node->setIsDownloading(false); // this stops & deletes the timer
-    node->setDownloadInfo({0, "", "", false});
     emit dataChanged(index, index);
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -250,20 +250,14 @@ void ContentManagerModel::startDownload(QModelIndex index)
 void ContentManagerModel::pauseDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    auto prevDownloadInfo = node->getDownloadInfo();
-    prevDownloadInfo.paused = true;
-    node->setDownloadInfo(prevDownloadInfo);
-    node->getDownloadUpdateTimer()->stop();
+    node->pauseDownload();
     emit dataChanged(index, index);
 }
 
 void ContentManagerModel::resumeDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    auto prevDownloadInfo = node->getDownloadInfo();
-    prevDownloadInfo.paused = false;
-    node->setDownloadInfo(prevDownloadInfo);
-    node->getDownloadUpdateTimer()->start(1000);
+    node->resumeDownload();
     emit dataChanged(index, index);
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -250,7 +250,6 @@ void ContentManagerModel::startDownload(QModelIndex index)
 void ContentManagerModel::pauseDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    auto id = node->getBookId();
     auto prevDownloadInfo = node->getDownloadInfo();
     prevDownloadInfo.paused = true;
     node->setDownloadInfo(prevDownloadInfo);
@@ -261,7 +260,6 @@ void ContentManagerModel::pauseDownload(QModelIndex index)
 void ContentManagerModel::resumeDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    auto id = node->getBookId();
     auto prevDownloadInfo = node->getDownloadInfo();
     prevDownloadInfo.paused = false;
     node->setDownloadInfo(prevDownloadInfo);
@@ -272,7 +270,6 @@ void ContentManagerModel::resumeDownload(QModelIndex index)
 void ContentManagerModel::cancelDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    auto id = node->getBookId();
     node->setIsDownloading(false); // this stops & deletes the timer
     node->setDownloadInfo({0, "", "", false});
     emit dataChanged(index, index);

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -232,7 +232,7 @@ void ContentManagerModel::startDownload(QModelIndex index)
         percent = QString::number(percent, 'g', 3).toDouble();
         auto completedLength = convertToUnits(downloadInfos["completedLength"].toString());
         auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toString()) + "/s";
-        node->setDownloadInfo({percent, completedLength, downloadSpeed});
+        node->setDownloadInfo({percent, completedLength, downloadSpeed, false});
         if (!downloadInfos["status"].isValid()) {
             node->setIsDownloading(false);
             timer->stop();

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -227,7 +227,7 @@ void ContentManagerModel::startDownload(QModelIndex index)
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, [=]() {
         auto downloadInfos = KiwixApp::instance()->getContentManager()->updateDownloadInfos(id, {"status", "completedLength", "totalLength", "downloadSpeed"});
-        double percent = (double) downloadInfos["completedLength"].toInt() / downloadInfos["totalLength"].toInt();
+        double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
         percent *= 100;
         percent = QString::number(percent, 'g', 3).toDouble();
         auto completedLength = convertToUnits(downloadInfos["completedLength"].toString());

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -242,7 +242,7 @@ void ContentManagerModel::startDownload(QModelIndex index)
     node->setIsDownloading(true); // this starts the internal timer
     QTimer *timer = node->getDownloadUpdateTimer();
     connect(timer, &QTimer::timeout, this, [=]() {
-        node->updateDownloadStatus();
+        node->updateDownloadStatus(node->getBookId());
         emit dataChanged(index, index);
     });
 }

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -239,10 +239,10 @@ std::shared_ptr<RowNode> getSharedPointer(RowNode* ptr)
 void ContentManagerModel::startDownload(QModelIndex index)
 {
     auto node = getSharedPointer(static_cast<RowNode*>(index.internalPointer()));
-    node->setIsDownloading(true); // this starts the internal timer
-    QTimer *timer = node->getDownloadUpdateTimer();
+    node->setDownloadState(new DownloadState);
+    QTimer *timer = node->getDownloadState()->getDownloadUpdateTimer();
     connect(timer, &QTimer::timeout, this, [=]() {
-        node->updateDownloadStatus(node->getBookId());
+        node->getDownloadState()->updateDownloadStatus(node->getBookId());
         emit dataChanged(index, index);
     });
 }
@@ -250,21 +250,21 @@ void ContentManagerModel::startDownload(QModelIndex index)
 void ContentManagerModel::pauseDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    node->pauseDownload();
+    node->getDownloadState()->pauseDownload();
     emit dataChanged(index, index);
 }
 
 void ContentManagerModel::resumeDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    node->resumeDownload();
+    node->getDownloadState()->resumeDownload();
     emit dataChanged(index, index);
 }
 
 void ContentManagerModel::cancelDownload(QModelIndex index)
 {
     auto node = static_cast<RowNode*>(index.internalPointer());
-    node->setIsDownloading(false); // this stops & deletes the timer
+    node->setDownloadState(nullptr);
     emit dataChanged(index, index);
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -124,7 +124,7 @@ QString convertToUnits(QString size)
     return preciseBytes + " " + units[unitIndex];
 }
 
-std::shared_ptr<RowNode> ContentManagerModel::createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap, std::shared_ptr<RowNode> rootNode)
+std::shared_ptr<RowNode> ContentManagerModel::createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap) const
 {
     auto faviconUrl = "https://" + bookItem["faviconUrl"].toString();
     QString id = bookItem["id"].toString();
@@ -158,7 +158,7 @@ void ContentManagerModel::setupNodes()
 {
     beginResetModel();
     for (auto bookItem : m_data) {
-        rootNode->appendChild(createNode(bookItem, iconMap, rootNode));
+        rootNode->appendChild(createNode(bookItem, iconMap));
     }
     endResetModel();
 }

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -35,7 +35,7 @@ public:
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
     void refreshIcons();
 
-    static std::shared_ptr<RowNode> createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap, std::shared_ptr<RowNode> rootNode);
+    std::shared_ptr<RowNode> createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap) const;
 
 public slots:
     void updateImage(QModelIndex index, QString url, QByteArray imageData);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -58,6 +58,7 @@ private: // data
     std::shared_ptr<RowNode> rootNode;
     int zimCount = 0;
     ThumbnailDownloader td;
+    QMap<QString, size_t> bookIdToRowMap;
     QMap<QString, QByteArray> iconMap;
     QMap<QString, std::shared_ptr<DownloadState>> m_downloads;
 };

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -35,6 +35,8 @@ public:
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
     void refreshIcons();
 
+    static std::shared_ptr<RowNode> createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap, std::shared_ptr<RowNode> rootNode);
+
 public slots:
     void updateImage(QModelIndex index, QString url, QByteArray imageData);
     void startDownload(QModelIndex index);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -58,7 +58,6 @@ private: // data
     int zimCount = 0;
     ThumbnailDownloader td;
     QMap<QString, QByteArray> iconMap;
-    QMap<QString, QTimer*> timers;
 };
 
 #endif // CONTENTMANAGERMODEL_H

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -53,6 +53,9 @@ protected: // functions
     bool canFetchMore(const QModelIndex &parent) const override;
     void fetchMore(const QModelIndex &parent) override;
 
+private: // functions
+    void updateDownload(QString bookId);
+
 private: // data
     BookInfoList m_data;
     std::shared_ptr<RowNode> rootNode;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -6,6 +6,7 @@
 #include <QVariant>
 #include <QIcon>
 #include "thumbnaildownloader.h"
+#include "rownode.h"
 #include <memory>
 
 class RowNode;
@@ -58,6 +59,7 @@ private: // data
     int zimCount = 0;
     ThumbnailDownloader td;
     QMap<QString, QByteArray> iconMap;
+    QMap<QString, std::shared_ptr<DownloadState>> m_downloads;
 };
 
 #endif // CONTENTMANAGERMODEL_H

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -16,7 +16,11 @@ class ContentManagerModel : public QAbstractItemModel
 {
     Q_OBJECT
 
-public:
+public: // types
+    typedef QMap<QString, QVariant> BookInfo;
+    typedef QList<BookInfo>         BookInfoList;
+
+public: // functions
     explicit ContentManagerModel(QObject *parent = nullptr);
     ~ContentManagerModel();
 
@@ -29,13 +33,13 @@ public:
     QModelIndex parent(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-    void setBooksData(const QList<QMap<QString, QVariant>>& data);
+    void setBooksData(const BookInfoList& data);
     void setupNodes();
     bool hasChildren(const QModelIndex &parent) const override;
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
     void refreshIcons();
 
-    std::shared_ptr<RowNode> createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap) const;
+    std::shared_ptr<RowNode> createNode(BookInfo bookItem, QMap<QString, QByteArray> iconMap) const;
 
 public slots:
     void updateImage(QModelIndex index, QString url, QByteArray imageData);
@@ -44,12 +48,12 @@ public slots:
     void resumeDownload(QModelIndex index);
     void cancelDownload(QModelIndex index);
 
-protected:
+protected: // functions
     bool canFetchMore(const QModelIndex &parent) const override;
     void fetchMore(const QModelIndex &parent) override;
 
-private:
-    QList<QMap<QString, QVariant>> m_data;
+private: // data
+    BookInfoList m_data;
     std::shared_ptr<RowNode> rootNode;
     int zimCount = 0;
     ThumbnailDownloader td;

--- a/src/opdsrequestmanager.cpp
+++ b/src/opdsrequestmanager.cpp
@@ -5,8 +5,22 @@ OpdsRequestManager::OpdsRequestManager()
 {
 }
 
-#define CATALOG_HOST "library.kiwix.org"
-#define CATALOG_PORT 443
+QString OpdsRequestManager::getCatalogHost()
+{
+    const char* const envVarVal = getenv("KIWIX_CATALOG_HOST");
+    return envVarVal
+         ? envVarVal
+         : "library.kiwix.org";
+}
+
+int OpdsRequestManager::getCatalogPort()
+{
+    const char* const envVarVal = getenv("KIWIX_CATALOG_PORT");
+    return envVarVal
+         ? atoi(envVarVal)
+         : 443;
+}
+
 void OpdsRequestManager::doUpdate(const QString& currentLanguage, const QString& categoryFilter)
 {
     QUrlQuery query;
@@ -36,9 +50,10 @@ void OpdsRequestManager::doUpdate(const QString& currentLanguage, const QString&
 QNetworkReply* OpdsRequestManager::opdsResponseFromPath(const QString &path, const QUrlQuery &query)
 {
     QUrl url;
-    url.setScheme("https");
-    url.setHost(CATALOG_HOST);
-    url.setPort(CATALOG_PORT);
+    const int port = getCatalogPort();
+    url.setScheme(port == 443 ? "https" : "http");
+    url.setHost(getCatalogHost());
+    url.setPort(port);
     url.setPath(path);
     url.setQuery(query);
     qInfo() << "Downloading" << url.toString(QUrl::FullyEncoded);

--- a/src/opdsrequestmanager.h
+++ b/src/opdsrequestmanager.h
@@ -32,6 +32,10 @@ public slots:
     void receiveContent(QNetworkReply*);
     void receiveLanguages(QNetworkReply*);
     void receiveCategories(QNetworkReply*);
+
+public:
+    static QString getCatalogHost();
+    static int     getCatalogPort();
 };
 
 #endif // OPDSREQUESTMANAGER_H

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -93,6 +93,7 @@ void DownloadState::setIsDownloading(bool val)
         // of any events that may be in the process of being delivered to it
         // from another thread.
         m_downloadUpdateTimer.reset();
+        m_downloadInfo = {0, "", "", false};
     }
 }
 
@@ -123,7 +124,7 @@ void DownloadState::updateDownloadStatus(QString id)
     percent = QString::number(percent, 'g', 3).toDouble();
     auto completedLength = convertToUnits(downloadInfos["completedLength"].toString());
     auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toString()) + "/s";
-    setDownloadInfo({percent, completedLength, downloadSpeed, false});
+    m_downloadInfo = {percent, completedLength, downloadSpeed, false};
     if (!downloadInfos["status"].isValid()) {
         setIsDownloading(false); // this stops & deletes the timer
     }

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -3,10 +3,14 @@
 #include "kiwixapp.h"
 #include "descriptionnode.h"
 
+DownloadState::DownloadState()
+    : m_downloadInfo({0, "", "", false})
+{
+}
+
 RowNode::RowNode(QList<QVariant> itemData, QString bookId, std::weak_ptr<RowNode> parent)
     : m_itemData(itemData), m_parentItem(parent), m_bookId(bookId)
 {
-    m_downloadInfo = {0, "", "", false};
 }
 
 RowNode::~RowNode()
@@ -75,7 +79,7 @@ bool RowNode::isChild(Node *candidate)
     return false;
 }
 
-void RowNode::setIsDownloading(bool val)
+void DownloadState::setIsDownloading(bool val)
 {
     assert(val != isDownloading());
     if ( val ) {
@@ -111,9 +115,8 @@ QString convertToUnits(QString size)
 
 } // unnamed namespace
 
-void RowNode::updateDownloadStatus()
+void DownloadState::updateDownloadStatus(QString id)
 {
-    const auto id = getBookId();
     auto downloadInfos = KiwixApp::instance()->getContentManager()->updateDownloadInfos(id, {"status", "completedLength", "totalLength", "downloadSpeed"});
     double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
     percent *= 100;
@@ -126,13 +129,13 @@ void RowNode::updateDownloadStatus()
     }
 }
 
-void RowNode::pauseDownload()
+void DownloadState::pauseDownload()
 {
     m_downloadInfo.paused = true;
     m_downloadUpdateTimer->stop();
 }
 
-void RowNode::resumeDownload()
+void DownloadState::resumeDownload()
 {
     m_downloadInfo.paused = false;
     m_downloadUpdateTimer->start(1000);

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -142,7 +142,7 @@ bool RowNode::isChild(Node *candidate)
     return false;
 }
 
-void RowNode::setDownloadState(DownloadState* ds)
+void RowNode::setDownloadState(std::shared_ptr<DownloadState> ds)
 {
-    m_downloadState.reset(ds);
+    m_downloadState = ds;
 }

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -125,3 +125,15 @@ void RowNode::updateDownloadStatus()
         setIsDownloading(false); // this stops & deletes the timer
     }
 }
+
+void RowNode::pauseDownload()
+{
+    m_downloadInfo.paused = true;
+    m_downloadUpdateTimer->stop();
+}
+
+void RowNode::resumeDownload()
+{
+    m_downloadInfo.paused = false;
+    m_downloadUpdateTimer->start(1000);
+}

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -33,7 +33,7 @@ QString convertToUnits(QString size)
 
 } // unnamed namespace
 
-void DownloadState::update(QString id)
+bool DownloadState::update(QString id)
 {
     auto downloadInfos = KiwixApp::instance()->getContentManager()->updateDownloadInfos(id, {"status", "completedLength", "totalLength", "downloadSpeed"});
     double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
@@ -51,7 +51,9 @@ void DownloadState::update(QString id)
         // from another thread.
         m_downloadUpdateTimer.reset();
         m_downloadInfo = {0, "", "", false};
+        return false;
     }
+    return true;
 }
 
 void DownloadState::pause()

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -2,7 +2,6 @@
 #include <QVariant>
 #include "kiwixapp.h"
 #include "descriptionnode.h"
-#include "kiwix/tools.h"
 
 RowNode::RowNode(QList<QVariant> itemData, QString bookId, std::weak_ptr<RowNode> parent)
     : m_itemData(itemData), m_parentItem(parent), m_bookId(bookId)
@@ -63,36 +62,6 @@ int RowNode::row() const
     }
 
     return 0;
-}
-
-std::shared_ptr<RowNode> RowNode::createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap, std::shared_ptr<RowNode> rootNode)
-{
-    auto faviconUrl = "https://" + bookItem["faviconUrl"].toString();
-    QString id = bookItem["id"].toString();
-    QByteArray bookIcon;
-    try {
-        auto book = KiwixApp::instance()->getLibrary()->getBookById(id);
-        std::string favicon;
-        auto item = book.getIllustration(48);
-        favicon = item->getData();
-        bookIcon = QByteArray::fromRawData(reinterpret_cast<const char*>(favicon.data()), favicon.size());
-        bookIcon.detach(); // deep copy
-    } catch (...) {
-        if (iconMap.contains(faviconUrl)) {
-            bookIcon = iconMap[faviconUrl];
-        }
-    }
-    std::weak_ptr<RowNode> weakRoot = rootNode;
-    auto rowNodePtr = std::shared_ptr<RowNode>(new
-                                    RowNode({bookIcon, bookItem["title"],
-                                   bookItem["date"],
-                                   QString::fromStdString(kiwix::beautifyFileSize(bookItem["size"].toULongLong())),
-                                   bookItem["tags"]
-                                   }, id, weakRoot));
-    std::weak_ptr<RowNode> weakRowNodePtr = rowNodePtr;
-    const auto descNodePtr = std::make_shared<DescriptionNode>(DescriptionNode(bookItem["description"].toString(), weakRowNodePtr));
-    rowNodePtr->appendChild(descNodePtr);
-    return rowNodePtr;
 }
 
 bool RowNode::isChild(Node *candidate)

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -74,3 +74,20 @@ bool RowNode::isChild(Node *candidate)
     }
     return false;
 }
+
+void RowNode::setIsDownloading(bool val)
+{
+    assert(val != isDownloading());
+    if ( val ) {
+        m_downloadUpdateTimer.reset(new QTimer);
+        m_downloadUpdateTimer->start(1000);
+    } else {
+        m_downloadUpdateTimer->stop();
+
+        // Deleting the timer object immediately instead of via
+        // QObject::deleteLater() seems to be safe since it is not a recipient
+        // of any events that may be in the process of being delivered to it
+        // from another thread.
+        m_downloadUpdateTimer.reset();
+    }
+}

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -33,7 +33,7 @@ QString convertToUnits(QString size)
 
 } // unnamed namespace
 
-void DownloadState::updateDownloadStatus(QString id)
+void DownloadState::update(QString id)
 {
     auto downloadInfos = KiwixApp::instance()->getContentManager()->updateDownloadInfos(id, {"status", "completedLength", "totalLength", "downloadSpeed"});
     double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
@@ -54,13 +54,13 @@ void DownloadState::updateDownloadStatus(QString id)
     }
 }
 
-void DownloadState::pauseDownload()
+void DownloadState::pause()
 {
     m_downloadInfo.paused = true;
     m_downloadUpdateTimer->stop();
 }
 
-void DownloadState::resumeDownload()
+void DownloadState::resume()
 {
     m_downloadInfo.paused = false;
     m_downloadUpdateTimer->start(1000);

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -36,12 +36,6 @@ QString convertToUnits(QString size)
 bool DownloadState::update(QString id)
 {
     auto downloadInfos = KiwixApp::instance()->getContentManager()->updateDownloadInfos(id, {"status", "completedLength", "totalLength", "downloadSpeed"});
-    double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
-    percent *= 100;
-    percent = QString::number(percent, 'g', 3).toDouble();
-    auto completedLength = convertToUnits(downloadInfos["completedLength"].toString());
-    auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toString()) + "/s";
-    m_downloadInfo = {percent, completedLength, downloadSpeed, false};
     if (!downloadInfos["status"].isValid()) {
         m_downloadUpdateTimer->stop();
 
@@ -53,6 +47,13 @@ bool DownloadState::update(QString id)
         m_downloadInfo = {0, "", "", false};
         return false;
     }
+
+    double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
+    percent *= 100;
+    percent = QString::number(percent, 'g', 3).toDouble();
+    auto completedLength = convertToUnits(downloadInfos["completedLength"].toString());
+    auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toString()) + "/s";
+    m_downloadInfo = {percent, completedLength, downloadSpeed, false};
     return true;
 }
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -35,6 +35,8 @@ public:
     void setIsDownloading(bool val);
     bool isChild(Node* candidate);
 
+    void updateDownloadStatus();
+
 private:
     QList<QVariant> m_itemData;
     QList<std::shared_ptr<Node>> m_childItems;

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -14,7 +14,28 @@ struct DownloadInfo
     bool paused;
 };
 
-class RowNode : public Node
+class DownloadState
+{
+public:
+    DownloadState();
+
+    bool isDownloading() const { return m_downloadUpdateTimer.get() != nullptr; }
+    void setDownloadInfo(DownloadInfo downloadInfo) { m_downloadInfo = downloadInfo; }
+    DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
+    QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
+    void setIsDownloading(bool val);
+    void pauseDownload();
+    void resumeDownload();
+    void updateDownloadStatus(QString id);
+
+protected:
+    // This is non-NULL only for a pending (even if paused) download
+    std::unique_ptr<QTimer> m_downloadUpdateTimer;
+
+    DownloadInfo m_downloadInfo;
+};
+
+class RowNode : public Node, public DownloadState
 {
 public:
     explicit RowNode(QList<QVariant> itemData, QString bookId, std::weak_ptr<RowNode> parentItem);
@@ -28,27 +49,13 @@ public:
     int row() const override;
     QString getBookId() const override { return m_bookId; }
     void setIconData(QByteArray iconData) { m_itemData[0] = iconData; }
-    bool isDownloading() const { return m_downloadUpdateTimer.get() != nullptr; }
-    void setDownloadInfo(DownloadInfo downloadInfo) { m_downloadInfo = downloadInfo; }
-    DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
-    QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
-    void setIsDownloading(bool val);
     bool isChild(Node* candidate);
-
-    void pauseDownload();
-    void resumeDownload();
-    void updateDownloadStatus();
 
 private:
     QList<QVariant> m_itemData;
     QList<std::shared_ptr<Node>> m_childItems;
     std::weak_ptr<RowNode> m_parentItem;
     QString m_bookId;
-
-    // This is non-NULL only for a pending (even if paused) download
-    std::unique_ptr<QTimer> m_downloadUpdateTimer;
-
-    DownloadInfo m_downloadInfo;
 };
 
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -22,7 +22,6 @@ public:
     bool isDownloading() const { return m_downloadUpdateTimer.get() != nullptr; }
     DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
     QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
-    void setIsDownloading(bool val);
     void pauseDownload();
     void resumeDownload();
     void updateDownloadStatus(QString id);
@@ -34,7 +33,7 @@ protected:
     DownloadInfo m_downloadInfo;
 };
 
-class RowNode : public Node, public DownloadState
+class RowNode : public Node
 {
 public:
     explicit RowNode(QList<QVariant> itemData, QString bookId, std::weak_ptr<RowNode> parentItem);
@@ -50,11 +49,16 @@ public:
     void setIconData(QByteArray iconData) { m_itemData[0] = iconData; }
     bool isChild(Node* candidate);
 
+
+    void setDownloadState(DownloadState* ds);
+    DownloadState* getDownloadState() { return m_downloadState.get(); }
+
 private:
     QList<QVariant> m_itemData;
     QList<std::shared_ptr<Node>> m_childItems;
     std::weak_ptr<RowNode> m_parentItem;
     QString m_bookId;
+    std::unique_ptr<DownloadState> m_downloadState;
 };
 
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -22,9 +22,9 @@ public:
     bool isDownloading() const { return m_downloadUpdateTimer.get() != nullptr; }
     DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
     QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
-    void pauseDownload();
-    void resumeDownload();
-    void updateDownloadStatus(QString id);
+    void pause();
+    void resume();
+    void update(QString id);
 
 protected:
     // This is non-NULL only for a pending (even if paused) download

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -24,7 +24,7 @@ public:
     QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
     void pause();
     void resume();
-    void update(QString id);
+    bool update(QString id);
 
 protected:
     // This is non-NULL only for a pending (even if paused) download

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -33,7 +33,6 @@ public:
     void setDownloadInfo(DownloadInfo downloadInfo) { m_downloadInfo = downloadInfo; }
     DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
     void setIsDownloading(bool val) { m_isDownloading = val; }
-    static std::shared_ptr<RowNode> createNode(QMap<QString, QVariant> bookItem, QMap<QString, QByteArray> iconMap, std::shared_ptr<RowNode> rootNode);
     bool isChild(Node* candidate);
 
 private:

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -3,7 +3,6 @@
 
 #include "node.h"
 #include <QList>
-#include "contentmanagermodel.h"
 #include <QIcon>
 #include "kiwix/book.h"
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -50,15 +50,15 @@ public:
     bool isChild(Node* candidate);
 
 
-    void setDownloadState(DownloadState* ds);
-    DownloadState* getDownloadState() { return m_downloadState.get(); }
+    void setDownloadState(std::shared_ptr<DownloadState> ds);
+    std::shared_ptr<DownloadState> getDownloadState() { return m_downloadState; }
 
 private:
     QList<QVariant> m_itemData;
     QList<std::shared_ptr<Node>> m_childItems;
     std::weak_ptr<RowNode> m_parentItem;
     QString m_bookId;
-    std::unique_ptr<DownloadState> m_downloadState;
+    std::shared_ptr<DownloadState> m_downloadState;
 };
 
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -35,6 +35,8 @@ public:
     void setIsDownloading(bool val);
     bool isChild(Node* candidate);
 
+    void pauseDownload();
+    void resumeDownload();
     void updateDownloadStatus();
 
 private:

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -28,10 +28,11 @@ public:
     int row() const override;
     QString getBookId() const override { return m_bookId; }
     void setIconData(QByteArray iconData) { m_itemData[0] = iconData; }
-    bool isDownloading() const { return m_isDownloading; }
+    bool isDownloading() const { return m_downloadUpdateTimer.get() != nullptr; }
     void setDownloadInfo(DownloadInfo downloadInfo) { m_downloadInfo = downloadInfo; }
     DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
-    void setIsDownloading(bool val) { m_isDownloading = val; }
+    QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
+    void setIsDownloading(bool val);
     bool isChild(Node* candidate);
 
 private:
@@ -39,7 +40,10 @@ private:
     QList<std::shared_ptr<Node>> m_childItems;
     std::weak_ptr<RowNode> m_parentItem;
     QString m_bookId;
-    bool m_isDownloading = false;
+
+    // This is non-NULL only for a pending (even if paused) download
+    std::unique_ptr<QTimer> m_downloadUpdateTimer;
+
     DownloadInfo m_downloadInfo;
 };
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -20,7 +20,6 @@ public:
     DownloadState();
 
     bool isDownloading() const { return m_downloadUpdateTimer.get() != nullptr; }
-    void setDownloadInfo(DownloadInfo downloadInfo) { m_downloadInfo = downloadInfo; }
     DownloadInfo getDownloadInfo() const { return m_downloadInfo; }
     QTimer* getDownloadUpdateTimer() const { return m_downloadUpdateTimer.get(); }
     void setIsDownloading(bool val);


### PR DESCRIPTION
Fixes #1021
Fixes #1023

This PR also contains some attempts at cleaning up the code, however the conclusion is that a major overhaul is required.

Overall it looks like there are many more bugs related to Download management, and the proper way to eliminate them all is to significantly simplify the code architecture through a more direct usage of `Kiwix::Download`.