### PR TITLE
Added nostrip to CONFIG to avoid illegal binary strips on WSL

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -8,6 +8,9 @@ QT       += core gui network
 QT       += webenginewidgets
 QT       += printsupport
 
+# Avoid stripping incompatible files, due to false identification as executables, on WSL
+DETECT_WSL = $$system(test -f /proc/sys/fs/binfmt_misc/WSLInterop && echo true || echo false)
+equals(DETECT_WSL , "true"): CONFIG += nostrip
 CONFIG += link_pkgconfig
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets


### PR DESCRIPTION
Fixes #1059

Added the `nostrip` flag to `CONFIG` in the `kiwix-desktop.pro` in case of WSL