### PR TITLE
Block External Content from Zim Web Pages

### DIFF
--- a/src/kprofile.h
+++ b/src/kprofile.h
@@ -2,6 +2,7 @@
 #define KPROFILE_H
 
 #include <QWebEngineProfile>
+#include <QWebEngineUrlRequestInterceptor>
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QWebEngineDownloadItem>
 #else
@@ -28,6 +29,23 @@ public slots:
     void startDownload(QWebEngineDownloadRequest*);
 #endif
     void downloadFinished();
+};
+
+/**
+ * @brief Intercepts and blocks a request if it is not native to our zim file.
+ * https://stackoverflow.com/questions/70721311/qwebview-disable-external-resources
+ */
+class ExternalReqInterceptor : public QWebEngineUrlRequestInterceptor
+{
+    Q_OBJECT
+public:
+    explicit ExternalReqInterceptor(QObject *parent = nullptr)
+        : QWebEngineUrlRequestInterceptor(parent)
+    {
+    }
+
+protected:
+    void interceptRequest(QWebEngineUrlRequestInfo &info) override;
 };
 
 #endif // KPROFILE_H


### PR DESCRIPTION
Fix #904
Changes:
- Added the toggle button to disable external content
- Refresh all opened articles when the button is toggled.
- Requests that do not start with "zim://" are blocked.

You can add this code to TabBar::openUrl to add an image, sourced online, to the top of each article.
```cpp
connect(webView, &QWebEngineView::loadFinished, [=](){
        webView->page()->runJavaScript(
            "var img = document.createElement(\"img\");"
            "img.src = \"https://picsum.photos/200/300\";"
            "var body = document.body;"
            "body.insertBefore(img, body.firstChild);"
        );
    });
```