### PR TITLE
Changing boomark icon to star and adding tooltip

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -30,6 +30,8 @@
     "set-fullscreen":"Set fullscreen",
     "quit-fullscreen":"Quit fullScreen",
     "table-of-content":"Table of content",
+    "add-bookmark": "Add to the reading list",
+    "remove-bookmark": "Remove from the reading list",
     "reading-list":"Reading list",
     "reading-list-title":"Reading List",
     "zoom-in":"Zoom in",

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -39,6 +39,8 @@
 	"videos": "{{identical|Video}}",
 	"yes": "{{identical|yes}}",
 	"no": "{{identical|no}}",
+	"add-bookmark": "Represents the action of adding a page as a bookmark",
+	"remove-bookmark": "Represents the action of removing a page from the bookmarks",
 	"open-link-in-web-browser": "Ouvrir le lien dans le navigateur",
 	"download-dir-dialog-msg": "Please note that <code><nowiki>{{DIRECTORY}}</nowiki></code> should be placed on a newline.",
 	"monitor-dir-dialog-title": "\"Monitor\" means \"watch\" in this context. The monitor directory is monitored/watched for new ZIM files.",

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -24,9 +24,11 @@ void SearchButton::set_searchMode(bool searchMode)
     } else {
         auto kiwixApp = KiwixApp::instance();
         if (kiwixApp->isCurrentArticleBookmarked()) {
-            setIcon(QIcon(":/icons/reading-list-active.svg"));
+            setIcon(QIcon(":/icons/star.svg"));
+            setToolTip(gt("add-bookmark"));
         } else {
-            setIcon(QIcon(":/icons/reading-list.svg"));
+            setIcon(QIcon(":/icons/star-active.svg"));
+            setToolTip(gt("remove-bookmark"));
         }
         setIconSize(QSize(25, 25));
     }

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -24,13 +24,13 @@ void SearchButton::set_searchMode(bool searchMode)
     } else {
         auto kiwixApp = KiwixApp::instance();
         if (kiwixApp->isCurrentArticleBookmarked()) {
-            setIcon(QIcon(":/icons/star.svg"));
-            setToolTip(gt("add-bookmark"));
-        } else {
             setIcon(QIcon(":/icons/star-active.svg"));
             setToolTip(gt("remove-bookmark"));
+        } else {
+            setIcon(QIcon(":/icons/star.svg"));
+            setToolTip(gt("add-bookmark"));
         }
-        setIconSize(QSize(25, 25));
+        setIconSize(QSize(32, 32));
     }
 }
 


### PR DESCRIPTION
This closes #605, by changing the reading list add/remove icon from the "glasses" to the "star" icon that is used in most places.
Also added a tooltip to signify the action about to be done.