### PR TITLE
Fix #697 : Clicking on a PDF link opens directly in a PDF reader

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -167,5 +167,7 @@
     "no-details": "Introduction only",
     "no-pictures": "No Pictures",
     "no-videos": "No Videos",
-    "open-previous-tabs-at-startup": "Open previous tabs at startup"
+    "open-previous-tabs-at-startup": "Open previous tabs at startup",
+    "download-or-open":"Do you want to open or download the file?"
+
 }

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -43,7 +43,6 @@ void KProfile::startDownload(QWebEngineDownloadRequest* download)
     QString dmimeType = download->mimeType();
     
     if (dmimeType.toStdString()=="application/pdf"){ 
-        
         auto downloadPath = getSettingsManager()->getDownloadDir();
         fileName = downloadPath + "/" + defaultFileName;
         setDownloadInfo(fileName,dmimeType);

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -4,6 +4,9 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QWebEngineSettings>
+#include <QDesktopServices>
+
+
 
 KProfile::KProfile(QObject *parent) :
     QWebEngineProfile(parent)
@@ -13,22 +16,59 @@ KProfile::KProfile(QObject *parent) :
     settings()->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, true);
 }
 
+SettingsManager* getSettingsManager()
+{
+    return KiwixApp::instance()->getSettingsManager();
+}
+
+void KProfile::setDownloadInfo(const QString &fileName, const QString &mimeType)
+{
+    m_downloadInfo = std::make_pair(fileName, mimeType);
+}
+
+KProfile::DownloadInfo KProfile::getDownloadInfo() const
+{
+    return m_downloadInfo;
+}
+
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void KProfile::startDownload(QWebEngineDownloadItem* download)
 #else
 void KProfile::startDownload(QWebEngineDownloadRequest* download)
 #endif
-{
+{   
+    QString fileName;
     QString defaultFileName = download->url().fileName();
-    QString fileName = QFileDialog::getSaveFileName(KiwixApp::instance()->getMainWindow(),
-                                                       gt("save-file-as-window-title"), defaultFileName);
-    if (fileName.isEmpty()) {
-        return;
+
+    QString dmimeType = download->mimeType();
+    
+    if (dmimeType.toStdString()=="application/pdf"){ 
+        
+        auto downloadPath = getSettingsManager()->getDownloadDir();
+        fileName = downloadPath + "/" + defaultFileName;
+        setDownloadInfo(fileName,dmimeType);
+        
+        QFile file(fileName);
+
+        if (file.exists()){
+            QDesktopServices::openUrl(QUrl::fromLocalFile(fileName));
+            return;
+        }
     }
-    QString extension = "." + download->url().url().section('.', -1);
-    if (!fileName.endsWith(extension)) {
-        fileName.append(extension);
+
+    else{
+        fileName = QFileDialog::getSaveFileName(KiwixApp::instance()->getMainWindow(),
+                                                        gt("save-file-as-window-title"), defaultFileName);
+        if (fileName.isEmpty()) {
+            return;
+        }
+        QString extension = "." + download->url().url().section('.', -1);
+        if (!fileName.endsWith(extension)) {
+            fileName.append(extension);
+        }
+        setDownloadInfo(fileName,dmimeType);
     }
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     download->setPath(fileName);
 #else
@@ -44,6 +84,10 @@ void KProfile::startDownload(QWebEngineDownloadRequest* download)
 
 void KProfile::downloadFinished()
 {
+    KProfile::DownloadInfo dInfo = getDownloadInfo();
+    if (dInfo.second.toStdString()=="application/pdf"){
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dInfo.first));
+    }
     QMessageBox msgBox;
     msgBox.setText(gt("download-finished-message"));
     msgBox.exec();

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -80,7 +80,6 @@ bool KProfile::isNonReadableFile(QString mimeType)
             }
             setFileOpenChoice(fileName,false);
         }
-        
     }
     return fileName;
 }

--- a/src/kprofile.h
+++ b/src/kprofile.h
@@ -13,15 +13,23 @@
 class KProfile : public QWebEngineProfile
 {
     Q_OBJECT
-    typedef std::pair<QString, QString> DownloadInfo;
+    typedef std::pair<QString, bool> DownloadInfo;
+    
 public:
     KProfile(QObject *parent = nullptr);
-    void setDownloadInfo(const QString &fileName, const QString &mimeType);
-    DownloadInfo getDownloadInfo() const;
+    void setFileOpenChoice(QString fileName, bool choice);
+    DownloadInfo getFileOpenChoice() const;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QString getFileName(QWebEngineDownloadItem* download);
+#else
+    QString getFileName(QWebEngineDownloadRequest* download);
+#endif
+    bool isNonReadableFile(QString mimeType);
+    
 
 private:
     UrlSchemeHandler m_schemeHandler;
-    DownloadInfo m_downloadInfo;
+    DownloadInfo m_fileOpenChoice;
 
 signals:
 public slots:

--- a/src/kprofile.h
+++ b/src/kprofile.h
@@ -13,11 +13,15 @@
 class KProfile : public QWebEngineProfile
 {
     Q_OBJECT
+    typedef std::pair<QString, QString> DownloadInfo;
 public:
     KProfile(QObject *parent = nullptr);
+    void setDownloadInfo(const QString &fileName, const QString &mimeType);
+    DownloadInfo getDownloadInfo() const;
 
 private:
     UrlSchemeHandler m_schemeHandler;
+    DownloadInfo m_downloadInfo;
 
 signals:
 public slots:


### PR DESCRIPTION
Fixes #697 

Checks for the mimetype to verify that its a PDF, and downloads the PDF directly and opens it in a PDF reader.

Added functionality where, clicking a PDF link does the following:
1. Checks if there exists a downloaded copy of the PDF. If yes skip to step 3.
2. Downloads the PDF into the Download directory set by the user.
3. Open the PDF in a PDF reader, using `<QDesktopServices>` as suggested by @juuz0 

