### PR TITLE
Handling of exceptions from kiwix::Downloader::close()

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -125,7 +125,12 @@ KiwixApp::~KiwixApp()
 {
     m_server.stop();
     if (mp_downloader) {
-        mp_downloader->close();
+        try {
+            mp_downloader->close();
+        } catch (const std::exception& err) {
+            std::cerr << "ERROR: Failed to save the downloader state: "
+                      << err.what() << std::endl;
+        }
         delete mp_downloader;
     }
     if (mp_manager) {


### PR DESCRIPTION
Fixes #694

If saving the downloader state during exit fails<sup>+</sup> then, instead of crashing, the following error is reported on `stderr`:

> ERROR: Failed to save the downloader state: Failed to serialize session to '/nonexistingdir/kiwix.session'.

---
<sup>+</sup>It can happen, for example, if `KIWIX_DATA_DIR` is set to a non-existing directory which in addition cannot be created due to permissions.