### PR TITLE
Fix #967: Search Bar Key Board Short Cut Performs the same as Mouse Click

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -439,8 +439,7 @@ void KiwixApp::createActions()
     HIDE_ACTION(SavePageAsAction);
     */
 
-    CREATE_ACTION_SHORTCUT(SearchArticleAction, gt("search-article"), QKeySequence(Qt::CTRL | Qt::Key_L));
-    HIDE_ACTION(SearchArticleAction);
+    CREATE_ACTION_SHORTCUTS(SearchArticleAction, gt("search-article"), QList<QKeySequence>({QKeySequence(Qt::Key_F6), QKeySequence(Qt::CTRL | Qt::Key_L), QKeySequence(Qt::ALT | Qt::Key_D)}));
 
     CREATE_ACTION_SHORTCUT(SearchLibraryAction, gt("search-in-library"), QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_R));
     HIDE_ACTION(SearchLibraryAction);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -148,18 +148,6 @@ void MainWindow::when_libraryPageDisplayed(bool showed)
     }
 }
 
-void MainWindow::keyPressEvent(QKeyEvent *event)
-{
-    auto key = event->key();
-    auto modifier = event->modifiers();
-    if (key == Qt::Key_F6 ||
-        (key == Qt::Key_L && modifier == Qt::ControlModifier) ||
-        (key == Qt::Key_D && modifier == Qt::AltModifier)) {
-        getTopWidget()->getSearchBar().selectAll();
-        getTopWidget()->getSearchBar().setFocus();
-    }
-    return QWidget::keyPressEvent(event);
-}
 TabBar* MainWindow::getTabBar()
 {
     return mp_ui->tabBar;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,7 +27,6 @@ public:
     QWidget getMainView();
 
 protected:
-    void keyPressEvent(QKeyEvent *event) override;
     bool eventFilter(QObject* object, QEvent* event) override;
 
 private slots:

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -94,6 +94,13 @@ SearchBar::SearchBar(QWidget *parent) :
     connect(this, &QLineEdit::returnPressed, this, [=]() {
         m_returnPressed = true;
     });
+    
+    auto app = KiwixApp::instance();
+    connect(app->getAction(KiwixApp::SearchArticleAction), &QAction::triggered,
+            this, [=]() {
+                this->selectAll();
+                this->setFocus(Qt::ShortcutFocusReason);
+            });
 }
 
 void SearchBar::hideSuggestions()
@@ -129,7 +136,8 @@ void SearchBar::focusInEvent( QFocusEvent* event)
         clear();
     }
     if (event->reason() == Qt::ActiveWindowFocusReason ||
-        event->reason() == Qt::MouseFocusReason) {
+        event->reason() == Qt::MouseFocusReason ||
+        event->reason() == Qt::ShortcutFocusReason) {
         connect(&m_completer, QOverload<const QModelIndex &>::of(&QCompleter::activated),
         this, QOverload<const QModelIndex &>::of(&SearchBar::openCompletion));
     }


### PR DESCRIPTION
Bug reason:
Our current focus in events performs actions based on event types, but we did not pass an event type into a user-defined focus event.

Changes:
- Refactored previous redundant code into the actions menu code.
- Moved the action to SearchBar
- Explicitly stated the reason for the focus in the event is from a shortcut (though the OtherReason would work as well but let's try to be explicit.)

Fix #967 