### PR TITLE
Declaration of USB (Unified States of Books)

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -218,7 +218,8 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
     QAction menuCancelBook(gt("cancel-download"), this);
     QAction menuOpenFolder(gt("open-folder"), this);
 
-    switch ( getBookState(id) ) {
+    const auto bookState = getBookState(id);
+    switch ( bookState ) {
     case BookState::DOWNLOAD_PAUSED:
         contextMenu.addAction(&menuResumeBook);
         contextMenu.addAction(&menuCancelBook);
@@ -230,10 +231,14 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
         break;
 
     case BookState::AVAILABLE_LOCALLY_AND_HEALTHY:
+    case BookState::ERROR_MISSING_ZIM_FILE:
+    case BookState::ERROR_CORRUPTED_ZIM_FILE:
         {
             const auto book = mp_library->getBookById(id);
             auto bookPath = QString::fromStdString(book.getPath());
-            contextMenu.addAction(&menuOpenBook);
+            if ( bookState == BookState::AVAILABLE_LOCALLY_AND_HEALTHY ) {
+                contextMenu.addAction(&menuOpenBook);
+            }
             contextMenu.addAction(&menuDeleteBook);
             contextMenu.addAction(&menuOpenFolder);
             connect(&menuOpenFolder, &QAction::triggered, [=]() {

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -20,6 +20,43 @@ public: // types
     typedef ContentManagerModel::BookInfo     BookInfo;
     typedef ContentManagerModel::BookInfoList BookInfoList;
 
+    enum class BookState
+    {
+        // Nothing known about a book with that id
+        INVALID,
+
+        // Only (some) metadata is available for the book, however neither a
+        // ZIM-file nor a URL is associated with it.
+        METADATA_ONLY,
+
+        // No ZIM file is associated with the book but a URL is provided.
+        AVAILABLE_ONLINE,
+
+        // The book is being downloaded.
+        DOWNLOADING,
+
+        // The book started downloading, but the download is currently paused.
+        DOWNLOAD_PAUSED,
+
+        // The book started downloading but the download was stopped due to
+        // errors.
+        DOWNLOAD_ERROR,
+
+        // A valid ZIM file path is associated with the book and no evidence
+        // about any issues with that ZIM file has so far been obtained.
+        AVAILABLE_LOCALLY_AND_HEALTHY,
+
+        // A ZIM file path is associated with the book but no such file seems
+        // to exist (may be caused by missing read permissions for the directory
+        // containing the ZIM file).
+        ERROR_MISSING_ZIM_FILE,
+
+        // A ZIM file is associated with the book but it cannot be opened
+        // due to issues with its content.
+        ERROR_CORRUPTED_ZIM_FILE
+    };
+
+
 public: // functions
     explicit ContentManager(Library* library, kiwix::Downloader *downloader, QObject *parent = nullptr);
     virtual ~ContentManager();
@@ -49,6 +86,7 @@ signals:
 public slots:
     QStringList getTranslations(const QStringList &keys);
     BookInfo getBookInfos(QString id, const QStringList &keys);
+    BookState getBookState(QString id);
     void openBook(const QString& id);
     void downloadBook(const QString& id);
     void downloadBook(const QString& id, QModelIndex index);

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -251,23 +251,21 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
 
     ContentManager& contentMgr = *KiwixApp::instance()->getContentManager();
     if (const auto downloadState = node->getDownloadState()) {
-        if (downloadState->paused) {
-            if (clickX < (x + w/2)) {
-                contentMgr.cancelBook(id);
-            } else {
-                contentMgr.resumeBook(id, index);
-            }
-        } else {
+        if ( !downloadState->paused ) {
             contentMgr.pauseBook(id, index);
+        } else if (clickX < (x + w/2)) {
+            contentMgr.cancelBook(id);
+        } else {
+            contentMgr.resumeBook(id, index);
         }
     } else {
-            try {
-                const auto book = KiwixApp::instance()->getLibrary()->getBookById(id);
-                contentMgr.openBook(id);
-            } catch (std::out_of_range& e) {
-                contentMgr.downloadBook(id, index);
-            }
-      }
+        try {
+            const auto book = KiwixApp::instance()->getLibrary()->getBookById(id);
+            contentMgr.openBook(id);
+        } catch (std::out_of_range& e) {
+            contentMgr.downloadBook(id, index);
+        }
+    }
 }
 
 QSize ContentManagerDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -249,22 +249,23 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
     int x = r.left();
     int w = r.width();
 
+    ContentManager& contentMgr = *KiwixApp::instance()->getContentManager();
     if (const auto downloadState = node->getDownloadState()) {
         if (downloadState->paused) {
             if (clickX < (x + w/2)) {
-                KiwixApp::instance()->getContentManager()->cancelBook(id);
+                contentMgr.cancelBook(id);
             } else {
-                KiwixApp::instance()->getContentManager()->resumeBook(id, index);
+                contentMgr.resumeBook(id, index);
             }
         } else {
-            KiwixApp::instance()->getContentManager()->pauseBook(id, index);
+            contentMgr.pauseBook(id, index);
         }
     } else {
             try {
                 const auto book = KiwixApp::instance()->getLibrary()->getBookById(id);
-                KiwixApp::instance()->getContentManager()->openBook(id);
+                contentMgr.openBook(id);
             } catch (std::out_of_range& e) {
-                KiwixApp::instance()->getContentManager()->downloadBook(id, index);
+                contentMgr.downloadBook(id, index);
             }
       }
 }

--- a/src/contentmanagerdelegate.h
+++ b/src/contentmanagerdelegate.h
@@ -15,6 +15,10 @@ public:
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) override;
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
+private: // functions
+    void paintBookState(QPainter *p, QRect r, const QModelIndex &index) const;
+    void paintButton(QPainter *p, const QRect &r, QString t) const;
+
 private:
     QScopedPointer<QPushButton> baseButton;
     QByteArray placeholderIcon;


### PR DESCRIPTION
Fixes the remaining part of #893 by implementing the proposal at https://github.com/kiwix/kiwix-desktop/issues/893#issuecomment-2091053574

In the current implementation there are no dedicated visual hints (icons, text) for local books with issues (missing or corrupted ZIM files) - instead the "open" action is disabled for such books.

Depends on #1097