### PR TITLE
Remove -Werror.

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -18,8 +18,12 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = kiwix-desktop
 TEMPLATE = app
 
-QMAKE_CXXFLAGS += -std=c++17 -Werror
+QMAKE_CXXFLAGS += -std=c++17
 QMAKE_LFLAGS +=  -std=c++17
+
+!win32 {
+    QMAKE_CXXFLAGS += -Werror
+}
 
 # Also change resources/org.kiwix.desktop.appdata.xml
 DEFINES += VERSION="2.3.1"


### PR DESCRIPTION
`-Werror` make compilation fails on Windows.

The exact warning making the compilation failing is not clear.
See (https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/49600994 for example).

Compilation without `-Werror` is ok (https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/49601697)

Fix kiwix/kiwix-build#690