### PR TITLE
Handling of corrupted Xapian DB during search

### DIFF
--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -100,6 +100,25 @@ class IdNameMapper : public kiwix::NameMapper {
 };
 
 
+namespace
+{
+
+struct SearchResultsWithEstimatedMatchCount
+{
+    std::shared_ptr<zim::SearchResultSet> results;
+    int estimatedMatchCount = 0;
+};
+
+SearchResultsWithEstimatedMatchCount getSearchResults(zim::Search& s, int start, int pageLength)
+{
+    SearchResultsWithEstimatedMatchCount r;
+    r.estimatedMatchCount = s.getEstimatedMatches();
+    r.results = std::make_shared<zim::SearchResultSet>(s.getResults(start, pageLength));
+    return r;
+}
+
+} // unnamed namespace
+
 void
 UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
 {
@@ -131,10 +150,19 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
         request->fail(QWebEngineUrlRequestJob::UrlInvalid);
         return;
     }
+
+    SearchResultsWithEstimatedMatchCount searchResult;
+    try {
+        searchResult = getSearchResults(*search, start, pageLength);
+    } catch (...) {
+        request->fail(QWebEngineUrlRequestJob::RequestFailed);
+        return;
+    }
+
     kiwix::SearchRenderer renderer(
-        search->getResults(start, pageLength),
+        *searchResult.results,
         start,
-        search->getEstimatedMatches());
+        searchResult.estimatedMatchCount);
     renderer.setSearchPattern(searchQuery);
     renderer.setSearchBookQuery("content="+bookId.toStdString());
     renderer.setProtocolPrefix("zim://");


### PR DESCRIPTION
Fixes #1074

It was only full-text search that could throw an exception if the Xapian DB was corrupted. Suggestions operations ([`SuggestionSearch::getEstimatedMatches()`](https://github.com/openzim/libzim/blob/9.1.0/src/suggestion.cpp#L213-L221) and [`SuggestionResultSet SuggestionSearch::getResults()`](https://github.com/openzim/libzim/blob/9.1.0/src/suggestion.cpp#L232-L238)) don't let any exceptions escape `libzim` (but the error output may be confusing).

I tested the fix on the Ray Charles ZIM file with pinpoint corruption introduced in full-text and title index Xapian DBs ([zim_files_with_corrupted_xapiandb.zip](https://github.com/kiwix/kiwix-desktop/files/14959107/zim_files_with_corrupted_xapiandb.zip)).

### Testing with corrupted full-text index

1. Open `ray_charles.corrupted_ft_xapiandb.zim` (find it in [zim_files_with_corrupted_xapiandb.zip](https://github.com/kiwix/kiwix-desktop/files/14959107/zim_files_with_corrupted_xapiandb.zip)).
2. Search for **beatles**
3. Your should see the following error page
> This site can’t be reached
>
> The webpage at **zim://6f1d19d0-633f-087b-fb55-7ac324ff9baf.search?content=6f1d19d0-633f-087b-fb55-7ac324ff9baf&pattern=beatles** might be temporarily down or it may have moved permanently to a new web address.
>
> ERR_FAILED

### Testing with corrupted full-text index

1. Launch `kiwix-desktop` from the terminal
2. Open `ray_charles.corrupted_title_xapiandb.zim` (find it in [zim_files_with_corrupted_xapiandb.zip](https://github.com/kiwix/kiwix-desktop/files/14959107/zim_files_with_corrupted_xapiandb.zip)).
3. Type **bu** in the searchbar
4. The following errors should be printed in the terminal
> Query Parsing failed, Switching to search without index.
