### PR TITLE
Fixed Whiteouts of Book Descriptions on Hover

### DIFF
--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -194,7 +194,7 @@ void ContentManagerDelegate::paintBookState(QPainter *p, const QStyleOptionViewI
 void ContentManagerDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QRect r = option.rect;
-    if (index.parent().isValid()) {
+    if (isDescriptionIndex(index)) {
         // additional info
         QRect nRect = r;
         auto viewWidth = KiwixApp::instance()->getContentManager()->getView()->getView()->width();
@@ -293,7 +293,7 @@ QSize ContentManagerDelegate::sizeHint(const QStyleOptionViewItem &option, const
 {
     Q_UNUSED(option);
 
-    if (index.parent().isValid()) {
+    if (isDescriptionIndex(index)) {
         return QSize(300, 70);
     }
     return QSize(50, 70);

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -285,10 +285,22 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
 
 QSize ContentManagerDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    Q_UNUSED(option);
+    if (isDescriptionIndex(index))
+    {
+        const auto treeView = KiwixApp::instance()->getContentManager()->getView()->getView();
 
-    if (isDescriptionIndex(index)) {
-        return QSize(300, 70);
+        const int width = treeView->header()->length() - 2*treeView->indentation();
+        // XXX: see QTreeView::padding in resources/css/_contentManager.css
+        const int verticalPadding = 4;
+        const int horizontalPadding = 4;
+        QRect descRect(0, 0, width - 2 * horizontalPadding, 0);
+
+        /* Based on the rectangle and text, find the best fitting size. */
+        QFontMetrics fm(option.font);
+        const QString text = index.data().toString();
+        const auto format = Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap;
+        const int textHeight = fm.boundingRect(descRect, format, text).height();
+        return QSize(width, std::max(textHeight + verticalPadding, 70));
     }
     return QSize(50, 70);
 }

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -193,15 +193,9 @@ void ContentManagerDelegate::paintBookState(QPainter *p, const QStyleOptionViewI
 
 void ContentManagerDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QRect r = option.rect;
-    if (isDescriptionIndex(index)) {
-        // additional info
-        QRect nRect = r;
-        auto viewWidth = KiwixApp::instance()->getContentManager()->getView()->getView()->width();
-        nRect.setWidth(viewWidth);
-        painter->drawText(nRect, Qt::AlignLeft | Qt::AlignVCenter, index.data(Qt::UserRole+1).toString());
-        return;
-    }
+    if (isDescriptionIndex(index))
+        return QStyledItemDelegate::paint(painter, option, index);
+
     QStyleOptionViewItem eOpt = option;
     if (index.column() == 1) {
         auto bFont = painter->font();

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -60,10 +60,13 @@ QVariant ContentManagerModel::data(const QModelIndex& index, int role) const
         return QVariant();
 
     const auto col = index.column();
-    const bool isThumbnailRequest = col == 0 && role == Qt::DecorationRole;
-    const bool otherDataRequest = col != 0 && (role == Qt::DisplayRole || role == Qt::UserRole+1 );
+    const bool isThumbnailRequest =
+        !isDescriptionIndex(index) && col == 0 && role == Qt::DecorationRole;
+    const bool isDescriptionRequest =
+        isDescriptionIndex(index) && col == 0 && role == Qt::DisplayRole;
+    const bool otherDataRequest = col != 0 && role == Qt::DisplayRole;
 
-    if ( !isThumbnailRequest && !otherDataRequest )
+    if ( !isThumbnailRequest && !otherDataRequest && !isDescriptionRequest )
         return QVariant();
 
     const auto item = static_cast<Node*>(index.internalPointer());

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -86,7 +86,7 @@ QVariant ContentManagerModel::data(const QModelIndex& index, int role) const
 Qt::ItemFlags ContentManagerModel::flags(const QModelIndex &index) const
 {
     Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index);
-    if (index.isValid() && index.parent().isValid()) {
+    if (isDescriptionIndex(index)) {
         return defaultFlags & ~Qt::ItemIsDropEnabled & ~Qt::ItemIsDragEnabled & ~Qt::ItemIsSelectable & ~Qt::ItemIsEditable & ~Qt::ItemIsUserCheckable;
     }
     return defaultFlags;

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -97,4 +97,9 @@ private: // data
     QMap<QString, QByteArray> m_iconMap;
 };
 
+inline bool isDescriptionIndex(const QModelIndex& index)
+{
+    return index.parent().isValid();
+}
+
 #endif // CONTENTMANAGERMODEL_H

--- a/src/contentmanagerview.cpp
+++ b/src/contentmanagerview.cpp
@@ -21,6 +21,7 @@ ContentManagerView::ContentManagerView(QWidget *parent)
 
     connect(mp_ui->m_view, &QTreeView::clicked, this, &ContentManagerView::onClicked);
     connect(mp_ui->m_view, &QTreeView::expanded, this, &ContentManagerView::onExpanded);
+    connect(this, &ContentManagerView::sizeHintChanged, managerDelegate, &QStyledItemDelegate::sizeHintChanged);
 }
 
 ContentManagerView::~ContentManagerView()
@@ -55,4 +56,22 @@ void ContentManagerView::onExpanded(QModelIndex index)
 {
     if (!mp_ui->m_view->isFirstColumnSpanned(0, index))
         mp_ui->m_view->setFirstColumnSpanned(0, index, true);
+}
+
+/**
+ * @brief Notify delegate to update size hint of the visible description rows.
+ */
+void ContentManagerView::updateSizeHint()
+{
+    auto view = this->getView();
+    if (!view->isVisible())
+        return;
+
+    auto visibleIndex = view->indexAt(view->rect().topLeft());
+    while (visibleIndex.isValid())
+    {
+        if (isDescriptionIndex(visibleIndex))
+            emit sizeHintChanged(visibleIndex);
+        visibleIndex = view->indexBelow(visibleIndex);
+    }
 }

--- a/src/contentmanagerview.cpp
+++ b/src/contentmanagerview.cpp
@@ -20,6 +20,7 @@ ContentManagerView::ContentManagerView(QWidget *parent)
     mp_ui->stackedWidget->setCurrentIndex(0);
 
     connect(mp_ui->m_view, &QTreeView::clicked, this, &ContentManagerView::onClicked);
+    connect(mp_ui->m_view, &QTreeView::expanded, this, &ContentManagerView::onExpanded);
 }
 
 ContentManagerView::~ContentManagerView()
@@ -48,4 +49,10 @@ void ContentManagerView::onClicked(QModelIndex index)
     } else {
         mp_ui->m_view->expand(zeroColIndex);
     }
+}
+
+void ContentManagerView::onExpanded(QModelIndex index)
+{
+    if (!mp_ui->m_view->isFirstColumnSpanned(0, index))
+        mp_ui->m_view->setFirstColumnSpanned(0, index, true);
 }

--- a/src/contentmanagerview.cpp
+++ b/src/contentmanagerview.cpp
@@ -19,17 +19,7 @@ ContentManagerView::ContentManagerView(QWidget *parent)
     loader = new KiwixLoader(mp_ui->loading);
     mp_ui->stackedWidget->setCurrentIndex(0);
 
-    connect(mp_ui->m_view, &QTreeView::clicked, [=](QModelIndex index) {
-        if (index.column() == (mp_ui->m_view->model()->columnCount() - 1))
-            return;
-
-        auto zeroColIndex = index.siblingAtColumn(0);
-        if (mp_ui->m_view->isExpanded(zeroColIndex)) {
-            mp_ui->m_view->collapse(zeroColIndex);
-        } else {
-            mp_ui->m_view->expand(zeroColIndex);
-        }
-    });
+    connect(mp_ui->m_view, &QTreeView::clicked, this, &ContentManagerView::onClicked);
 }
 
 ContentManagerView::~ContentManagerView()
@@ -44,5 +34,18 @@ void ContentManagerView::showLoader(bool show)
         loader->startAnimation();
     } else {
         loader->stopAnimation();
+    }
+}
+
+void ContentManagerView::onClicked(QModelIndex index)
+{
+    if (index.column() == (mp_ui->m_view->model()->columnCount() - 1))
+        return;
+
+    auto zeroColIndex = index.siblingAtColumn(0);
+    if (mp_ui->m_view->isExpanded(zeroColIndex)) {
+        mp_ui->m_view->collapse(zeroColIndex);
+    } else {
+        mp_ui->m_view->expand(zeroColIndex);
     }
 }

--- a/src/contentmanagerview.h
+++ b/src/contentmanagerview.h
@@ -21,6 +21,7 @@ public:
 public slots:
     void showLoader(bool show);
     void onClicked(QModelIndex index);
+    void onExpanded(QModelIndex index);
 
 private:
     Ui::contentmanagerview *mp_ui;

--- a/src/contentmanagerview.h
+++ b/src/contentmanagerview.h
@@ -22,6 +22,10 @@ public slots:
     void showLoader(bool show);
     void onClicked(QModelIndex index);
     void onExpanded(QModelIndex index);
+    void updateSizeHint();
+
+signals:
+    void sizeHintChanged(const QModelIndex& index);
 
 private:
     Ui::contentmanagerview *mp_ui;

--- a/src/contentmanagerview.h
+++ b/src/contentmanagerview.h
@@ -20,6 +20,7 @@ public:
 
 public slots:
     void showLoader(bool show);
+    void onClicked(QModelIndex index);
 
 private:
     Ui::contentmanagerview *mp_ui;

--- a/src/descriptionnode.cpp
+++ b/src/descriptionnode.cpp
@@ -36,7 +36,7 @@ int DescriptionNode::columnCount() const
 
 QVariant DescriptionNode::data(int column)
 {
-    if (column == 1)
+    if (column == 0)
         return m_desc;
     return QVariant();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -125,6 +125,12 @@ void MainWindow::closeEvent(QCloseEvent *event)
     QMainWindow::closeEvent(event);
 }
 
+void MainWindow::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+    KiwixApp::instance()->getContentManager()->getView()->updateSizeHint();
+}
+
 void MainWindow::readingListToggled(bool state)
 {
     if (state) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,6 +29,7 @@ public:
 protected:
     bool eventFilter(QObject* object, QEvent* event) override;
     void closeEvent(QCloseEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void toggleFullScreen();


### PR DESCRIPTION
Fix #1112

Changes:
- For the description row, only use one column to span across.
- DescriptionNode's data is now available on column index 0 instead of 1.
- Added word wrap to previously unwrapped text
- Prevented button actions from the last column to overflow into the description row.