### PR TITLE
Download management fixes and improvements

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -443,7 +443,7 @@ void ContentManager::downloadStarted(const kiwix::Book& book, const std::string&
 {
     kiwix::Book bookCopy(book);
     bookCopy.setDownloadId(downloadId);
-    mp_library->addBookToLibrary(bookCopy);
+    mp_library->addBookBeingDownloaded(bookCopy, getSettingsManager()->getDownloadDir());
     mp_library->save();
     emit(oneBookChanged(QString::fromStdString(book.getId())));
 }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -640,7 +640,7 @@ void ContentManager::pauseBook(const QString& id, QModelIndex index)
         download->pauseDownload();
         m_downloads[id]->pause();
     }
-    emit managerModel->pauseDownload(index);
+    managerModel->triggerDataUpdateAt(index);
 }
 
 void ContentManager::resumeBook(const QString& id, QModelIndex index)
@@ -651,7 +651,7 @@ void ContentManager::resumeBook(const QString& id, QModelIndex index)
         download->resumeDownload();
         m_downloads[id]->resume();
     }
-    emit managerModel->resumeDownload(index);
+    managerModel->triggerDataUpdateAt(index);
 }
 
 void ContentManager::cancelBook(const QString& id)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -671,11 +671,11 @@ void ContentManager::cancelBook(const QString& id, QModelIndex index)
     auto text = gt("cancel-download-text");
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
     showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {
-        cancelBook(id);
+        reallyCancelBook(id);
     });
 }
 
-void ContentManager::cancelBook(const QString& id)
+void ContentManager::reallyCancelBook(const QString& id)
 {
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -140,7 +140,7 @@ void ContentManager::updateModel()
 {
     const auto bookIds = getBookIds();
     BookInfoList bookList;
-    QStringList keys = {"title", "tags", "date", "id", "size", "description", "faviconUrl", "favicon"};
+    QStringList keys = {"title", "tags", "date", "id", "size", "description", "favicon"};
     QIcon bookIcon;
     for (auto bookId : bookIds) {
         auto mp = getBookInfos(bookId, keys);
@@ -316,6 +316,12 @@ QByteArray getFaviconData(const kiwix::Book& b)
     return qdata;
 }
 
+QVariant getFaviconDataOrUrl(const kiwix::Book& b)
+{
+    const QByteArray data = getFaviconData(b);
+    return !data.isNull() ? QVariant(data) : QVariant(getFaviconUrl(b));
+}
+
 QVariant getBookAttribute(const kiwix::Book& b, const QString& a)
 {
     if ( a == "id" )          return QString::fromStdString(b.getId());
@@ -326,8 +332,7 @@ QVariant getBookAttribute(const kiwix::Book& b, const QString& a)
     if ( a == "url" )         return QString::fromStdString(b.getUrl());
     if ( a == "name" )        return QString::fromStdString(b.getName());
     if ( a == "downloadId" )  return QString::fromStdString(b.getDownloadId());
-    if ( a == "favicon")      return getFaviconData(b);
-    if ( a == "faviconUrl")   return getFaviconUrl(b);
+    if ( a == "favicon")      return getFaviconDataOrUrl(b);
     if ( a == "size" )        return QString::number(b.getSize());
     if ( a == "tags" )        return getBookTags(b);
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -120,7 +120,6 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     connect(this, &ContentManager::filterParamsChanged, this, &ContentManager::updateLibrary);
     connect(this, &ContentManager::booksChanged, this, [=]() {
         updateModel();
-        managerModel->refreshIcons();
     });
     connect(&m_remoteLibraryManager, &OpdsRequestManager::requestReceived, this, &ContentManager::updateRemoteLibrary);
     connect(mp_view->getView(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onCustomContextMenu(const QPoint &)));

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -543,7 +543,7 @@ void ContentManager::downloadBook(const QString &id, QModelIndex index)
         downloadBook(id);
         auto node = getSharedPointer(static_cast<RowNode*>(index.internalPointer()));
         const auto newDownload = std::make_shared<DownloadState>();
-        m_downloads[id] = newDownload;
+        m_downloads.set(id, newDownload);
         node->setDownloadState(newDownload);
     }
     catch ( const ContentManagerError& err )

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -501,7 +501,7 @@ DownloadInfo ContentManager::getDownloadInfo(QString bookId) const
 void ContentManager::updateDownload(QString bookId, const DownloadInfo& downloadInfo)
 {
     const auto downloadState = m_downloads.value(bookId);
-    if ( downloadState && !downloadState->paused ) {
+    if ( downloadState ) {
         if ( downloadInfo["status"].toString() == "completed" ) {
             downloadCompleted(bookId, downloadInfo["path"].toString());
         } else {
@@ -684,9 +684,6 @@ void ContentManager::pauseBook(const QString& id, QModelIndex index)
     if (download->getStatus() == kiwix::Download::K_ACTIVE) {
         try {
             download->pauseDownload();
-            if ( const auto downloadState = m_downloads.value(id) ) {
-                downloadState->pause();
-            }
         } catch (const kiwix::AriaError&) {
             // Download has completed before the pause request was handled.
             // Most likely the download was already complete at the time
@@ -704,9 +701,6 @@ void ContentManager::resumeBook(const QString& id, QModelIndex index)
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_PAUSED) {
         download->resumeDownload();
-        if ( const auto downloadState = m_downloads.value(id) ) {
-            downloadState->resume();
-        }
     }
     managerModel->triggerDataUpdateAt(index);
 }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -402,7 +402,7 @@ void ContentManager::removeDownload(QString bookId)
     managerModel->removeDownload(bookId);
 }
 
-void ContentManager::downloadCancelled(QString bookId)
+void ContentManager::downloadDisappeared(QString bookId)
 {
     removeDownload(bookId);
     kiwix::Book bCopy(mp_library->getBookById(bookId));
@@ -459,7 +459,7 @@ void ContentManager::updateDownload(QString bookId)
         const auto downloadInfo = getDownloadInfo(bookId);
 
         if ( downloadInfo.isEmpty() ) {
-            downloadCancelled(bookId);
+            downloadDisappeared(bookId);
         } else if ( downloadInfo["status"] == "completed" ) {
             downloadCompleted(bookId, downloadInfo["path"].toString());
         } else {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -477,12 +477,10 @@ DownloadInfo ContentManager::getDownloadInfo(QString bookId) const
     };
 }
 
-void ContentManager::updateDownload(QString bookId)
+void ContentManager::updateDownload(QString bookId, const DownloadInfo& downloadInfo)
 {
     const auto downloadState = m_downloads.value(bookId);
     if ( downloadState && !downloadState->paused ) {
-        const auto downloadInfo = getDownloadInfo(bookId);
-
         if ( downloadInfo.isEmpty() ) {
             downloadDisappeared(bookId);
         } else if ( downloadInfo["status"] == "completed" ) {
@@ -497,7 +495,9 @@ void ContentManager::updateDownload(QString bookId)
 void ContentManager::updateDownloads()
 {
     for ( const auto& bookId : m_downloads.keys() ) {
-        updateDownload(bookId);
+        const auto downloadInfo = getDownloadInfo(bookId);
+
+        updateDownload(bookId, downloadInfo);
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -674,7 +674,9 @@ void ContentManager::pauseBook(const QString& id, QModelIndex index)
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_ACTIVE) {
         download->pauseDownload();
-        m_downloads[id]->pause();
+        if ( const auto downloadState = m_downloads.value(id) ) {
+            downloadState->pause();
+        }
     }
     managerModel->triggerDataUpdateAt(index);
 }
@@ -685,7 +687,9 @@ void ContentManager::resumeBook(const QString& id, QModelIndex index)
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_PAUSED) {
         download->resumeDownload();
-        m_downloads[id]->resume();
+        if ( const auto downloadState = m_downloads.value(id) ) {
+            downloadState->resume();
+        }
     }
     managerModel->triggerDataUpdateAt(index);
 }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -133,6 +133,9 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     m_downloadUpdateTimer.start(1000);
     connect(&m_downloadUpdateTimer, &QTimer::timeout,
             this, &ContentManager::updateDownloads);
+
+    connect(this, &ContentManager::downloadUpdated,
+            this, &ContentManager::updateDownload);
 }
 
 void ContentManager::updateModel()
@@ -497,7 +500,7 @@ void ContentManager::updateDownloads()
     for ( const auto& bookId : m_downloads.keys() ) {
         const auto downloadInfo = getDownloadInfo(bookId);
 
-        updateDownload(bookId, downloadInfo);
+        emit downloadUpdated(bookId, downloadInfo);
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -672,7 +672,6 @@ void ContentManager::cancelBook(const QString& id, QModelIndex index)
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
     showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {
         cancelBook(id);
-        emit managerModel->removeDownload(id);
     });
 }
 
@@ -683,7 +682,7 @@ void ContentManager::cancelBook(const QString& id)
     if (download->getStatus() != kiwix::Download::K_COMPLETE) {
         download->cancelDownload();
     }
-    m_downloads.remove(id);
+    removeDownload(id);
 
     QString dirPath = QString::fromStdString(kiwix::removeLastPathElement(download->getPath()));
     QString filename = QString::fromStdString(kiwix::getLastPathElement(download->getPath())) + "*";

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -566,6 +566,14 @@ void ContentManager::downloadBook(const QString &id)
     downloadStarted(book, downloadId);
 }
 
+static const char MSG_FOR_PREVENTED_RMSTAR_OPERATION[] = R"(
+    BUG: Errare humanum est.
+    BUG: Kiwix developers are human, but we try to ensure that our mistakes
+    BUG: don't cause harm to our users.
+    BUG: If we didn't detect this situation we could have erased a lot of files
+    BUG: on your computer.
+)";
+
 void ContentManager::eraseBookFilesFromComputer(const std::string& bookPath, bool moveToTrash)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
@@ -573,6 +581,12 @@ void ContentManager::eraseBookFilesFromComputer(const std::string& bookPath, boo
 #endif
     const std::string dirPath = kiwix::removeLastPathElement(bookPath);
     const std::string fileGlob = kiwix::getLastPathElement(bookPath) + "*";
+
+    if ( fileGlob == "*" ) {
+        std::cerr << MSG_FOR_PREVENTED_RMSTAR_OPERATION << std::endl;
+        return;
+    }
+
     QDir dir(QString::fromStdString(dirPath), QString::fromStdString(fileGlob));
     for(const QString& file: dir.entryList()) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -634,27 +634,16 @@ void ContentManager::eraseBook(const QString& id)
 
 void ContentManager::pauseBook(const QString& id, QModelIndex index)
 {
-    pauseBook(id);
-    emit managerModel->pauseDownload(index);
-}
-
-void ContentManager::pauseBook(const QString& id)
-{
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_ACTIVE) {
         download->pauseDownload();
         m_downloads[id]->pause();
     }
+    emit managerModel->pauseDownload(index);
 }
 
 void ContentManager::resumeBook(const QString& id, QModelIndex index)
-{
-    resumeBook(id);
-    emit managerModel->resumeDownload(index);
-}
-
-void ContentManager::resumeBook(const QString& id)
 {
     auto& b = mp_library->getBookById(id);
     auto download = mp_downloader->getDownload(b.getDownloadId());
@@ -662,6 +651,7 @@ void ContentManager::resumeBook(const QString& id)
         download->resumeDownload();
         m_downloads[id]->resume();
     }
+    emit managerModel->resumeDownload(index);
 }
 
 void ContentManager::cancelBook(const QString& id)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -90,7 +90,7 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     // mp_view will be passed to the tab who will take ownership,
     // so, we don't need to delete it.
     mp_view = new ContentManagerView();
-    managerModel = new ContentManagerModel(&m_downloads, this);
+    managerModel = new ContentManagerModel(this);
     updateModel();
     auto treeView = mp_view->getView();
     treeView->setModel(managerModel);
@@ -145,7 +145,7 @@ void ContentManager::updateModel()
         auto mp = getBookInfos(bookId, keys);
         bookList.append(mp);
     }
-    managerModel->setBooksData(bookList);
+    managerModel->setBooksData(bookList, m_downloads);
 }
 
 void ContentManager::onCustomContextMenu(const QPoint &point)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -91,8 +91,7 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     // so, we don't need to delete it.
     mp_view = new ContentManagerView();
     managerModel = new ContentManagerModel(&m_downloads, this);
-    const auto booksList = getBooksList();
-    managerModel->setBooksData(booksList);
+    updateModel();
     auto treeView = mp_view->getView();
     treeView->setModel(managerModel);
     treeView->show();
@@ -120,8 +119,7 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     connect(mp_library, &Library::booksChanged, this, [=]() {emit(this->booksChanged());});
     connect(this, &ContentManager::filterParamsChanged, this, &ContentManager::updateLibrary);
     connect(this, &ContentManager::booksChanged, this, [=]() {
-        const auto nBookList = getBooksList();
-        managerModel->setBooksData(nBookList);
+        updateModel();
         managerModel->refreshIcons();
     });
     connect(&m_remoteLibraryManager, &OpdsRequestManager::requestReceived, this, &ContentManager::updateRemoteLibrary);
@@ -138,7 +136,7 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
             this, &ContentManager::updateDownloads);
 }
 
-ContentManager::BookInfoList ContentManager::getBooksList()
+void ContentManager::updateModel()
 {
     const auto bookIds = getBookIds();
     BookInfoList bookList;
@@ -148,7 +146,7 @@ ContentManager::BookInfoList ContentManager::getBooksList()
         auto mp = getBookInfos(bookId, keys);
         bookList.append(mp);
     }
-    return bookList;
+    managerModel->setBooksData(bookList);
 }
 
 void ContentManager::onCustomContextMenu(const QPoint &point)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -200,7 +200,7 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
         pauseBook(id, index);
     });
     connect(&menuCancelBook, &QAction::triggered, [=]() {
-        cancelBook(id, index);
+        cancelBook(id);
     });
     connect(&menuResumeBook, &QAction::triggered, [=]() {
         resumeBook(id, index);
@@ -664,10 +664,8 @@ void ContentManager::resumeBook(const QString& id)
     }
 }
 
-void ContentManager::cancelBook(const QString& id, QModelIndex index)
+void ContentManager::cancelBook(const QString& id)
 {
-    Q_UNUSED(index);
-
     auto text = gt("cancel-download-text");
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
     showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -87,6 +87,8 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
       mp_downloader(downloader),
       m_remoteLibraryManager()
 {
+    restoreDownloads();
+
     // mp_view will be passed to the tab who will take ownership,
     // so, we don't need to delete it.
     mp_view = new ContentManagerView();
@@ -135,6 +137,19 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
 
     if ( mp_downloader ) {
         startDownloadUpdaterThread();
+    }
+}
+
+void ContentManager::restoreDownloads()
+{
+    for ( const auto& bookId : mp_library->getBookIds() ) {
+        const kiwix::Book& book = mp_library->getBookById(bookId);
+        const QString downloadId = QString::fromStdString(book.getDownloadId());
+        if ( ! downloadId.isEmpty() ) {
+            const auto newDownload = std::make_shared<DownloadState>();
+            newDownload->paused = true;
+            m_downloads.set(bookId, newDownload);
+        }
     }
 }
 

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -59,8 +59,6 @@ public slots:
     void updateRemoteLibrary(const QString& content);
     void updateLanguages(const QString& content);
     void updateCategories(const QString& content);
-    void pauseBook(const QString& id);
-    void resumeBook(const QString& id);
     void pauseBook(const QString& id, QModelIndex index);
     void resumeBook(const QString& id, QModelIndex index);
     // cancelBook() asks for confirmation (reallyCancelBook() doesn't)

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -44,6 +44,7 @@ signals:
     void categoriesLoaded(QStringList);
     void languagesLoaded(LanguageList);
     void localChanged(const bool);
+    void downloadUpdated(QString bookId, const DownloadInfo& );
 
 public slots:
     QStringList getTranslations(const QStringList &keys);
@@ -66,6 +67,7 @@ public slots:
     void onCustomContextMenu(const QPoint &point);
     void openBookWithIndex(const QModelIndex& index);
     void updateDownloads();
+    void updateDownload(QString bookId, const DownloadInfo& downloadInfo);
 
 private: // functions
     QStringList getBookIds();
@@ -83,7 +85,6 @@ private: // functions
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
 
     std::string startDownload(const kiwix::Book& book);
-    void updateDownload(QString bookId, const DownloadInfo& downloadInfo);
     void removeDownload(QString bookId);
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
     void downloadDisappeared(QString bookId);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -73,7 +73,7 @@ private: // functions
     void reallyCancelBook(const QString& id);
     // reallyEraseBook() doesn't ask for confirmation (unlike eraseBook())
     void reallyEraseBook(const QString& id, bool moveToTrash);
-    void eraseBookFilesFromComputer(const QString dirPath, const QString filename, const bool moveToTrash);
+    void eraseBookFilesFromComputer(const std::string& bookPath, bool moveToTrash);
     void updateModel();
     void setCategories();
     void setLanguages();

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -22,7 +22,7 @@ public: // types
 
 public: // functions
     explicit ContentManager(Library* library, kiwix::Downloader *downloader, QObject *parent = nullptr);
-    virtual ~ContentManager() {}
+    virtual ~ContentManager();
 
     ContentManagerView* getView() { return mp_view; }
     void setLocal(bool local);
@@ -84,6 +84,7 @@ private: // functions
     // the remote or local library (in that order).
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
 
+    void startDownloadUpdaterThread();
     std::string startDownload(const kiwix::Book& book);
     void removeDownload(QString bookId);
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
@@ -96,7 +97,7 @@ private: // data
     kiwix::LibraryPtr mp_remoteLibrary;
     kiwix::Downloader* mp_downloader;
     ContentManagerModel::Downloads m_downloads;
-    QTimer m_downloadUpdateTimer;
+    QThread* mp_downloadUpdaterThread = nullptr;
     OpdsRequestManager m_remoteLibraryManager;
     ContentManagerView* mp_view;
     bool m_local = true;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -74,7 +74,7 @@ private: // functions
     // reallyEraseBook() doesn't ask for confirmation (unlike eraseBook())
     void reallyEraseBook(const QString& id, bool moveToTrash);
     void eraseBookFilesFromComputer(const QString dirPath, const QString filename, const bool moveToTrash);
-    BookInfoList getBooksList();
+    void updateModel();
     void setCategories();
     void setLanguages();
 

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -86,7 +86,7 @@ private: // functions
     void updateDownload(QString bookId);
     void removeDownload(QString bookId);
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
-    void downloadCancelled(QString bookId);
+    void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
     DownloadInfo getDownloadInfo(QString bookId) const;
 

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -83,7 +83,7 @@ private: // functions
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
 
     std::string startDownload(const kiwix::Book& book);
-    void updateDownload(QString bookId);
+    void updateDownload(QString bookId, const DownloadInfo& downloadInfo);
     void removeDownload(QString bookId);
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
     void downloadDisappeared(QString bookId);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -61,9 +61,9 @@ public slots:
     void updateCategories(const QString& content);
     void pauseBook(const QString& id);
     void resumeBook(const QString& id);
-    void cancelBook(const QString& id);
     void pauseBook(const QString& id, QModelIndex index);
     void resumeBook(const QString& id, QModelIndex index);
+    // cancelBook() asks for confirmation (reallyCancelBook() doesn't)
     void cancelBook(const QString& id, QModelIndex index);
     void onCustomContextMenu(const QPoint &point);
     void openBookWithIndex(const QModelIndex& index);
@@ -71,6 +71,8 @@ public slots:
 
 private: // functions
     QStringList getBookIds();
+    // reallyCancelBook() doesn't ask for confirmation (unlike cancelBook())
+    void reallyCancelBook(const QString& id);
     // reallyEraseBook() doesn't ask for confirmation (unlike eraseBook())
     void reallyEraseBook(const QString& id, bool moveToTrash);
     void eraseBookFilesFromComputer(const QString dirPath, const QString filename, const bool moveToTrash);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -91,6 +91,7 @@ private: // functions
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
     DownloadInfo getDownloadInfo(QString bookId) const;
+    void restoreDownloads();
 
 private: // data
     Library* mp_library;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -64,7 +64,7 @@ public slots:
     void pauseBook(const QString& id, QModelIndex index);
     void resumeBook(const QString& id, QModelIndex index);
     // cancelBook() asks for confirmation (reallyCancelBook() doesn't)
-    void cancelBook(const QString& id, QModelIndex index);
+    void cancelBook(const QString& id);
     void onCustomContextMenu(const QPoint &point);
     void openBookWithIndex(const QModelIndex& index);
     void updateDownloads();

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -253,7 +253,7 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
     if (const auto downloadState = node->getDownloadState()) {
         if (downloadState->paused) {
             if (clickX < (x + w/2)) {
-                KiwixApp::instance()->getContentManager()->cancelBook(id, index);
+                KiwixApp::instance()->getContentManager()->cancelBook(id);
             } else {
                 KiwixApp::instance()->getContentManager()->resumeBook(id, index);
             }

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -92,8 +92,11 @@ QModelIndex ContentManagerModel::parent(const QModelIndex &index) const
 
 int ContentManagerModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
-    return m_data.size();
+    const auto node = parent.isValid()
+                    ? static_cast<const Node*>(parent.internalPointer())
+                    : rootNode.get();
+
+    return node->childCount();
 }
 
 QVariant ContentManagerModel::headerData(int section, Qt::Orientation orientation, int role) const

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -113,16 +113,8 @@ void ContentManagerModel::setBooksData(const BookInfoList& data)
 
 QByteArray ContentManagerModel::getThumbnail(const BookInfo& bookItem) const
 {
-    QString id = bookItem["id"].toString();
-    QByteArray bookIcon;
-    try {
-        auto book = KiwixApp::instance()->getLibrary()->getBookById(id);
-        std::string favicon;
-        auto item = book.getIllustration(48);
-        favicon = item->getData();
-        bookIcon = QByteArray::fromRawData(reinterpret_cast<const char*>(favicon.data()), favicon.size());
-        bookIcon.detach(); // deep copy
-    } catch (...) {
+    QByteArray bookIcon = bookItem["favicon"].toByteArray();
+    if ( bookIcon.isNull() ) {
         const auto faviconUrl = bookItem["faviconUrl"].toString();
         if (m_iconMap.contains(faviconUrl)) {
             bookIcon = m_iconMap[faviconUrl];
@@ -174,16 +166,11 @@ void ContentManagerModel::refreshIcons()
         return;
     td.clearQueue();
     for (auto i = 0; i < rowCount() && i < m_data.size(); i++) {
-        auto bookItem = m_data[i];
-        auto id = bookItem["id"].toString();
-        const auto faviconUrl = bookItem["faviconUrl"].toString();
-        auto app = KiwixApp::instance();
-        try {
-            auto book = app->getLibrary()->getBookById(id);
-            auto item = book.getIllustration(48);
-        } catch (...) {
+        const auto& bookItem = m_data[i];
+        if ( bookItem["favicon"].toByteArray().isNull() ) {
+            const auto faviconUrl = bookItem["faviconUrl"].toString();
             if (faviconUrl != "" && !m_iconMap.contains(faviconUrl)) {
-                td.addDownload(faviconUrl, id);
+                td.addDownload(faviconUrl, bookItem["id"].toString());
             }
         }
     }

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -211,8 +211,7 @@ void ContentManagerModel::updateImage(QString bookId, QString url, QByteArray im
     const auto item = getRowNode(row);
     item->setIconData(imageData);
     m_iconMap[url] = imageData;
-    const QModelIndex index = this->index(row, 0);
-    emit dataChanged(index, index);
+    triggerDataUpdateAt( this->index(row, 0) );
 }
 
 void ContentManagerModel::updateDownload(QString bookId)
@@ -221,18 +220,11 @@ void ContentManagerModel::updateDownload(QString bookId)
 
     if ( it != bookIdToRowMap.constEnd() ) {
         const size_t row = it.value();
-        const QModelIndex newIndex = this->index(row, 5);
-        emit dataChanged(newIndex, newIndex);
+        triggerDataUpdateAt( this->index(row, 5) );
     }
 }
 
-
-void ContentManagerModel::pauseDownload(QModelIndex index)
-{
-    emit dataChanged(index, index);
-}
-
-void ContentManagerModel::resumeDownload(QModelIndex index)
+void ContentManagerModel::triggerDataUpdateAt(QModelIndex index)
 {
     emit dataChanged(index, index);
 }
@@ -245,7 +237,6 @@ void ContentManagerModel::removeDownload(QString bookId)
 
     const size_t row = it.value();
     getRowNode(row)->setDownloadState(nullptr);
-    const QModelIndex index = this->index(row, 5);
-    emit dataChanged(index, index);
+    triggerDataUpdateAt( this->index(row, 5) );
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -113,14 +113,14 @@ void ContentManagerModel::setBooksData(const BookInfoList& data)
 
 QByteArray ContentManagerModel::getThumbnail(const BookInfo& bookItem) const
 {
-    QByteArray bookIcon = bookItem["favicon"].toByteArray();
-    if ( bookIcon.isNull() ) {
-        const auto faviconUrl = bookItem["faviconUrl"].toString();
-        if (m_iconMap.contains(faviconUrl)) {
-            bookIcon = m_iconMap[faviconUrl];
-        }
-    }
-    return bookIcon;
+    const QVariant faviconEntry = bookItem["favicon"];
+    if ( faviconEntry.type() == QVariant::ByteArray )
+        return faviconEntry.toByteArray();
+
+    const auto faviconUrl = faviconEntry.toString();
+    return m_iconMap.contains(faviconUrl)
+         ? m_iconMap[faviconUrl]
+         : QByteArray();
 }
 
 std::shared_ptr<RowNode> ContentManagerModel::createNode(BookInfo bookItem) const
@@ -167,8 +167,8 @@ void ContentManagerModel::refreshIcons()
     td.clearQueue();
     for (auto i = 0; i < rowCount() && i < m_data.size(); i++) {
         const auto& bookItem = m_data[i];
-        if ( bookItem["favicon"].toByteArray().isNull() ) {
-            const auto faviconUrl = bookItem["faviconUrl"].toString();
+        if ( bookItem["favicon"].type() == QVariant::String ) {
+            const auto faviconUrl = bookItem["favicon"].toString();
             if (faviconUrl != "" && !m_iconMap.contains(faviconUrl)) {
                 td.addDownload(faviconUrl, bookItem["id"].toString());
             }

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -94,7 +94,7 @@ QModelIndex ContentManagerModel::parent(const QModelIndex &index) const
 int ContentManagerModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return zimCount;
+    return m_data.size();
 }
 
 QVariant ContentManagerModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -176,24 +176,6 @@ bool ContentManagerModel::hasChildren(const QModelIndex &parent) const
     if (item)
         return item->childCount() > 0;
     return true;
-}
-
-bool ContentManagerModel::canFetchMore(const QModelIndex &parent) const
-{
-    if (parent.isValid())
-        return false;
-    return (zimCount < m_data.size());
-}
-
-void ContentManagerModel::fetchMore(const QModelIndex &parent)
-{
-    if (parent.isValid())
-        return;
-    int remainder = m_data.size() - zimCount;
-    int zimsToFetch = qMin(5, remainder);
-    beginInsertRows(QModelIndex(), zimCount, zimCount + zimsToFetch - 1);
-    zimCount += zimsToFetch;
-    endInsertRows();
 }
 
 void ContentManagerModel::sort(int column, Qt::SortOrder order)

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -27,13 +27,10 @@ int ContentManagerModel::columnCount(const QModelIndex &parent) const
 
 QVariant ContentManagerModel::data(const QModelIndex& index, int role) const
 {
-    if (!index.isValid())
-        return QVariant();
-
-    auto item = static_cast<Node*>(index.internalPointer());
     const auto displayRole = role == Qt::DisplayRole;
     const auto additionalInfoRole = role == Qt::UserRole+1;
-    if (displayRole || additionalInfoRole) {
+    if ( (displayRole || additionalInfoRole) && index.isValid() ) {
+        const auto item = static_cast<Node*>(index.internalPointer());
         QVariant r = item->data(index.column());
         if ( index.column() != 0 )
             return r;

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -123,10 +123,7 @@ void ContentManagerModel::setBooksData(const BookInfoList& data, const Downloads
         const auto rowNode = createNode(bookItem);
 
         // Restore download state during model updates (filtering, etc)
-        const auto downloadIter = downloads.constFind(rowNode->getBookId());
-        if ( downloadIter != downloads.constEnd() ) {
-            rowNode->setDownloadState(downloadIter.value());
-        }
+        rowNode->setDownloadState(downloads.value(rowNode->getBookId()));
 
         bookIdToRowMap[bookItem["id"].toString()] = rootNode->childCount();
         rootNode->appendChild(rowNode);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -25,7 +25,7 @@ public: // types
     typedef QMap<QString, std::shared_ptr<DownloadState>> Downloads;
 
 public: // functions
-    ContentManagerModel(const Downloads* downloads, QObject *parent = nullptr);
+    explicit ContentManagerModel(QObject *parent = nullptr);
     ~ContentManagerModel();
 
     QVariant data(const QModelIndex &index, int role) const override;
@@ -37,8 +37,8 @@ public: // functions
     QModelIndex parent(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-    void setBooksData(const BookInfoList& data);
-    void setupNodes();
+    void setBooksData(const BookInfoList& data, const Downloads& downloads);
+    void setupNodes(const Downloads& downloads);
     bool hasChildren(const QModelIndex &parent) const override;
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
@@ -63,7 +63,6 @@ private: // data
     mutable ThumbnailDownloader td;
     QMap<QString, size_t> bookIdToRowMap;
     QMap<QString, QByteArray> m_iconMap;
-    const Downloads& m_downloads;
 };
 
 #endif // CONTENTMANAGERMODEL_H

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -57,7 +57,9 @@ protected: // functions
     void fetchMore(const QModelIndex &parent) override;
 
 private: // functions
-    QByteArray getThumbnail(const BookInfo& bookItem) const;
+    // Returns either data of the thumbnail (as a QByteArray) or a URL (as a
+    // QString) from where the actual data can be obtained.
+    QVariant getThumbnail(const BookInfo& bookItem) const;
 
 private: // data
     BookInfoList m_data;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -22,7 +22,33 @@ public: // types
     typedef QList<BookInfo>         BookInfoList;
 
     // BookId -> DownloadState map
-    typedef QMap<QString, std::shared_ptr<DownloadState>> Downloads;
+    class Downloads
+    {
+    private:
+        typedef std::shared_ptr<DownloadState> DownloadStatePtr;
+        typedef QMap<QString, DownloadStatePtr> ImplType;
+
+    public:
+        void set(const QString& id, DownloadStatePtr d) {
+            impl[id] = d;
+        }
+
+        DownloadStatePtr value(const QString& id) const {
+            return impl.value(id);
+        }
+
+        QList<QString> keys() const {
+            return impl.keys();
+        }
+
+        void remove(const QString& id) {
+            impl.remove(id);
+        }
+
+    private:
+        ImplType impl;
+    };
+
 
 public: // functions
     explicit ContentManagerModel(QObject *parent = nullptr);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -41,7 +41,6 @@ public: // functions
     void setupNodes();
     bool hasChildren(const QModelIndex &parent) const override;
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
-    void refreshIcons();
 
     std::shared_ptr<RowNode> createNode(BookInfo bookItem) const;
 
@@ -59,14 +58,14 @@ protected: // functions
 private: // functions
     // Returns either data of the thumbnail (as a QByteArray) or a URL (as a
     // QString) from where the actual data can be obtained.
-    QVariant getThumbnail(const BookInfo& bookItem) const;
+    QVariant getThumbnail(const QVariant& faviconEntry) const;
     RowNode* getRowNode(size_t row);
 
 private: // data
     BookInfoList m_data;
     std::shared_ptr<RowNode> rootNode;
     int zimCount = 0;
-    ThumbnailDownloader td;
+    mutable ThumbnailDownloader td;
     QMap<QString, size_t> bookIdToRowMap;
     QMap<QString, QByteArray> m_iconMap;
     const Downloads& m_downloads;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -60,6 +60,7 @@ private: // functions
     // Returns either data of the thumbnail (as a QByteArray) or a URL (as a
     // QString) from where the actual data can be obtained.
     QVariant getThumbnail(const BookInfo& bookItem) const;
+    RowNode* getRowNode(size_t row);
 
 private: // data
     BookInfoList m_data;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -45,8 +45,7 @@ public: // functions
 
 public slots:
     void updateImage(QString bookId, QString url, QByteArray imageData);
-    void pauseDownload(QModelIndex index);
-    void resumeDownload(QModelIndex index);
+    void triggerDataUpdateAt(QModelIndex index);
     void removeDownload(QString bookId);
     void updateDownload(QString bookId);
 

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -51,10 +51,6 @@ public slots:
     void removeDownload(QString bookId);
     void updateDownload(QString bookId);
 
-protected: // functions
-    bool canFetchMore(const QModelIndex &parent) const override;
-    void fetchMore(const QModelIndex &parent) override;
-
 private: // functions
     // Returns either data of the thumbnail (as a QByteArray) or a URL (as a
     // QString) from where the actual data can be obtained.
@@ -64,7 +60,6 @@ private: // functions
 private: // data
     BookInfoList m_data;
     std::shared_ptr<RowNode> rootNode;
-    int zimCount = 0;
     mutable ThumbnailDownloader td;
     QMap<QString, size_t> bookIdToRowMap;
     QMap<QString, QByteArray> m_iconMap;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -38,7 +38,6 @@ public: // functions
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     void setBooksData(const BookInfoList& data, const Downloads& downloads);
-    void setupNodes(const Downloads& downloads);
     bool hasChildren(const QModelIndex &parent) const override;
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
@@ -58,7 +57,6 @@ private: // functions
     RowNode* getRowNode(size_t row);
 
 private: // data
-    BookInfoList m_data;
     std::shared_ptr<RowNode> rootNode;
     mutable ThumbnailDownloader td;
     QMap<QString, size_t> bookIdToRowMap;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -5,6 +5,8 @@
 #include <QModelIndex>
 #include <QVariant>
 #include <QIcon>
+#include <QMutex>
+#include <QMutexLocker>
 #include "thumbnaildownloader.h"
 #include "rownode.h"
 #include <memory>
@@ -30,23 +32,28 @@ public: // types
 
     public:
         void set(const QString& id, DownloadStatePtr d) {
+            const QMutexLocker threadSafetyGuarantee(&mutex);
             impl[id] = d;
         }
 
         DownloadStatePtr value(const QString& id) const {
+            const QMutexLocker threadSafetyGuarantee(&mutex);
             return impl.value(id);
         }
 
         QList<QString> keys() const {
+            const QMutexLocker threadSafetyGuarantee(&mutex);
             return impl.keys();
         }
 
         void remove(const QString& id) {
+            const QMutexLocker threadSafetyGuarantee(&mutex);
             impl.remove(id);
         }
 
     private:
         ImplType impl;
+        mutable QMutex mutex;
     };
 
 

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -108,8 +108,8 @@ void KiwixApp::init()
         m_library.asyncUpdateFromDir(monitorDir);
     });
     QString monitorDir = m_settingsManager.getMonitorDir();
-    QString downloadDir = m_settingsManager.getDownloadDir();
-    auto dirList = QSet<QString>({monitorDir, downloadDir});
+    //QString downloadDir = m_settingsManager.getDownloadDir();
+    auto dirList = QSet<QString>({monitorDir /*, downloadDir*/});
     for (auto dir : dirList) {
         if (dir != "") {
             m_library.setMonitorDirZims(dir, m_library.getLibraryZimsFromDir(dir));

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -108,8 +108,8 @@ void KiwixApp::init()
         m_library.asyncUpdateFromDir(monitorDir);
     });
     QString monitorDir = m_settingsManager.getMonitorDir();
-    //QString downloadDir = m_settingsManager.getDownloadDir();
-    auto dirList = QSet<QString>({monitorDir /*, downloadDir*/});
+    QString downloadDir = m_settingsManager.getDownloadDir();
+    auto dirList = QSet<QString>({monitorDir, downloadDir});
     for (auto dir : dirList) {
         if (dir != "") {
             m_library.setMonitorDirZims(dir, m_library.getLibraryZimsFromDir(dir));

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -97,6 +97,43 @@ void Library::removeBookFromLibraryById(const QString& id) {
     mp_library->removeBookById(id.toStdString());
 }
 
+namespace
+{
+
+std::string pseudoPathOfAFileBeingDownloaded(const std::string& path)
+{
+    return path + ".beingdownloadedbykiwix";
+}
+
+} // unnamed namespace
+
+void Library::addBookBeingDownloaded(const kiwix::Book& book, QString downloadDir)
+{
+    const QString downloadUrl = QString::fromStdString(book.getUrl());
+
+    // XXX: This works if the URL is a direct link to a ZIM file
+    // XXX: rather than to a torrent or a metalink file
+    const QString fileName = downloadUrl.split('/').back();
+
+    const QString path = QDir(downloadDir).absoluteFilePath(fileName);
+    const std::string stlPath = QDir::toNativeSeparators(path).toStdString();
+
+    kiwix::Book bookCopy(book);
+    bookCopy.setPath(pseudoPathOfAFileBeingDownloaded(stlPath));
+    addBookToLibrary(bookCopy);
+}
+
+bool Library::isBeingDownloadedByUs(QString path) const
+{
+    const auto fakePath = pseudoPathOfAFileBeingDownloaded(path.toStdString());
+    try {
+        mp_library->getBookByPath(fakePath);
+        return true;
+    } catch ( const std::out_of_range& ) {
+        return false;
+    }
+}
+
 void Library::addBookmark(kiwix::Bookmark &bookmark)
 {
     mp_library->addBookmark(bookmark);
@@ -125,6 +162,8 @@ QStringList Library::getLibraryZimsFromDir(QString dir) const
     QStringList zimsInDir;
     for (auto str : getBookIds()) {
         auto filePath = QString::fromStdString(getBookById(str).getPath());
+        if ( filePath.endsWith(".beingdownloadedbykiwix") )
+                continue;
         QDir absoluteDir = QFileInfo(filePath).absoluteDir();
         if (absoluteDir == dir) {
             zimsInDir.push_back(filePath);
@@ -154,8 +193,14 @@ void Library::updateFromDir(QString monitorDir)
     QStringList removedZims = (oldDir - newDir).values();
     auto manager = kiwix::Manager(LibraryManipulator(this));
     bool needsRefresh = !removedZims.empty();
-    for (auto book : addedZims) {
-        needsRefresh |= manager.addBookFromPath(book.toStdString());
+    for (auto bookPath : addedZims) {
+        if ( isBeingDownloadedByUs(bookPath) ) {
+            // qDebug() << "DBG: Library::updateFromDir(): "
+            //          << bookPath
+            //          << " ignored since it is being downloaded by us.";
+        } else {
+            needsRefresh |= manager.addBookFromPath(bookPath.toStdString());
+        }
     }
     for (auto bookPath : removedZims) {
         try {

--- a/src/library.h
+++ b/src/library.h
@@ -37,6 +37,8 @@ public:
     QStringList getLibraryZimsFromDir(QString dir) const;
     void setMonitorDirZims(QString monitorDir, QStringList zimList);
     void addBookToLibrary(kiwix::Book& book);
+    void addBookBeingDownloaded(const kiwix::Book& book, QString downloadDir);
+    bool isBeingDownloadedByUs(QString path) const;
     void removeBookFromLibraryById(const QString& id);
     void addBookmark(kiwix::Bookmark& bookmark);
     void removeBookmark(const QString& zimId, const QString& url);

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -32,17 +32,8 @@ void DownloadState::update(const DownloadInfo& downloadInfos)
     percent = QString::number(percent, 'g', 3).toDouble();
     auto completedLength = convertToUnits(downloadInfos["completedLength"].toDouble());
     auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toDouble()) + "/s";
-    *this = {percent, completedLength, downloadSpeed, false};
-}
-
-void DownloadState::pause()
-{
-    this->paused = true;
-}
-
-void DownloadState::resume()
-{
-    this->paused = false;
+    const bool paused = downloadInfos["status"] == "paused";
+    *this = {percent, completedLength, downloadSpeed, paused};
 }
 
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -17,8 +17,6 @@ public:
     bool paused = false;
 
 public:
-    void pause();
-    void resume();
     void update(const DownloadInfo& info);
 };
 


### PR DESCRIPTION
Should fix #87, #1037

This PR contains a significant amount of changes related to download management and fixes various bugs discovered while performing those (refactoring) changes.

- Download progress/status updates are performed in a separate worker thread
- Thumbnails of remote books are downloaded lazily
- Running and/or paused downloads are restored after `kiwix-desktop` is closed and started again
- Fixed issues coming from the monitoring of the download directory interfering with download state lifecycle
- Eliminated a few crash scenarios