### PR TITLE
Fix #186: Introduced Tab Restoration on Restart

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -162,5 +162,6 @@
     "content-type-searcher-placeholder": "Filter content type",
     "no-details": "Introduction only",
     "no-pictures": "No Pictures",
-    "no-videos": "No Videos"
+    "no-videos": "No Videos",
+    "open-previous-tabs-at-startup": "Open previous tabs at startup"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -45,5 +45,6 @@
 	"monitor-dir-dialog-msg": "\"Monitor\" means \"watch\" in this context. The monitor directory is monitored/watched for new ZIM files.",
 	"monitor-clear-dir-dialog-title": "\"Monitor\" means \"watch\" in this context. The monitor directory is monitored/watched for new ZIM files.",
 	"monitor-clear-dir-dialog-msg": "\"Monitor\" means \"watch\" in this context. The monitor directory is monitored/watched for new ZIM files.",
-	"open-book": "\"Open\" is a imperative, not an adjective."
+	"open-book": "\"Open\" is a imperative, not an adjective.",
+	"open-previous-tabs-at-startup": "The tabs that were open when the user closed the application is opened again when the application is restarted."
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -189,15 +189,18 @@ void KiwixApp::restoreTabs()
 
     /* Restart a new session to prevent duplicate records in openURL */
     saveListOfOpenTabs();
-    for (const auto &zimUrl : tabsToOpen)
+    if (m_settingsManager.getReopenTab())
     {
-      try
+      for (const auto &zimUrl : tabsToOpen)
       {
+        try
+        {
           /* Throws exception if zim file cannot be found */
           m_library.getArchive(QUrl(zimUrl).host().split('.')[0]);
           openUrl(QUrl(zimUrl));
+        }
+        catch (std::exception &e) { /* Blank */ }
       }
-      catch (std::exception &e) { /* Blank */ }
     }
 }
 

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -32,7 +32,8 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
       mp_manager(nullptr),
       mp_mainWindow(nullptr),
       mp_nameMapper(std::make_shared<kiwix::UpdatableNameMapper>(m_library.getKiwixLibrary(), false)),
-      m_server(m_library.getKiwixLibrary(), mp_nameMapper)
+      m_server(m_library.getKiwixLibrary(), mp_nameMapper),
+      mp_session(nullptr)
 {
     try {
         m_translation.setTranslation(QLocale());
@@ -113,6 +114,8 @@ void KiwixApp::init()
             m_library.asyncUpdateFromDir(dir);
         }
     }
+
+    restoreTabs();
 }
 
 KiwixApp::~KiwixApp()
@@ -174,6 +177,28 @@ QString KiwixApp::findLibraryDirectory()
   }
 
   return currentDataDir;
+}
+
+void KiwixApp::restoreTabs()
+{
+    /* Place session file in our global library path */
+    QDir dir(m_libraryDirectory);
+    mp_session = new QSettings(dir.filePath("kiwix-desktop.session"),
+                               QSettings::defaultFormat(), this);
+    QStringList tabsToOpen = mp_session->value("reopenTabList").toStringList();
+
+    /* Restart a new session to prevent duplicate records in openURL */
+    saveListOfOpenTabs();
+    for (const auto &zimUrl : tabsToOpen)
+    {
+      try
+      {
+          /* Throws exception if zim file cannot be found */
+          m_library.getArchive(QUrl(zimUrl).host().split('.')[0]);
+          openUrl(QUrl(zimUrl));
+      }
+      catch (std::exception &e) { /* Blank */ }
+    }
 }
 
 KiwixApp *KiwixApp::instance()
@@ -503,4 +528,9 @@ QString KiwixApp::parseStyleFromFile(QString filePath)
     QString styleSheet = QString(file.readAll());
     file.close();
     return styleSheet;
+}
+
+void KiwixApp::saveListOfOpenTabs()
+{
+  return mp_session->setValue("reopenTabList", getTabWidget()->getTabUrls());
 }

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -87,6 +87,7 @@ public:
     void setMonitorDir(const QString &dir);
     bool isCurrentArticleBookmarked();
     QString parseStyleFromFile(QString filePath);
+    void saveListOfOpenTabs();
 
 public slots:
     void newTab();
@@ -116,10 +117,12 @@ private:
     kiwix::Server m_server;
     Translation m_translation;
     QFileSystemWatcher m_watcher;
+    QSettings* mp_session;
 
     QAction*     mpa_actions[MAX_ACTION];
 
     QString findLibraryDirectory();
+    void restoreTabs();
 };
 
 QString gt(const QString &key);

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -19,7 +19,8 @@ SettingsView* SettingsManager::getView()
 {
     if (m_view == nullptr) {
         auto view = new SettingsView();
-        view->init(m_zoomFactor * 100, m_downloadDir, m_monitorDir, m_moveToTrash);
+        view->init(m_zoomFactor * 100, m_downloadDir, m_monitorDir,
+                   m_moveToTrash, m_reopenTab);
         connect(view, &QObject::destroyed, this, [=]() { m_view = nullptr; });
         m_view = view;
     }
@@ -99,6 +100,13 @@ void SettingsManager::setMoveToTrash(bool moveToTrash)
     emit(moveToTrashChanged(m_moveToTrash));
 }
 
+void SettingsManager::setReopenTab(bool reopenTab)
+{
+    m_reopenTab = reopenTab;
+    setSettings("reopenTab", m_reopenTab);
+    emit(reopenTabChanged(reopenTab));
+}
+
 QList<QVariant> SettingsManager::flattenPair(FilterList pairList)
 {
     QList<QVariant> res;
@@ -148,6 +156,7 @@ void SettingsManager::initSettings()
     m_kiwixServerIpAddress = m_settings.value("localKiwixServer/ipAddress", QString("0.0.0.0")).toString();
     m_monitorDir = m_settings.value("monitor/dir", QString("")).toString();
     m_moveToTrash = m_settings.value("moveToTrash", true).toBool();
+    m_reopenTab = m_settings.value("reopenTab", false).toBool();
     QString defaultLang = QLocale::languageToString(QLocale().language()) + '|' + QLocale().name().split("_").at(0);
 
     /*

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -29,6 +29,7 @@ public:
     QString getDownloadDir() const { return m_downloadDir; }
     QString getMonitorDir() const { return m_monitorDir; }
     bool getMoveToTrash() const { return m_moveToTrash; }
+    bool getReopenTab() const { return m_reopenTab; }
     FilterList getLanguageList() { return deducePair(m_langList); }
     FilterList getCategoryList() { return deducePair(m_categoryList); }
     FilterList getContentType() { return deducePair(m_contentTypeList); }
@@ -40,9 +41,11 @@ public slots:
     void setDownloadDir(QString downloadDir);
     void setMonitorDir(QString monitorDir);
     void setMoveToTrash(bool moveToTrash);
+    void setReopenTab(bool reopenTab);
     void setLanguage(FilterList langList);
     void setCategory(FilterList categoryList);
     void setContentType(FilterList contentTypeList);
+
 private:
     void initSettings();
     QList<QVariant> flattenPair(FilterList pairList);
@@ -54,6 +57,7 @@ signals:
     void downloadDirChanged(QString downloadDir);
     void monitorDirChanged(QString monitorDir);
     void moveToTrashChanged(bool moveToTrash);
+    void reopenTabChanged(bool reopenTab);
     void languageChanged(QList<QVariant> langList);
     void categoryChanged(QList<QVariant> categoryList);
     void contentTypeChanged(QList<QVariant> contentTypeList);
@@ -67,6 +71,7 @@ private:
     QString m_downloadDir;
     QString m_monitorDir;
     bool m_moveToTrash;
+    bool m_reopenTab;
     QList<QVariant> m_langList;
     QList<QVariant> m_categoryList;
     QList<QVariant> m_contentTypeList;

--- a/src/settingsview.cpp
+++ b/src/settingsview.cpp
@@ -12,6 +12,7 @@ SettingsView::SettingsView(QWidget *parent)
     ui->widget->setStyleSheet(KiwixApp::instance()->parseStyleFromFile(":/css/_settingsManager.css"));
     connect(ui->zoomPercentSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &SettingsView::setZoom);
     connect(ui->moveToTrashToggle, &QCheckBox::clicked, this, &SettingsView::setMoveToTrash);
+    connect(ui->reopenTabToggle, &QCheckBox::clicked, this, &SettingsView::setReopenTab);
     connect(ui->browseButton, &QPushButton::clicked, this, &SettingsView::browseDownloadDir);
     connect(ui->resetButton, &QPushButton::clicked, this, &SettingsView::resetDownloadDir);
     connect(ui->monitorBrowse, &QPushButton::clicked, this, &SettingsView::browseMonitorDir);
@@ -20,6 +21,7 @@ SettingsView::SettingsView(QWidget *parent)
     connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::monitorDirChanged, this, &SettingsView::onMonitorDirChanged);
     connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::zoomChanged, this, &SettingsView::onZoomChanged);
     connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::moveToTrashChanged, this, &SettingsView::onMoveToTrashChanged);
+    connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::reopenTabChanged, this, &SettingsView::onReopenTabChanged);
     ui->settingsLabel->setText(gt("settings"));
     ui->zoomPercentLabel->setText(gt("zoom-level-setting"));
     ui->downloadDirLabel->setText(gt("download-directory-setting"));
@@ -31,14 +33,18 @@ SettingsView::SettingsView(QWidget *parent)
     ui->monitorHelp->setText("<b>?</b>");
     ui->monitorHelp->setToolTip(gt("monitor-directory-tooltip"));
     ui->moveToTrashLabel->setText(gt("move-files-to-trash"));
+    ui->reopenTabLabel->setText(gt("open-previous-tabs-at-startup"));
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    ui->line_5->hide();
     ui->moveToTrashLabel->hide();
     ui->moveToTrashToggle->hide();
 #endif
 
 }
 
-void SettingsView::init(int zoomPercent, const QString &downloadDir, const QString &monitorDir, const bool moveToTrash)
+void SettingsView::init(int zoomPercent, const QString &downloadDir,
+                        const QString &monitorDir, const bool moveToTrash,
+                        bool reopentab)
 {
     ui->zoomPercentSpinBox->setValue(zoomPercent);
     ui->downloadDirPath->setText(downloadDir);
@@ -47,6 +53,7 @@ void SettingsView::init(int zoomPercent, const QString &downloadDir, const QStri
     }
     ui->monitorDirPath->setText(monitorDir);
     ui->moveToTrashToggle->setChecked(moveToTrash);
+    ui->reopenTabToggle->setChecked(reopentab);
 }
 bool SettingsView::confirmDialog( QString messageText, QString messageTitle)
 {
@@ -142,6 +149,11 @@ void SettingsView::setMoveToTrash(bool moveToTrash)
     KiwixApp::instance()->getSettingsManager()->setMoveToTrash(moveToTrash);
 }
 
+void SettingsView::setReopenTab(bool reopen)
+{
+    KiwixApp::instance()->getSettingsManager()->setReopenTab(reopen);
+}
+
 void SettingsView::onDownloadDirChanged(const QString &dir)
 {
     ui->downloadDirPath->setText(dir);
@@ -166,4 +178,9 @@ void SettingsView::onZoomChanged(qreal zoomFactor)
 void SettingsView::onMoveToTrashChanged(bool moveToTrash)
 {
     ui->moveToTrashToggle->setChecked(moveToTrash);
+}
+
+void SettingsView::onReopenTabChanged(bool reopen)
+{
+    ui->reopenTabToggle->setChecked(reopen);
 }

--- a/src/settingsview.h
+++ b/src/settingsview.h
@@ -11,18 +11,22 @@ class SettingsView : public QWidget
 public:
     SettingsView(QWidget *parent = nullptr);
     ~SettingsView(){};
-    void init(int zoomPercent, const QString &downloadDir, const QString &monitorDir, const bool moveToTrash);
-public Q_SLOTS:
+    void init(int zoomPercent, const QString &downloadDir,
+              const QString &monitorDir, const bool moveToTrash,
+              bool reopentab);
+  public Q_SLOTS:
     void resetDownloadDir();
     void browseDownloadDir();
     void browseMonitorDir();
     void clearMonitorDir();
     void setZoom(int zoomPercent);
     void setMoveToTrash(bool moveToTrash);
+    void setReopenTab(bool reopen);
     void onDownloadDirChanged(const QString &dir);
     void onMonitorDirChanged(const QString &dir);
     void onZoomChanged(qreal zoomFactor);
     void onMoveToTrashChanged(bool moveToTrash);
+    void onReopenTabChanged(bool reopen);
 private:
     bool confirmDialogDownloadDir(const QString& dir);
     bool confirmDialog(QString messageText, QString messageTitle);

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -268,6 +268,16 @@ void TabBar::closeTabsByZimId(const QString &id)
     }
 }
 
+QStringList TabBar::getTabUrls() const {
+    QStringList idList;
+    for (int index = 0; index <= mp_stackedWidget->count(); index++)
+    {
+        if (ZimView* zv = qobject_cast<ZimView*>(mp_stackedWidget->widget(index)))
+            idList.push_back(zv->getWebView()->url().url());
+    }
+    return idList;
+}
+
 void TabBar::closeTab(int index)
 {
     // The first and last tabs (i.e. the library tab and the + (new tab) button)
@@ -285,6 +295,8 @@ void TabBar::closeTab(int index)
     removeTab(index);
     view->close();
     view->deleteLater();
+
+    KiwixApp::instance()->saveListOfOpenTabs();
 }
 
 void TabBar::onCurrentChanged(int index)
@@ -466,4 +478,6 @@ void TabBar::onTabMoved(int from, int to)
     QWidget *w_from = mp_stackedWidget->widget(from);
     mp_stackedWidget->removeWidget(w_from);
     mp_stackedWidget->insertWidget(to, w_from);
+
+    KiwixApp::instance()->saveListOfOpenTabs();
 }

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -49,6 +49,7 @@ public:
     virtual QSize tabSizeHint(int index) const;
     void openFindInPageBar();
     void closeTabsByZimId(const QString &id);
+    QStringList getTabUrls() const;
 
 protected:
     void mousePressEvent(QMouseEvent *event);

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -166,12 +166,13 @@ QWebEngineView* WebView::createWindow(QWebEnginePage::WebWindowType type)
 
 void WebView::onUrlChanged(const QUrl& url) {
     auto zimId = getZimIdFromUrl(url);
+    auto app = KiwixApp::instance();
+    app->saveListOfOpenTabs();
     if (m_currentZimId == zimId ) {
         return;
     }
     m_currentZimId = zimId;
     emit zimIdChanged(m_currentZimId);
-    auto app = KiwixApp::instance();
     std::shared_ptr<zim::Archive> archive;
     try {
         archive = app->getLibrary()->getArchive(m_currentZimId);

--- a/ui/settings.ui
+++ b/ui/settings.ui
@@ -329,6 +329,50 @@
          </layout>
         </item>
         <item>
+         <widget class="Line" name="line_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="reopenTabLabel">
+            <property name="text">
+             <string>Re-open closed tabs</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="reopenTabToggle">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Changes:
- ~Pop-up to prompt users whether they want to restore the tabs. If not, start a new session.~ Added a checkbox in settings for users to toggle whether they want tab restoration or not.
- Tab order is preserved.
- Tab closures are recorded.
- Tab navigation URL is preserved.
- Blank/Settings tabs are recorded but not opened again on startup.

Fix-up Changes:
- Does not open zim files that are deleted from the File System.
- Pop-ups replaced with toggle option in settings.
- Writes to a separate file than the program settings registry.
- Simplifies session commit strategy.

Fix #186