### PR TITLE
Library list pinning behavior

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -32,7 +32,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(app->getAction(KiwixApp::ToggleFullscreenAction), &QAction::triggered,
             this, &MainWindow::toggleFullScreen);
     connect(app->getAction(KiwixApp::ToggleReadingListAction), &QAction::toggled,
-            this, &MainWindow::when_ReadingList_toggled);
+            this, &MainWindow::readingListToggled);
     connect(app->getAction(KiwixApp::AboutAction), &QAction::triggered,
             mp_about, &QDialog::show);
     connect(app->getAction(KiwixApp::DonateAction), &QAction::triggered,
@@ -57,12 +57,11 @@ MainWindow::MainWindow(QWidget *parent) :
             mp_ui->mainToolBar, &TopWidget::updateBackForwardButtons);
     connect(mp_ui->tabBar, &TabBar::tabDisplayed,
             this, [=](TabType tabType) {
-                when_libraryPageDisplayed(tabType == TabType::LibraryTab);
+                tabChanged(tabType);
             });
 
     connect(mp_ui->tabBar, &TabBar::currentTitleChanged,
             &(mp_ui->mainToolBar->getSearchBar()), &SearchBar::currentTitleChanged);
-
     // This signal emited more often than the history really updated
     // but for now we have no better signal for it.
     connect(mp_ui->tabBar, &TabBar::currentTitleChanged,
@@ -120,8 +119,7 @@ bool MainWindow::eventFilter(QObject* /*object*/, QEvent* event)
     return false;
 }
 
-
-void MainWindow::when_ReadingList_toggled(bool state)
+void MainWindow::readingListToggled(bool state)
 {
     if (state) {
         mp_ui->sideBar->setCurrentWidget(mp_ui->readinglistbar);
@@ -132,19 +130,16 @@ void MainWindow::when_ReadingList_toggled(bool state)
     }
 }
 
-void MainWindow::when_libraryPageDisplayed(bool showed)
+void MainWindow::tabChanged(TabType tabType) 
 {
-    auto app = KiwixApp::instance();
-
-    // When library sidebar appeared, or hidden, reading list is always hidden.
-    app->getAction(KiwixApp::ToggleReadingListAction)->setChecked(false);
-
-    if (showed) {
+    QAction *readingList = KiwixApp::instance()->getAction(KiwixApp::ToggleReadingListAction);
+    if (tabType == TabType::SettingsTab) { 
+        mp_ui->sideBar->hide();    
+    } else if(tabType == TabType::LibraryTab) { 
         mp_ui->sideBar->setCurrentWidget(mp_ui->contentmanagerside);
         mp_ui->sideBar->show();
-    }
-    else {
-        mp_ui->sideBar->hide();
+    } else { 
+        readingListToggled(readingList->isChecked());
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,8 +31,8 @@ protected:
 
 private slots:
     void toggleFullScreen();
-    void when_ReadingList_toggled(bool state);
-    void when_libraryPageDisplayed(bool showed);
+    void tabChanged(TabBar::TabType);
+    void readingListToggled(bool state);
     void hideTabAndTop();
     void showTabAndTop();
 

--- a/src/readinglistbar.cpp
+++ b/src/readinglistbar.cpp
@@ -13,8 +13,19 @@ ReadingListBar::ReadingListBar(QWidget *parent) :
     ui->setupUi(this);
     connect(KiwixApp::instance()->getLibrary(), &Library::bookmarksChanged,
             this, &ReadingListBar::setupList);
-    connect(ui->listWidget, &QListWidget::itemActivated,
-            this, &ReadingListBar::on_itemActivated);
+    connect(ui->listWidget, &QListWidget::itemClicked,
+            this, &ReadingListBar::onItemClicked);
+    connect(ui->listWidget, &QListWidget::itemDoubleClicked,
+            this, &ReadingListBar::onItemDoubleClicked);
+    connect(ui->listWidget, &QListWidget::itemPressed, 
+            this, [this](QListWidgetItem* item) {
+                onItemPressed(item, QGuiApplication::mouseButtons());
+            });
+    connect(ui->listWidget, &QListWidget::itemActivated, 
+            this, [this](QListWidgetItem* item) {
+                onItemActivated(item, QGuiApplication::mouseButtons());
+            });
+
     setupList();
 
     ui->label->setText(gt("reading-list-title"));
@@ -24,7 +35,6 @@ ReadingListBar::~ReadingListBar()
 {
     delete ui;
 }
-
 
 void ReadingListBar::setupList()
 {
@@ -60,7 +70,41 @@ void ReadingListBar::setupList()
     }
 }
 
-void ReadingListBar::on_itemActivated(QListWidgetItem* item)
+// Receives single clicks
+void ReadingListBar::onItemClicked(QListWidgetItem* item)
+{
+    clickKind = 1;
+    QTimer::singleShot(QApplication::doubleClickInterval(), [=]() { // Give time for a double click be handled
+        if (clickKind == 1) {
+            openUrl(item, false);
+        }
+    });
+}
+
+// Receives double clicks
+void ReadingListBar::onItemDoubleClicked(QListWidgetItem* item)
+{ 
+    clickKind = 2;
+    openUrl(item, true);
+}
+
+// Receives single and middle click
+void ReadingListBar::onItemPressed(QListWidgetItem* item, Qt::MouseButtons buttons)
+{
+    if (buttons & Qt::MiddleButton) {
+        openUrl(item, true);
+    }
+}
+
+// Receives left clicks and activation key
+void ReadingListBar::onItemActivated(QListWidgetItem* item, Qt::MouseButtons buttons)
+{
+    if (!buttons) { // clicks are handled elsewhere, handle only the activation key case 
+        openUrl(item, true);
+    }
+}
+
+void ReadingListBar::openUrl(QListWidgetItem* item, bool newTab)
 {
     int index = ui->listWidget->row(item);
     auto bookmark = KiwixApp::instance()->getLibrary()->getBookmarks(true).at(index);
@@ -68,5 +112,5 @@ void ReadingListBar::on_itemActivated(QListWidgetItem* item)
     url.setScheme("zim");
     url.setHost(QString::fromStdString(bookmark.getBookId())+".zim");
     url.setPath(QString::fromStdString(bookmark.getUrl()));
-    KiwixApp::instance()->openUrl(url);
+    KiwixApp::instance()->openUrl(url, newTab);
 }

--- a/src/readinglistbar.h
+++ b/src/readinglistbar.h
@@ -18,9 +18,14 @@ public:
 
 public slots:
     void setupList();
-    void on_itemActivated(QListWidgetItem *item);
+    void onItemClicked(QListWidgetItem* item);
+    void onItemDoubleClicked(QListWidgetItem *item);
+    void onItemPressed(QListWidgetItem* item, Qt::MouseButtons buttons);
+    void onItemActivated(QListWidgetItem *item, Qt::MouseButtons buttons);
 private:
     Ui::readinglistbar *ui;
+    int clickKind;
+    void openUrl(QListWidgetItem* item, bool newTab);
 };
 
 #endif // READINGLISTBAR_H


### PR DESCRIPTION
This refactors the behavior of tab changes, to make sure the reading list stays pinned until the user closes it (should be hidden in library at all times)

Fixes #1078 