### PR TITLE
Don't reset the webview on exiting search-in-page

### DIFF
--- a/src/findinpagebar.cpp
+++ b/src/findinpagebar.cpp
@@ -54,6 +54,7 @@ void FindInPageBar::findClose()
         return;
     auto page = current->page();
     page->findText("");
+    current->setFocus();
     close();
 }
 


### PR DESCRIPTION
Fixes #755

Just had to set the focus back to the current web view before closing the find-in-page bar.
