### PR TITLE
On undefined fullscreen key sequence, hardcode to F11

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -413,8 +413,13 @@ void KiwixApp::createActions()
     mpa_actions[FindInPageAction]->setShortcuts({QKeySequence::Find, Qt::Key_F3});
     connect(mpa_actions[FindInPageAction], &QAction::triggered,
             this, [=]() { getTabWidget()->openFindInPageBar(); });
-
-    CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"),  QKeySequence::FullScreen);
+    
+    bool fullScreenKeyUndefined = (QKeySequence(QKeySequence::FullScreen).toString()).isEmpty();
+    if (fullScreenKeyUndefined) {
+        CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"), Qt::Key_F11);
+    } else {
+        CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"), QKeySequence::FullScreen);
+    }
     connect(mpa_actions[ToggleFullscreenAction], &QAction::toggled,
             this, [=](bool checked) {
         auto action = mpa_actions[ToggleFullscreenAction];

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -414,12 +414,10 @@ void KiwixApp::createActions()
     connect(mpa_actions[FindInPageAction], &QAction::triggered,
             this, [=]() { getTabWidget()->openFindInPageBar(); });
     
-    bool fullScreenKeyUndefined = (QKeySequence(QKeySequence::FullScreen).toString()).isEmpty();
-    if (fullScreenKeyUndefined) {
-        CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"), Qt::Key_F11);
-    } else {
-        CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"), QKeySequence::FullScreen);
-    }
+    const auto fullScreenKeySeq = QKeySequence(QKeySequence::FullScreen).isEmpty()
+                                ? Qt::Key_F11
+                                : QKeySequence::FullScreen;
+    CREATE_ACTION_ICON_SHORTCUT(ToggleFullscreenAction, "full-screen-enter", gt("set-fullscreen"), fullScreenKeySeq);
     connect(mpa_actions[ToggleFullscreenAction], &QAction::toggled,
             this, [=](bool checked) {
         auto action = mpa_actions[ToggleFullscreenAction];


### PR DESCRIPTION
This closes #1067, by adding a condition to check if the fullscreen key sequence is undefined and in that case hardcode it with F11