### PR TITLE
Fixed thumbnail display for books being downloaded

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -157,8 +157,7 @@ void ContentManager::restoreDownloads()
 {
     for ( const auto& bookId : mp_library->getBookIds() ) {
         const kiwix::Book& book = mp_library->getBookById(bookId);
-        const QString downloadId = QString::fromStdString(book.getDownloadId());
-        if ( ! downloadId.isEmpty() ) {
+        if ( ! book.getDownloadId().empty() ) {
             const auto newDownload = std::make_shared<DownloadState>();
             newDownload->paused = true;
             m_downloads.set(bookId, newDownload);
@@ -195,7 +194,6 @@ void ContentManager::updateModel()
     const auto bookIds = getBookIds();
     BookInfoList bookList;
     QStringList keys = {"title", "tags", "date", "id", "size", "description", "favicon"};
-    QIcon bookIcon;
     for (auto bookId : bookIds) {
         auto mp = getBookInfos(bookId, keys);
         bookList.append(mp);
@@ -418,9 +416,8 @@ ContentManager::BookInfo ContentManager::getBookInfos(QString id, const QStringL
 void ContentManager::openBookWithIndex(const QModelIndex &index)
 {
     try {
-        QString bookId;
         auto bookNode = static_cast<Node*>(index.internalPointer());
-        bookId = bookNode->getBookId();
+        const QString bookId = bookNode->getBookId();
         // throws std::out_of_range if the book isn't available in local library
         const kiwix::Book& book = mp_library->getBookById(bookId);
         if ( !book.getDownloadId().empty() )
@@ -444,7 +441,6 @@ void ContentManager::openBook(const QString &id)
         mp_library->removeBookFromLibraryById(id);
         tabBar->setCurrentIndex(0);
         emit(booksChanged());
-        return;
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -385,7 +385,6 @@ QVariant getBookAttribute(const kiwix::Book& b, const QString& a)
     if ( a == "date" )        return QString::fromStdString(b.getDate());
     if ( a == "url" )         return QString::fromStdString(b.getUrl());
     if ( a == "name" )        return QString::fromStdString(b.getName());
-    if ( a == "downloadId" )  return QString::fromStdString(b.getDownloadId());
     if ( a == "favicon")      return getFaviconDataOrUrl(b);
     if ( a == "size" )        return QString::number(b.getSize());
     if ( a == "tags" )        return getBookTags(b);
@@ -422,9 +421,9 @@ void ContentManager::openBookWithIndex(const QModelIndex &index)
         QString bookId;
         auto bookNode = static_cast<Node*>(index.internalPointer());
         bookId = bookNode->getBookId();
-        // check if the book is available in local library, will throw std::out_of_range if it isn't.
-        mp_library->getBookById(bookId);
-        if (getBookInfos(bookId, {"downloadId"})["downloadId"] != "")
+        // throws std::out_of_range if the book isn't available in local library
+        const kiwix::Book& book = mp_library->getBookById(bookId);
+        if ( !book.getDownloadId().empty() )
             return;
         openBook(bookId);
     } catch (std::out_of_range &e) {}

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -169,8 +169,7 @@ void ContentManagerDelegate::paint(QPainter *painter, const QStyleOptionViewItem
     try {
         const auto id = node->getBookId();
         const auto book = KiwixApp::instance()->getLibrary()->getBookById(id);
-        if(KiwixApp::instance()->getContentManager()->getBookInfos(id, {"downloadId"})["downloadId"] != "") {
-        } else {
+        if ( book.getDownloadId().empty() ) {
             button.text = gt("open");
         }
     } catch (std::out_of_range& e) {


### PR DESCRIPTION
When a book download starts, the book is entered into the local library for technical reasons and further attempts to get the thumbnail for that book are wrongfully - until the download has completed - served from the (partial) ZIM file. This results in the thumbnail of the book changing to a question mark.

This PR addresses that bug.