### PR TITLE
Do not use removed `setHasBorderInFullScreen` with qt >= 6.0

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -15,7 +15,7 @@
 #include <QPrintDialog>
 #include <thread>
 #include <QMessageBox>
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QtPlatformHeaders\QWindowsWindowFunctions>
 #endif
 
@@ -96,7 +96,12 @@ void KiwixApp::init()
 #ifdef Q_OS_WIN
     QWindow *window = mp_mainWindow->windowHandle();
     if (window) {
-        QWindowsWindowFunctions::setHasBorderInFullScreen(window, true);
+        #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            QWindowsWindowFunctions::setHasBorderInFullScreen(window, true);
+        #else
+            HWND handle = reinterpret_cast<HWND>(window->winId());
+            SetWindowLongPtr(handle, GWL_STYLE, GetWindowLongPtr(handle, GWL_STYLE) | WS_BORDER);
+        #endif
     }
 #endif
     connect(this, &QtSingleApplication::messageReceived, this, [=](const QString &message) {


### PR DESCRIPTION
`QWindowsWindowFunctions` class has been removed in Qt 6.

See https://doc-snapshots.qt.io/qt5-5.15/windows-issues.html vs https://doc-snapshots.qt.io/qt6-6.2/windows-issues.html

I haven't found more specific documentation.

See https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/49874490 for a failing CI with Qt6.7 on Windows.