### PR TITLE
BugFix: Compilation Failure for Qt6 Due to Deprecated Members 

### DIFF
--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -36,7 +36,7 @@ QVariant ContentManagerModel::data(const QModelIndex& index, int role) const
 
         r = getThumbnail(r);
 
-        if ( r.type() == QVariant::ByteArray )
+        if ( r.userType() == QMetaType::QByteArray )
             return r;
 
         const QString faviconUrl = r.toString();
@@ -136,7 +136,7 @@ void ContentManagerModel::setBooksData(const BookInfoList& data, const Downloads
 // QString) from where the actual data can be obtained.
 QVariant ContentManagerModel::getThumbnail(const QVariant& faviconEntry) const
 {
-    if ( faviconEntry.type() == QVariant::ByteArray )
+    if ( faviconEntry.userType() == QMetaType::QByteArray )
         return faviconEntry;
 
     const auto faviconUrl = faviconEntry.toString();


### PR DESCRIPTION
Fixes #1102

Tested on Qt 6.2.4.
```
src/contentmanagermodel.cpp:40:16: error: ‘class QVariant’ has no member named ‘type’; did you mean ‘typeId’?
   39 |         if ( r.type() == QVariant::ByteArray )
      |                ^~~~
      |                typeId
src/contentmanagermodel.cpp:40:36: error: ‘ByteArray’ is not a member of ‘QVariant’
   39 |         if ( r.type() == QVariant::ByteArray )
      |
```
QVariant.type() and QVariant::ByteArray has been [deprecated](https://doc.qt.io/qt-6.2/qvariant-obsolete.html). We will use the new function QVariant.typeId() and QMetaType::QByteArray from Qt6.

I recommend we have compilation pipelines to check both Qt versions.

Fix:
- Added macro to make the application still compatible with Qt 5
- Used equivalent new features from Qt 6 to replace the lines.