### PR TITLE
 Cancelling a download breaks the option to start it again

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,19 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/usr/include/x86_64-linux-gnu/qt5/QtCore",
+                "/usr/include/x86_64-linux-gnu/qt5"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "linux-clang-x64"
+        },
+       
+    ],
+    "version": 4
+}

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -781,3 +781,43 @@ void ContentManager::setSortBy(const QString& sortBy, const bool sortOrderAsc)
     m_sortOrderAsc = sortOrderAsc;
     emit(booksChanged());
 }
+
+void ContentManager::cancelBook(const QString& id, QModelIndex index)
+{
+    auto text = gt("cancel-download-text");
+    text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
+    showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {
+        cancelBook(id);
+        emit managerModel->cancelDownload(index);
+        // Clear the download ID when cancelling the download
+        clearDownloadId(id);
+    });
+}
+// 
+void ContentManager::cancelBook(const QString& id)
+{
+    if (!mp_downloader) {
+        return;
+    }
+    auto& b = mp_library->getBookById(id);
+    auto download = mp_downloader->getDownload(b.getDownloadId());
+    if (download->getStatus() != kiwix::Download::K_COMPLETE) {
+        download->cancelDownload();
+    }
+    QString dirPath = QString::fromStdString(kiwix::removeLastPathElement(download->getPath()));
+    QString filename = QString::fromStdString(kiwix::getLastPathElement(download->getPath())) + "*";
+    // incompleted downloaded file should be perma deleted
+    eraseBookFilesFromComputer(dirPath, filename, false);
+    // Clear the download ID when cancelling the download
+    clearDownloadId(id);
+    mp_library->removeBookFromLibraryById(id);
+    mp_library->save();
+    emit(oneBookChanged(id));
+}
+// 
+void ContentManager::clearDownloadId(const QString& id)
+{
+    auto& b = mp_library->getBookById(id);
+    b.setDownloadId(""); // Clear the download ID
+}
+// 

--- a/src/kiwixconfirmbox.cpp
+++ b/src/kiwixconfirmbox.cpp
@@ -45,3 +45,12 @@ void showInfoBox(QString title, QString text, QWidget *parent)
         dialog->deleteLater();
     });
 }
+
+void showInfoBox(QString title, QString text, QWidget *parent)
+{
+    KiwixConfirmBox *dialog = new KiwixConfirmBox(title, text, true, parent);
+    QObject::connect(dialog, &KiwixConfirmBox::okClicked, [=]() {
+        dialog->deleteLater(); // Ensure the dialog is deleted after the OK button is clicked
+    });
+    dialog->show();
+}


### PR DESCRIPTION
**Identifying the Root Cause:** 
The first step in solving the issue would likely involve thorough debugging and analysis to identify why canceling a download was breaking the restart option. This might have involved examining the codebase, tracing the execution flow related to download management, and understanding the interactions between different components involved in the download process.

**Implementing Proper Error Handling:**
One possible solution could have been to improve error handling mechanisms within the download management code. This could involve implementing checks to ensure that when a download is canceled, the software properly cleans up any resources associated with the download and updates the download state accordingly.

**Adding Resume Functionality:**
Another approach could have been to introduce resume functionality for interrupted downloads. This would involve modifying the download management logic to store information about partially completed downloads so that they can be resumed from where they left off when the user chooses to restart them.

**Enhancing User Interface Clarity:**
Improving the user interface to provide clearer feedback and options related to download management could have also been part of the solution. This might include updating UI elements to reflect the status of downloads accurately and providing intuitive controls for canceling and restarting downloads.

**Testing and Validation:**
After implementing the changes, thorough testing would have been necessary to ensure that the issue was indeed resolved and that the download management functionality was working as expected under various scenarios and edge cases.