### PR TITLE
Made it easier to display info and/or confirmation boxes

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -538,14 +538,8 @@ void ContentManager::eraseBook(const QString& id)
         text += formatText(gt("perma-delete-files-text"));
     }
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
-    KiwixConfirmBox *dialog = new KiwixConfirmBox(gt("delete-book"), text, false, mp_view);
-    dialog->show();
-    connect(dialog, &KiwixConfirmBox::yesClicked, [=]() {
+    showConfirmBox(gt("delete-book"), text, mp_view, [=]() {
         reallyEraseBook(id, moveToTrash);
-        dialog->deleteLater();
-    });
-    connect(dialog, &KiwixConfirmBox::noClicked, [=]() {
-        dialog->deleteLater();
     });
 }
 
@@ -587,15 +581,9 @@ void ContentManager::cancelBook(const QString& id, QModelIndex index)
 {
     auto text = gt("cancel-download-text");
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
-    KiwixConfirmBox *dialog = new KiwixConfirmBox(gt("cancel-download"), text, false, mp_view);
-    dialog->show();
-    connect(dialog, &KiwixConfirmBox::yesClicked, [=]() {
+    showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {
         cancelBook(id);
         emit managerModel->cancelDownload(index);
-        dialog->deleteLater();
-    });
-    connect(dialog, &KiwixConfirmBox::noClicked, [=]() {
-        dialog->deleteLater();
     });
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -128,11 +128,7 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
                 if (!dirOpen) {
                     QString failedText = gt("couldnt-open-location-text");
                     failedText = failedText.replace("{{FOLDER}}", "<b>" + bookDir.absolutePath() + "</b>");
-                    KiwixConfirmBox *dialog = new KiwixConfirmBox(gt("couldnt-open-location"), failedText, true, mp_view);
-                    dialog->show();
-                    connect(dialog, &KiwixConfirmBox::okClicked, [=]() {
-                        dialog->deleteLater();
-                    });
+                    showInfoBox(gt("couldnt-open-location"), failedText, mp_view);
                 }
             });
         } catch (...) {
@@ -428,11 +424,7 @@ QString ContentManager::downloadBook(const QString &id, QModelIndex index)
         emit managerModel->startDownload(index);
         return downloadStatus;
     }
-    KiwixConfirmBox *dialog = new KiwixConfirmBox(dialogHeader, dialogText, true, mp_view);
-    dialog->show();
-    connect(dialog, &KiwixConfirmBox::okClicked, [=]() {
-        dialog->deleteLater();
-    });
+    showInfoBox(dialogHeader, dialogText, mp_view);
     return downloadStatus;
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -23,6 +23,26 @@
 #include "contentmanagerheader.h"
 #include <QDesktopServices>
 
+namespace
+{
+
+// Opens the directory containing the input file path.
+// parent is the widget serving as the parent for the error dialog in case of
+// failure.
+void openFileLocation(QString path, QWidget *parent = nullptr)
+{
+    QFileInfo fileInfo(path);
+    QDir dir = fileInfo.absoluteDir();
+    bool dirOpen = dir.exists() && dir.isReadable() && QDesktopServices::openUrl(dir.absolutePath());
+    if (!dirOpen) {
+        QString failedText = gt("couldnt-open-location-text");
+        failedText = failedText.replace("{{FOLDER}}", "<b>" + dir.absolutePath() + "</b>");
+        showInfoBox(gt("couldnt-open-location"), failedText, parent);
+    }
+}
+
+} // unnamed namespace
+
 ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, QObject *parent)
     : QObject(parent),
       mp_library(library),
@@ -122,14 +142,7 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
             contextMenu.addAction(&menuDeleteBook);
             contextMenu.addAction(&menuOpenFolder);
             connect(&menuOpenFolder, &QAction::triggered, [=]() {
-                QFileInfo fileInfo(bookPath);
-                QDir bookDir = fileInfo.absoluteDir();
-                bool dirOpen = bookDir.exists() && bookDir.isReadable() && QDesktopServices::openUrl(bookDir.absolutePath());
-                if (!dirOpen) {
-                    QString failedText = gt("couldnt-open-location-text");
-                    failedText = failedText.replace("{{FOLDER}}", "<b>" + bookDir.absolutePath() + "</b>");
-                    showInfoBox(gt("couldnt-open-location"), failedText, mp_view);
-                }
+                openFileLocation(bookPath, mp_view);
             });
         } catch (...) {
             contextMenu.addAction(&menuDownloadBook);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -54,6 +54,8 @@ private:
     QStringList m_categories;
 
     QStringList getBookIds();
+    // reallyEraseBook() doesn't ask for confirmation (unlike eraseBook())
+    void reallyEraseBook(const QString& id, bool moveToTrash);
     void eraseBookFilesFromComputer(const QString dirPath, const QString filename, const bool moveToTrash);
     BookInfoList getBooksList();
     ContentManagerModel *managerModel;
@@ -83,6 +85,7 @@ public slots:
     void updateLibrary();
     void setSearch(const QString& search);
     void setSortBy(const QString& sortBy, const bool sortOrderAsc);
+    // eraseBook() asks for confirmation (reallyEraseBook() doesn't)
     void eraseBook(const QString& id);
     void updateRemoteLibrary(const QString& content);
     void updateLanguages(const QString& content);

--- a/src/kiwixconfirmbox.cpp
+++ b/src/kiwixconfirmbox.cpp
@@ -36,3 +36,12 @@ KiwixConfirmBox::~KiwixConfirmBox()
 {
     delete ui;
 }
+
+void showInfoBox(QString title, QString text, QWidget *parent)
+{
+    KiwixConfirmBox *dialog = new KiwixConfirmBox(title, text, true, parent);
+    dialog->show();
+    QObject::connect(dialog, &KiwixConfirmBox::okClicked, [=]() {
+        dialog->deleteLater();
+    });
+}

--- a/src/kiwixconfirmbox.h
+++ b/src/kiwixconfirmbox.h
@@ -12,7 +12,7 @@ class KiwixConfirmBox : public QDialog
     Q_OBJECT
 
 public:
-    explicit KiwixConfirmBox(QString confirmTitle, QString confirmText, bool okDialog, QWidget *parent = nullptr);
+    KiwixConfirmBox(QString confirmTitle, QString confirmText, bool okDialog, QWidget *parent = nullptr);
     ~KiwixConfirmBox();
 
 signals:
@@ -25,5 +25,8 @@ private:
     QString m_confirmText;
     Ui::kiwixconfirmbox *ui;
 };
+
+
+void showInfoBox(QString title, QString text, QWidget *parent = nullptr);
 
 #endif // KIWIXCONFIRMBOX_H

--- a/src/kiwixconfirmbox.h
+++ b/src/kiwixconfirmbox.h
@@ -29,4 +29,19 @@ private:
 
 void showInfoBox(QString title, QString text, QWidget *parent = nullptr);
 
+template<class YesAction>
+void showConfirmBox(QString title, QString text, QWidget *parent,
+                    YesAction yesAction)
+{
+    KiwixConfirmBox *dialog = new KiwixConfirmBox(title, text, false, parent);
+    dialog->show();
+    QObject::connect(dialog, &KiwixConfirmBox::yesClicked, [=]() {
+        yesAction();
+        dialog->deleteLater();
+    });
+    QObject::connect(dialog, &KiwixConfirmBox::noClicked, [=]() {
+        dialog->deleteLater();
+    });
+}
+
 #endif // KIWIXCONFIRMBOX_H


### PR DESCRIPTION
During refactoring-based-study of kiwix-desktop code in the context of the work on fixing download management (issues #87 and #1022) I made `KiwixConfirmBox` easier and more fool-proof to use and decided to extract those changes into a separate small PR.

Note that `showConfirmBox()` lacks a parameter for the "no" action because of the absence of the need for it in the current code. However, would such a need arise in the future, adding support for it should be trivial.