### PR TITLE
Library::getArchive() returns a valid pointer or throws

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -60,7 +60,11 @@ QString Library::openBookFromPath(const QString &zimPath)
 
 std::shared_ptr<zim::Archive> Library::getArchive(const QString &zimId)
 {
-    return mp_library->getArchiveById(zimId.toStdString());
+    const auto archive =  mp_library->getArchiveById(zimId.toStdString());
+    if ( ! archive ) {
+        throw std::out_of_range("ZIM file doesn't exist (or cannot be opened)");
+    }
+    return archive;
 }
 
 std::shared_ptr<zim::Searcher> Library::getSearcher(const QString &zimId)

--- a/src/readinglistbar.cpp
+++ b/src/readinglistbar.cpp
@@ -39,9 +39,6 @@ void ReadingListBar::setupList()
         } catch (std::out_of_range& e) {
             continue;
         }
-        if ( !archive ) {
-            continue;
-        }
         try {
             auto illustration = archive->getIllustrationItem(48);
             std::string content = illustration.getData();


### PR DESCRIPTION
Fixes #893

The PR fixes crashes but not the confusing behaviour caused by missing ZIM files.