### PR TITLE
Results were never shown in fulltext search

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -133,8 +133,8 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     }
     kiwix::SearchRenderer renderer(
         search->getResults(start, pageLength),
-        search->getEstimatedMatches(),
-        start);
+        start,
+        search->getEstimatedMatches());
     renderer.setSearchPattern(searchQuery);
     renderer.setSearchBookQuery("content="+bookId.toStdString());
     renderer.setProtocolPrefix("zim://");


### PR DESCRIPTION
This closes #988 if there are no additional requests on removing the "(fulltext search)" from the searchbar.