### PR TITLE
Fix #1053: Close Button No Longer Only Close Current Tab on Linux

### DIFF
--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -10,6 +10,7 @@
 #include "fullscreenwindow.h"
 #include <QMouseEvent>
 #include <QWebEngineFullScreenRequest>
+#include <QToolButton>
 
 class TabBar : public QTabBar
 {
@@ -49,6 +50,7 @@ public:
     virtual QSize tabSizeHint(int index) const;
     void openFindInPageBar();
     void closeTabsByZimId(const QString &id);
+    int tabIndexOf(QObject *object);
 
 protected:
     void mousePressEvent(QMouseEvent *event);
@@ -79,6 +81,18 @@ private slots:
     void onTabMoved(int from, int to);
     void onCurrentChanged(int index);
     void onWebviewHistoryActionChanged(QWebEnginePage::WebAction action, bool enabled);
+};
+
+class TabCloseButton : public QToolButton
+{
+public:
+    TabCloseButton(QWidget *parent = nullptr, QObject *parent_view = nullptr)
+        : QToolButton(parent), parent_view(parent_view){};
+
+protected:
+    void mousePressEvent(QMouseEvent *event);
+private:
+    QObject *parent_view;
 };
 
 #endif // TABWIDGET_H


### PR DESCRIPTION
The Problem:

**The `CloseTabAction` has nothing wrong. Its purpose is to close the current tab. However, to close non-current tabs, the behaviour is unwanted (No idea why it works on Windows, might be the tab switch event happens first.). We cannot use the [tabCloseRequested()](https://doc.qt.io/qt-6/qtabbar.html#tabCloseRequested) function since we replaced the close button widget with our own. Closing non-current tabs is only possible with mouse clicks**

Changes:

- Replaced `QToolButton` with its new subclass `TabCloseButton` that will overtake the mouse click event.
- Introduce `tabIndexOf` function to get tab index based on a view widget. (Will modify #1048's less flexible version to this)
- `TabCloseButton` takes a view widget and will close the tab based on where the view is located.

Fix #1053 