### PR TITLE
More reliable loading of remote thumbnails

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -679,12 +679,26 @@ void ContentManager::updateLibrary() {
     } catch (std::runtime_error&) {}
 }
 
+namespace
+{
+
+QString makeHttpUrl(QString host, int port)
+{
+    return port == 443
+         ? "https://" + host
+         : "http://" + host + ":" + QString::number(port);
+}
+
+} // unnamed namespace
+
 void ContentManager::updateRemoteLibrary(const QString& content) {
     QtConcurrent::run([=]() {
         QMutexLocker locker(&remoteLibraryLocker);
         mp_remoteLibrary = kiwix::Library::create();
         kiwix::Manager manager(mp_remoteLibrary);
-        const auto catalogUrl = m_remoteLibraryManager.getCatalogHost();
+        const auto catalogHost = m_remoteLibraryManager.getCatalogHost();
+        const auto catalogPort = m_remoteLibraryManager.getCatalogPort();
+        const auto catalogUrl = makeHttpUrl(catalogHost, catalogPort);
         manager.readOpds(content.toStdString(), catalogUrl.toStdString());
         emit(this->booksChanged());
         emit(this->pendingRequest(false));

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -175,7 +175,7 @@ void ContentManagerModel::refreshIcons()
             auto item = book.getIllustration(48);
         } catch (...) {
             if (faviconUrl != "" && !iconMap.contains(faviconUrl)) {
-                td.addDownload(faviconUrl, index(i, 0));
+                td.addDownload(faviconUrl, id);
             }
         }
     }
@@ -230,15 +230,17 @@ void ContentManagerModel::sort(int column, Qt::SortOrder order)
     KiwixApp::instance()->getContentManager()->setSortBy(sortBy, order == Qt::AscendingOrder);
 }
 
-void ContentManagerModel::updateImage(QModelIndex index, QString url, QByteArray imageData)
+void ContentManagerModel::updateImage(QString bookId, QString url, QByteArray imageData)
 {
-    if (!index.isValid())
+    const auto it = bookIdToRowMap.constFind(bookId);
+    if ( it == bookIdToRowMap.constEnd() )
         return;
-    auto item = static_cast<RowNode*>(index.internalPointer());
-    if (!rootNode->isChild(item))
-        return;
+
+    const size_t row = it.value();
+    const auto item = static_cast<RowNode*>(rootNode->child(row).get());
     item->setIconData(imageData);
     iconMap[url] = imageData;
+    const QModelIndex index = this->index(row, 0);
     emit dataChanged(index, index);
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -112,7 +112,7 @@ void ContentManagerModel::setBooksData(const BookInfoList& data)
 
 std::shared_ptr<RowNode> ContentManagerModel::createNode(BookInfo bookItem, QMap<QString, QByteArray> iconMap) const
 {
-    auto faviconUrl = "https://" + bookItem["faviconUrl"].toString();
+    const auto faviconUrl = bookItem["faviconUrl"].toString();
     QString id = bookItem["id"].toString();
     QByteArray bookIcon;
     try {
@@ -168,7 +168,7 @@ void ContentManagerModel::refreshIcons()
     for (auto i = 0; i < rowCount() && i < m_data.size(); i++) {
         auto bookItem = m_data[i];
         auto id = bookItem["id"].toString();
-        auto faviconUrl = "https://" + bookItem["faviconUrl"].toString();
+        const auto faviconUrl = bookItem["faviconUrl"].toString();
         auto app = KiwixApp::instance();
         try {
             auto book = app->getLibrary()->getBookById(id);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -43,7 +43,7 @@ public: // functions
     std::shared_ptr<RowNode> createNode(BookInfo bookItem, QMap<QString, QByteArray> iconMap) const;
 
 public slots:
-    void updateImage(QModelIndex index, QString url, QByteArray imageData);
+    void updateImage(QString bookId, QString url, QByteArray imageData);
     void startDownload(QModelIndex index);
     void pauseDownload(QModelIndex index);
     void resumeDownload(QModelIndex index);

--- a/src/thumbnaildownloader.cpp
+++ b/src/thumbnaildownloader.cpp
@@ -18,7 +18,7 @@ ThumbnailDownloader::~ThumbnailDownloader()
 {
 }
 
-void ThumbnailDownloader::addDownload(QString url, QModelIndex index)
+void ThumbnailDownloader::addDownload(QString url, ThumbnailId index)
 {
     m_urlPairList.append({index, url});
     if (!m_isDownloading)
@@ -35,18 +35,18 @@ void ThumbnailDownloader::startDownload()
     downloadOnePair(m_urlPairList.takeFirst());
 }
 
-void ThumbnailDownloader::downloadOnePair(QPair<QModelIndex, QString> urlPair)
+void ThumbnailDownloader::downloadOnePair(ThumbnailInfo thumbnailInfo)
 {
-    QNetworkRequest req(urlPair.second);
+    QNetworkRequest req(thumbnailInfo.second);
     auto reply = manager.get(req);
     connect(reply, &QNetworkReply::finished, this, [=](){
-        fileDownloaded(reply, urlPair);
+        fileDownloaded(reply, thumbnailInfo);
     });
 }
 
-void ThumbnailDownloader::fileDownloaded(QNetworkReply *pReply, QPair<QModelIndex, QString> urlPair)
+void ThumbnailDownloader::fileDownloaded(QNetworkReply *pReply, ThumbnailInfo thumbnailInfo)
 {
     auto downloadedData = pReply->readAll();
-    emit oneThumbnailDownloaded(urlPair.first, urlPair.second, downloadedData);
+    emit oneThumbnailDownloaded(thumbnailInfo.first, thumbnailInfo.second, downloadedData);
     pReply->deleteLater();
 }

--- a/src/thumbnaildownloader.cpp
+++ b/src/thumbnaildownloader.cpp
@@ -6,12 +6,8 @@
 
 ThumbnailDownloader::ThumbnailDownloader()
 {
-    connect(this, &ThumbnailDownloader::oneThumbnailDownloaded, [=]() {
-        if (m_downloadQueue.size() != 0)
-            downloadThumbnail(m_downloadQueue.takeFirst());
-        else
-            m_isDownloading = false;
-    });
+    connect(this, &ThumbnailDownloader::oneThumbnailDownloaded,
+            this, &ThumbnailDownloader::startNextDownload);
 }
 
 ThumbnailDownloader::~ThumbnailDownloader()
@@ -22,10 +18,10 @@ void ThumbnailDownloader::addDownload(QString url, ThumbnailId index)
 {
     m_downloadQueue.append({index, url});
     if (!m_isDownloading)
-        startDownload();
+        startNextDownload();
 }
 
-void ThumbnailDownloader::startDownload()
+void ThumbnailDownloader::startNextDownload()
 {
     if (m_downloadQueue.size() == 0) {
         m_isDownloading = false;

--- a/src/thumbnaildownloader.cpp
+++ b/src/thumbnaildownloader.cpp
@@ -7,8 +7,8 @@
 ThumbnailDownloader::ThumbnailDownloader()
 {
     connect(this, &ThumbnailDownloader::oneThumbnailDownloaded, [=]() {
-        if (m_urlPairList.size() != 0)
-            downloadOnePair(m_urlPairList.takeFirst());
+        if (m_downloadQueue.size() != 0)
+            downloadThumbnail(m_downloadQueue.takeFirst());
         else
             m_isDownloading = false;
     });
@@ -20,22 +20,22 @@ ThumbnailDownloader::~ThumbnailDownloader()
 
 void ThumbnailDownloader::addDownload(QString url, ThumbnailId index)
 {
-    m_urlPairList.append({index, url});
+    m_downloadQueue.append({index, url});
     if (!m_isDownloading)
         startDownload();
 }
 
 void ThumbnailDownloader::startDownload()
 {
-    if (m_urlPairList.size() == 0) {
+    if (m_downloadQueue.size() == 0) {
         m_isDownloading = false;
         return;
     }
     m_isDownloading = true;
-    downloadOnePair(m_urlPairList.takeFirst());
+    downloadThumbnail(m_downloadQueue.takeFirst());
 }
 
-void ThumbnailDownloader::downloadOnePair(ThumbnailInfo thumbnailInfo)
+void ThumbnailDownloader::downloadThumbnail(ThumbnailInfo thumbnailInfo)
 {
     QNetworkRequest req(thumbnailInfo.second);
     auto reply = manager.get(req);

--- a/src/thumbnaildownloader.cpp
+++ b/src/thumbnaildownloader.cpp
@@ -4,7 +4,7 @@
 #include <QPixmap>
 #include <QIcon>
 
-ThumbnailDownloader::ThumbnailDownloader(QObject *parent)
+ThumbnailDownloader::ThumbnailDownloader()
 {
     connect(this, &ThumbnailDownloader::oneThumbnailDownloaded, [=]() {
         if (m_urlPairList.size() != 0)

--- a/src/thumbnaildownloader.h
+++ b/src/thumbnaildownloader.h
@@ -21,7 +21,7 @@ public:
     ~ThumbnailDownloader();
 
     void addDownload(QString url, ThumbnailId index);
-    void startDownload();
+    void startNextDownload();
     void clearQueue() { m_downloadQueue.clear(); }
 
 private:

--- a/src/thumbnaildownloader.h
+++ b/src/thumbnaildownloader.h
@@ -17,7 +17,7 @@ public:
     typedef QPair<ThumbnailId, QString> ThumbnailInfo;
 
 public:
-    ThumbnailDownloader(QObject *parent = 0);
+    ThumbnailDownloader();
     ~ThumbnailDownloader();
 
     void addDownload(QString url, ThumbnailId index);

--- a/src/thumbnaildownloader.h
+++ b/src/thumbnaildownloader.h
@@ -4,16 +4,14 @@
 #include <QObject>
 #include <QQueue>
 #include <QNetworkAccessManager>
-#include <QIcon>
 #include <QNetworkReply>
-#include <QModelIndex>
 
 class ThumbnailDownloader : public QObject
 {
     Q_OBJECT
 
 public:
-    typedef QModelIndex ThumbnailId;
+    typedef QString ThumbnailId;
     typedef QPair<ThumbnailId, QString> ThumbnailInfo;
 
 public:

--- a/src/thumbnaildownloader.h
+++ b/src/thumbnaildownloader.h
@@ -13,24 +13,28 @@ class ThumbnailDownloader : public QObject
     Q_OBJECT
 
 public:
+    typedef QModelIndex ThumbnailId;
+    typedef QPair<ThumbnailId, QString> ThumbnailInfo;
+
+public:
     ThumbnailDownloader(QObject *parent = 0);
     ~ThumbnailDownloader();
 
-    void addDownload(QString url, QModelIndex index);
+    void addDownload(QString url, ThumbnailId index);
     void startDownload();
-    void downloadOnePair(QPair<QModelIndex, QString> urlPair);
+    void downloadOnePair(ThumbnailInfo thumbnailInfo);
     void clearQueue() { m_urlPairList.clear(); }
 
 signals:
-    void oneThumbnailDownloaded(QModelIndex, QString, QByteArray);
+    void oneThumbnailDownloaded(ThumbnailId, QString, QByteArray);
 
 private:
-    QQueue<QPair<QModelIndex, QString>> m_urlPairList;
+    QQueue<ThumbnailInfo> m_urlPairList;
     QNetworkAccessManager manager;
     bool m_isDownloading = false;
 
 private slots:
-    void fileDownloaded(QNetworkReply *pReply, QPair<QModelIndex, QString> urlPair);
+    void fileDownloaded(QNetworkReply *pReply, ThumbnailInfo thumbnailInfo);
 
 };
 

--- a/src/thumbnaildownloader.h
+++ b/src/thumbnaildownloader.h
@@ -22,14 +22,16 @@ public:
 
     void addDownload(QString url, ThumbnailId index);
     void startDownload();
-    void downloadOnePair(ThumbnailInfo thumbnailInfo);
-    void clearQueue() { m_urlPairList.clear(); }
+    void clearQueue() { m_downloadQueue.clear(); }
+
+private:
+    void downloadThumbnail(ThumbnailInfo thumbnailInfo);
 
 signals:
     void oneThumbnailDownloaded(ThumbnailId, QString, QByteArray);
 
 private:
-    QQueue<ThumbnailInfo> m_urlPairList;
+    QQueue<ThumbnailInfo> m_downloadQueue;
     QNetworkAccessManager manager;
     bool m_isDownloading = false;
 


### PR DESCRIPTION
In the wake of #1035 comes the next small PR.

It solves two problems:

1. Loading of thumbnails if a debug server (support for which was introduced in the first commit of #1024) is used
2. Changing the library view (applying filtering, switching from online to local) while the loading of thumbnails is in progress. I don't have a test case proving that it can lead to some undesirable behaviour. I tried the simplest scenario but it worked nicely. It's  possible that no such scenario exists since the potential bug may be compensated by extra code in other places. However these changes make the implementation more robust.