### PR TITLE
Fix warnings and enable Werror

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -15,7 +15,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = kiwix-desktop
 TEMPLATE = app
 
-QMAKE_CXXFLAGS += -std=c++17
+QMAKE_CXXFLAGS += -std=c++17 -Werror
 QMAKE_LFLAGS +=  -std=c++17
 
 # Also change resources/org.kiwix.desktop.appdata.xml

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -543,6 +543,9 @@ void ContentManager::downloadBook(const QString &id)
 
 void ContentManager::eraseBookFilesFromComputer(const QString dirPath, const QString fileName, const bool moveToTrash)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    Q_UNUSED(moveToTrash);
+#endif
     if (fileName == "*") {
         return;
     }
@@ -638,6 +641,8 @@ void ContentManager::resumeBook(const QString& id)
 
 void ContentManager::cancelBook(const QString& id, QModelIndex index)
 {
+    Q_UNUSED(index);
+
     auto text = gt("cancel-download-text");
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
     showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {
@@ -738,7 +743,7 @@ QString makeHttpUrl(QString host, int port)
 } // unnamed namespace
 
 void ContentManager::updateRemoteLibrary(const QString& content) {
-    QtConcurrent::run([=]() {
+    (void) QtConcurrent::run([=]() {
         QMutexLocker locker(&remoteLibraryLocker);
         mp_remoteLibrary = kiwix::Library::create();
         kiwix::Manager manager(mp_remoteLibrary);

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -210,6 +210,8 @@ void ContentManagerDelegate::paint(QPainter *painter, const QStyleOptionViewItem
 
 bool ContentManagerDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
+    Q_UNUSED(model);
+
     if(event->type() == QEvent::MouseButtonRelease )
     {
         QMouseEvent * e = (QMouseEvent *)event;
@@ -270,6 +272,8 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
 
 QSize ContentManagerDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
+    Q_UNUSED(option);
+
     if (index.parent().isValid()) {
         return QSize(300, 70);
     }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -41,17 +41,14 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
         QMessageBox::critical(nullptr, "Translation error", e.what());
         return;
     }
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    m_qtTranslator.load(QLocale(), "qt", "_",
-                        QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-#else
-    m_qtTranslator.load(QLocale(), "qt", "_",
-                        QLibraryInfo::path(QLibraryInfo::TranslationsPath));
-#endif
-    installTranslator(&m_qtTranslator);
 
-    m_appTranslator.load(QLocale(), "kiwix-desktop", "_", ":/i18n/");
-    installTranslator(&m_appTranslator);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QString path = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#else
+    QString path = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+#endif
+    loadAndInstallTranslations(m_qtTranslator, "qt", path);
+    loadAndInstallTranslations(m_appTranslator, "kiwix-desktop", ":/i18n/");
 
     QFontDatabase::addApplicationFont(":/fonts/Selawik/selawkb.ttf");
     QFontDatabase::addApplicationFont(":/fonts/Selawik/selawkl.ttf");
@@ -59,6 +56,12 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
     QFontDatabase::addApplicationFont(":/fonts/Selawik/selawksl.ttf");
     QFontDatabase::addApplicationFont(":/fonts/Selawik/selawk.ttf");
     setFont(QFont("Selawik"));
+}
+
+void KiwixApp::loadAndInstallTranslations(QTranslator& translator, const QString& filename, const QString& directory) {
+    if (translator.load(QLocale(), filename, "_", directory)) {
+        installTranslator(&translator);
+    }
 }
 
 void KiwixApp::init()
@@ -441,10 +444,10 @@ void KiwixApp::createActions()
     mpa_actions[FindInPageAction]->setShortcuts({QKeySequence::Find, Qt::Key_F3});
     connect(mpa_actions[FindInPageAction], &QAction::triggered,
             this, [=]() { getTabWidget()->openFindInPageBar(); });
-    
+
     const auto fullScreenKeySeq = QKeySequence(QKeySequence::FullScreen).isEmpty()
-                                ? Qt::Key_F11
-                                : QKeySequence::FullScreen;
+                                ? (int) Qt::Key_F11
+                                : (int) QKeySequence::FullScreen;
     CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"), fullScreenKeySeq);
     connect(mpa_actions[ToggleFullscreenAction], &QAction::toggled,
             this, [=](bool checked) {

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -123,6 +123,7 @@ private:
 
     QString findLibraryDirectory();
     void restoreTabs();
+    void loadAndInstallTranslations(QTranslator& translator, const QString& filename, const QString& directory);
 };
 
 QString gt(const QString &key);

--- a/src/kiwixlineedit.cpp
+++ b/src/kiwixlineedit.cpp
@@ -16,6 +16,8 @@ void KiwixLineEdit::resizeEvent(QResizeEvent *event)
 }
 bool KiwixLineEdit::eventFilter(QObject* object, QEvent* event)
 {
+    Q_UNUSED(object);
+
     if (event->type() == QEvent::MouseButtonPress) {
         emit(clicked());
     } else if (event->type() == QEvent::FocusIn) {

--- a/src/kiwixloader.cpp
+++ b/src/kiwixloader.cpp
@@ -41,6 +41,8 @@ void createArc(QPainter &painter, int startAngle, int spanAngle, QRect rectangle
 
 void KiwixLoader::paintEvent(QPaintEvent *event)
 {
+    Q_UNUSED(event);
+
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -170,7 +170,7 @@ void Library::updateFromDir(QString monitorDir)
 
 void Library::asyncUpdateFromDir(QString dir)
 {
-    QtConcurrent::run( [=]() {
+    (void) QtConcurrent::run([=]() {
         updateFromDir(dir);
     });
 }


### PR DESCRIPTION
Fixed all the warnings in the build and added `-Werror`. Not sure if `Werror` is wanted since it might be annoying during development - please let me know either way.

Regarding the loading/installation of the translators, there seems to be a bug. `m_qtTranslator.load()` for the Qt translations succeeds, but then installing always fails. Both loading and installing `m_appTranslator` always fail. I didn't want to break any application functionality, so I added variables to check the return values to satisfy the warnings, but the behavior should be roughly the same.