### PR TITLE
Asynchronous execution of download actions

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -47,6 +47,7 @@ SOURCES += \
     src/contentmanagermodel.cpp \
     src/contenttypefilter.cpp \
     src/descriptionnode.cpp \
+    src/downloadmanagement.cpp \
     src/findinpagebar.cpp \
     src/flowlayout.cpp \
     src/kiwixchoicebox.cpp \
@@ -93,6 +94,7 @@ HEADERS += \
     src/contentmanagerview.h \
     src/contenttypefilter.h \
     src/descriptionnode.h \
+    src/downloadmanagement.h \
     src/findinpagebar.h \
     src/flowlayout.h \
     src/kiwixchoicebox.h \

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -107,6 +107,8 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
     connect(this, &DownloadManager::downloadDisappeared,
             this, &ContentManager::downloadDisappeared);
 
+    connect(this, &DownloadManager::error, this, &ContentManager::handleError);
+
     if ( DownloadManager::downloadingFunctionalityAvailable() ) {
         startDownloadUpdaterThread();
     }
@@ -506,6 +508,11 @@ void ContentManager::updateDownload(QString bookId, const DownloadInfo& download
     }
 }
 
+void ContentManager::handleError(QString errSummary, QString errDetails)
+{
+    showErrorBox(KiwixAppError(errSummary, errDetails), mp_view);
+}
+
 void ContentManager::downloadBook(const QString &id)
 {
     kiwix::Book book = getRemoteOrLocalBook(id);
@@ -530,7 +537,7 @@ void ContentManager::startDownload(QString id)
     try {
         downloadId = DownloadManager::startDownload(book, downloadPath);
     } catch ( const KiwixAppError& err ) {
-        showErrorBox(err, mp_view);
+        emit error(err.summary(), err.details());
         return;
     }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -689,8 +689,7 @@ void ContentManager::reallyEraseBook(const QString& id, bool moveToTrash)
 {
     auto tabBar = KiwixApp::instance()->getTabWidget();
     tabBar->closeTabsByZimId(id);
-    kiwix::Book book = mp_library->getBookById(id);
-    eraseBookFilesFromComputer(book.getPath(), moveToTrash);
+    eraseBookFilesFromComputer(mp_library->getBookFilePath(id), moveToTrash);
     mp_library->removeBookFromLibraryById(id);
     mp_library->save();
     emit mp_library->bookmarksChanged();
@@ -767,7 +766,7 @@ void ContentManager::reallyCancelBook(const QString& id)
     removeDownload(id);
 
     // incompleted downloaded file should be perma deleted
-    eraseBookFilesFromComputer(download->getPath(), false);
+    eraseBookFilesFromComputer(mp_library->getBookFilePath(id), false);
     mp_library->removeBookFromLibraryById(id);
     mp_library->save();
     emit(oneBookChanged(id));

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -379,7 +379,7 @@ ContentManager::BookInfo ContentManager::getBookInfos(QString id, const QStringL
 ContentManager::BookState ContentManager::getBookState(QString bookId)
 {
     if ( const auto downloadState = DownloadManager::getDownloadState(bookId) ) {
-        return downloadState->status == DownloadState::PAUSED
+        return downloadState->getStatus() == DownloadState::PAUSED
              ? BookState::DOWNLOAD_PAUSED
              : BookState::DOWNLOADING;
              // TODO: a download may be in error state

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -593,9 +593,7 @@ void ContentManager::downloadBook(const QString &id, QModelIndex index)
     {
         downloadBook(id);
         auto node = getSharedPointer(static_cast<RowNode*>(index.internalPointer()));
-        const auto newDownload = std::make_shared<DownloadState>();
-        m_downloads.set(id, newDownload);
-        node->setDownloadState(newDownload);
+        node->setDownloadState(DownloadManager::getDownloadState(id));
     }
     catch ( const ContentManagerError& err )
     {
@@ -626,7 +624,7 @@ std::string ContentManager::startDownload(const kiwix::Book& book)
     auto downloadPath = getSettingsManager()->getDownloadDir();
     checkThatBookCanBeSaved(book, downloadPath);
 
-    return DownloadManager::startDownload(book.getUrl(), downloadPath.toStdString());
+    return DownloadManager::startDownload(book, downloadPath.toStdString());
 }
 
 void ContentManager::downloadBook(const QString &id)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -93,9 +93,8 @@ void openFileLocation(QString path, QWidget *parent = nullptr)
 
 } // unnamed namespace
 
-ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, QObject *parent)
-    : QObject(parent),
-      DownloadManager(library, downloader),
+ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
+    : DownloadManager(library, downloader),
       mp_library(library),
       mp_remoteLibrary(kiwix::Library::create()),
       m_remoteLibraryManager()

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -622,12 +622,7 @@ std::string ContentManager::startDownload(const kiwix::Book& book)
     auto downloadPath = getSettingsManager()->getDownloadDir();
     checkThatBookCanBeSaved(book, downloadPath);
 
-    typedef std::vector<std::pair<std::string, std::string>> DownloadOptions;
-
-    const DownloadOptions downloadOptions{{"dir", downloadPath.toStdString()}};
-
-    const auto d = mp_downloader->startDownload(book.getUrl(), downloadOptions);
-    return d->getDid();
+    return DownloadManager::startDownload(book.getUrl(), downloadPath.toStdString());
 }
 
 void ContentManager::downloadBook(const QString &id)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -622,13 +622,13 @@ void ContentManager::eraseBook(const QString& id)
 
 void ContentManager::pauseBook(const QString& id, QModelIndex index)
 {
-    DownloadManager::pauseDownload(id);
+    DownloadManager::addRequest(DownloadManager::PAUSE, id);
     managerModel->triggerDataUpdateAt(index);
 }
 
 void ContentManager::resumeBook(const QString& id, QModelIndex index)
 {
-    DownloadManager::resumeDownload(id);
+    DownloadManager::addRequest(DownloadManager::RESUME, id);
     managerModel->triggerDataUpdateAt(index);
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -527,7 +527,7 @@ void ContentManager::downloadStarted(const kiwix::Book& book, const std::string&
 
 void ContentManager::removeDownload(QString bookId)
 {
-    m_downloads.remove(bookId);
+    DownloadManager::removeDownload(bookId);
     managerModel->removeDownload(bookId);
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -149,7 +149,7 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
     connect(this, &DownloadManager::downloadDisappeared,
             this, &ContentManager::downloadDisappeared);
 
-    if ( mp_downloader ) {
+    if ( DownloadManager::downloadingFunctionalityAvailable() ) {
         startDownloadUpdaterThread();
     }
 }
@@ -605,7 +605,7 @@ std::string ContentManager::startDownload(const kiwix::Book& book)
 
 void ContentManager::downloadBook(const QString &id)
 {
-    if (!mp_downloader)
+    if ( ! DownloadManager::downloadingFunctionalityAvailable() )
         throwDownloadUnavailableError();
 
     const auto& book = getRemoteOrLocalBook(id);

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -32,47 +32,32 @@ SettingsManager* getSettingsManager()
     return KiwixApp::instance()->getSettingsManager();
 }
 
-class ContentManagerError : public std::runtime_error
-{
-public:
-    ContentManagerError(const QString& summary, const QString& details)
-        : std::runtime_error(summary.toStdString())
-        , m_details(details)
-    {}
-
-    QString summary() const { return QString::fromStdString(what()); }
-    QString details() const { return m_details; }
-
-private:
-    QString m_details;
-};
-
 void throwDownloadUnavailableError()
 {
-    throw ContentManagerError(gt("download-unavailable"),
-                              gt("download-unavailable-text"));
+    throw KiwixAppError(gt("download-unavailable"),
+                        gt("download-unavailable-text"));
 }
 
 void checkThatBookCanBeSaved(const kiwix::Book& book, QString targetDir)
 {
     const QFileInfo targetDirInfo(targetDir);
     if ( !targetDirInfo.isDir() ) {
-        throw ContentManagerError(gt("download-storage-error"),
-                                  gt("download-dir-missing"));
+        throw KiwixAppError(gt("download-storage-error"),
+                            gt("download-dir-missing"));
     }
 
     // XXX: This may lie under Windows
     // XXX: (see https://doc.qt.io/qt-5/qfile.html#platform-specific-issues)
     if ( !targetDirInfo.isWritable() ) {
-        throw ContentManagerError(gt("download-storage-error"),
-                                  gt("download-dir-not-writable"));
+        throw KiwixAppError(gt("download-storage-error"),
+                            gt("download-dir-not-writable"));
     }
 
     QStorageInfo storage(targetDir);
     auto bytesAvailable = storage.bytesAvailable();
     if (bytesAvailable == -1 || book.getSize() > (unsigned long long) bytesAvailable) {
-        throw ContentManagerError(gt("download-storage-error"),
-                                  gt("download-storage-error-text"));
+        throw KiwixAppError(gt("download-storage-error"),
+                            gt("download-storage-error-text"));
     }
 }
 
@@ -556,9 +541,9 @@ void ContentManager::downloadBook(const QString &id)
         managerModel->setDownloadState(id, downloadState);
         emit(oneBookChanged(id));
     }
-    catch ( const ContentManagerError& err )
+    catch ( const KiwixAppError& err )
     {
-        showInfoBox(err.summary(), err.details(), mp_view);
+        showErrorBox(err, mp_view);
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -733,11 +733,7 @@ void ContentManager::pauseBook(const QString& id, QModelIndex index)
 
 void ContentManager::resumeBook(const QString& id, QModelIndex index)
 {
-    auto& b = mp_library->getBookById(id);
-    auto download = mp_downloader->getDownload(b.getDownloadId());
-    if (download->getStatus() == kiwix::Download::K_PAUSED) {
-        download->resumeDownload();
-    }
+    DownloadManager::resumeDownload(id);
     managerModel->triggerDataUpdateAt(index);
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -727,28 +727,7 @@ void ContentManager::eraseBook(const QString& id)
 
 void ContentManager::pauseBook(const QString& id, QModelIndex index)
 {
-    const auto downloadId = mp_library->getBookById(id).getDownloadId();
-    if ( downloadId.empty() ) {
-        // Completion of the download has been detected (and its id was reset)
-        // before the pause-download action was triggered (most likely through
-        // the context menu which can stay open for an arbitrarily long time,
-        // or, unlikely, through the ⏸ button during the last milliseconds of
-        // the download progress).
-        return;
-    }
-
-    auto download = mp_downloader->getDownload(downloadId);
-    if (download->getStatus() == kiwix::Download::K_ACTIVE) {
-        try {
-            download->pauseDownload();
-        } catch (const kiwix::AriaError&) {
-            // Download has completed before the pause request was handled.
-            // Most likely the download was already complete at the time
-            // when ContentManager::pauseBook() started executing, but its
-            // completion was not yet detected (and/or handled) by the download
-            // updater thread.
-        }
-    }
+    DownloadManager::pauseDownload(id);
     managerModel->triggerDataUpdateAt(index);
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -597,9 +597,6 @@ QString ContentManager::getRemoteLibraryUrl() const
 
 void ContentManager::downloadBook(const QString &id)
 {
-    if ( ! DownloadManager::downloadingFunctionalityAvailable() )
-        throwDownloadUnavailableError();
-
     const auto& book = getRemoteOrLocalBook(id);
 
     const auto downloadPath = getSettingsManager()->getDownloadDir();

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -564,9 +564,11 @@ void ContentManager::updateDownload(QString bookId, const DownloadInfo& download
 {
     const auto downloadState = m_downloads.value(bookId);
     if ( downloadState ) {
+        const auto downloadPath = downloadInfo["path"].toString();
         if ( downloadInfo["status"].toString() == "completed" ) {
-            downloadCompleted(bookId, downloadInfo["path"].toString());
+            downloadCompleted(bookId, downloadPath);
         } else {
+            mp_library->updateBookBeingDownloaded(bookId, downloadPath);
             downloadState->update(downloadInfo);
             managerModel->updateDownload(bookId);
         }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -595,14 +595,6 @@ QString ContentManager::getRemoteLibraryUrl() const
                         : "http://" + host + ":" + QString::number(port);
 }
 
-std::string ContentManager::startDownload(const kiwix::Book& book)
-{
-    auto downloadPath = getSettingsManager()->getDownloadDir();
-    checkThatBookCanBeSaved(book, downloadPath);
-
-    return DownloadManager::startDownload(book, downloadPath.toStdString());
-}
-
 void ContentManager::downloadBook(const QString &id)
 {
     if ( ! DownloadManager::downloadingFunctionalityAvailable() )
@@ -610,11 +602,12 @@ void ContentManager::downloadBook(const QString &id)
 
     const auto& book = getRemoteOrLocalBook(id);
 
+    const auto downloadPath = getSettingsManager()->getDownloadDir();
+    checkThatBookCanBeSaved(book, downloadPath);
+
     std::string downloadId;
     try {
-        downloadId = startDownload(book);
-    } catch (const ContentManagerError& ) {
-        throw;
+        downloadId = DownloadManager::startDownload(book, downloadPath.toStdString());
     } catch (std::exception& e) {
         throwDownloadUnavailableError();
     }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -513,6 +513,7 @@ void ContentManager::downloadBook(const QString &id)
 
     std::string downloadId;
     try {
+        DownloadManager::checkThatBookCanBeDownloaded(book, downloadPath);
         downloadId = DownloadManager::startDownload(book, downloadPath);
     } catch ( const KiwixAppError& err ) {
         showErrorBox(err, mp_view);

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -143,8 +143,11 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
     setCategories();
     setLanguages();
 
-    connect(this, &ContentManager::downloadUpdated,
+    connect(this, &DownloadManager::downloadUpdated,
             this, &ContentManager::updateDownload);
+
+    connect(this, &DownloadManager::downloadDisappeared,
+            this, &ContentManager::downloadDisappeared);
 
     if ( mp_downloader ) {
         startDownloadUpdaterThread();
@@ -567,21 +570,6 @@ void ContentManager::updateDownload(QString bookId, const DownloadInfo& download
             downloadState->update(downloadInfo);
             managerModel->updateDownload(bookId);
         }
-    }
-}
-
-void ContentManager::updateDownloads()
-{
-    DownloadInfo downloadInfo;
-    for ( const auto& bookId : m_downloads.keys() ) {
-        try {
-            downloadInfo = getDownloadInfo(bookId);
-        } catch ( ... ) {
-            downloadDisappeared(bookId);
-            continue;
-        }
-
-        emit downloadUpdated(bookId, downloadInfo);
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -232,7 +232,7 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
         openBook(id);
     });
     connect(&menuDownloadBook, &QAction::triggered, [=]() {
-        downloadBook(id, index);
+        downloadBook(id);
     });
     connect(&menuPauseBook, &QAction::triggered, [=]() {
         pauseBook(id, index);
@@ -544,11 +544,14 @@ void ContentManager::updateDownload(QString bookId, const DownloadInfo& download
     }
 }
 
-void ContentManager::downloadBook(const QString &id, QModelIndex /*index*/)
+void ContentManager::downloadBook(const QString &id)
 {
+    kiwix::Book book = getRemoteOrLocalBook(id);
+    const auto downloadPath = getSettingsManager()->getDownloadDir();
+
     try
     {
-        downloadBook(id);
+        downloadBook(book, downloadPath);
         const auto downloadState = DownloadManager::getDownloadState(id);
         managerModel->setDownloadState(id, downloadState);
         emit(oneBookChanged(id));
@@ -577,11 +580,8 @@ QString ContentManager::getRemoteLibraryUrl() const
                         : "http://" + host + ":" + QString::number(port);
 }
 
-void ContentManager::downloadBook(const QString &id)
+void ContentManager::downloadBook(kiwix::Book book, const QString& downloadPath)
 {
-    kiwix::Book book = getRemoteOrLocalBook(id);
-
-    const auto downloadPath = getSettingsManager()->getDownloadDir();
     checkThatBookCanBeSaved(book, downloadPath);
 
     std::string downloadId;

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -95,7 +95,7 @@ void openFileLocation(QString path, QWidget *parent = nullptr)
 
 ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, QObject *parent)
     : QObject(parent),
-      DownloadManager(downloader),
+      DownloadManager(library, downloader),
       mp_library(library),
       mp_remoteLibrary(kiwix::Library::create()),
       m_remoteLibraryManager()
@@ -528,24 +528,6 @@ void ContentManager::openBookPreview(const QString &id)
     } catch (...) {}
 }
 
-namespace
-{
-
-QString downloadStatus2QString(kiwix::Download::StatusResult status)
-{
-    switch(status){
-    case kiwix::Download::K_ACTIVE:   return "active";
-    case kiwix::Download::K_WAITING:  return "waiting";
-    case kiwix::Download::K_PAUSED:   return "paused";
-    case kiwix::Download::K_ERROR:    return "error";
-    case kiwix::Download::K_COMPLETE: return "completed";
-    case kiwix::Download::K_REMOVED:  return "removed";
-    default:                          return "unknown";
-    }
-}
-
-} // unnamed namespace
-
 void ContentManager::downloadStarted(const kiwix::Book& book, const std::string& downloadId)
 {
     kiwix::Book bookCopy(book);
@@ -588,21 +570,6 @@ void ContentManager::downloadCompleted(QString bookId, QString path)
     } else {
         emit(mp_library->booksChanged());
     }
-}
-
-DownloadInfo ContentManager::getDownloadInfo(QString bookId) const
-{
-    auto& b = mp_library->getBookById(bookId);
-    const auto d = mp_downloader->getDownload(b.getDownloadId());
-    d->updateStatus(true);
-
-    return {
-             { "status"          , downloadStatus2QString(d->getStatus())   },
-             { "completedLength" , QString::number(d->getCompletedLength()) },
-             { "totalLength"     , QString::number(d->getTotalLength())     },
-             { "downloadSpeed"   , QString::number(d->getDownloadSpeed())   },
-             { "path"            , QString::fromStdString(d->getPath())     }
-    };
 }
 
 void ContentManager::updateDownload(QString bookId, const DownloadInfo& downloadInfo)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -145,16 +145,16 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
     switch ( bookState ) {
     case BookState::DOWNLOAD_PAUSED:
         if ( getDownloadState(id)->getStatus() == DownloadState::PAUSED ) {
-        contextMenu.addAction(&menuResumeBook);
-        contextMenu.addAction(&menuCancelBook);
+            contextMenu.addAction(&menuResumeBook);
+            contextMenu.addAction(&menuCancelBook);
         }
         contextMenu.addAction(&menuPreviewBook);
         break;
 
     case BookState::DOWNLOADING:
         if ( getDownloadState(id)->getStatus() == DownloadState::DOWNLOADING ) {
-        contextMenu.addAction(&menuPauseBook);
-        contextMenu.addAction(&menuCancelBook);
+            contextMenu.addAction(&menuPauseBook);
+            contextMenu.addAction(&menuCancelBook);
         }
         contextMenu.addAction(&menuPreviewBook);
         break;

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -144,14 +144,18 @@ void ContentManager::onCustomContextMenu(const QPoint &point)
     const auto bookState = getBookState(id);
     switch ( bookState ) {
     case BookState::DOWNLOAD_PAUSED:
+        if ( getDownloadState(id)->getStatus() == DownloadState::PAUSED ) {
         contextMenu.addAction(&menuResumeBook);
         contextMenu.addAction(&menuCancelBook);
+        }
         contextMenu.addAction(&menuPreviewBook);
         break;
 
     case BookState::DOWNLOADING:
+        if ( getDownloadState(id)->getStatus() == DownloadState::DOWNLOADING ) {
         contextMenu.addAction(&menuPauseBook);
         contextMenu.addAction(&menuCancelBook);
+        }
         contextMenu.addAction(&menuPreviewBook);
         break;
 
@@ -622,13 +626,13 @@ void ContentManager::eraseBook(const QString& id)
 
 void ContentManager::pauseBook(const QString& id, QModelIndex index)
 {
-    DownloadManager::addRequest(DownloadManager::PAUSE, id);
+    DownloadManager::addRequest(DownloadState::PAUSE, id);
     managerModel->triggerDataUpdateAt(index);
 }
 
 void ContentManager::resumeBook(const QString& id, QModelIndex index)
 {
-    DownloadManager::addRequest(DownloadManager::RESUME, id);
+    DownloadManager::addRequest(DownloadState::RESUME, id);
     managerModel->triggerDataUpdateAt(index);
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -187,7 +187,9 @@ void ContentManager::updateModel()
         auto mp = getBookInfos(bookId, keys);
         bookList.append(mp);
     }
-    managerModel->setBooksData(bookList, m_downloads);
+
+    const DownloadManager& downloadMgr = *this;
+    managerModel->setBooksData(bookList, downloadMgr);
 }
 
 void ContentManager::onCustomContextMenu(const QPoint &point)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -506,7 +506,7 @@ void ContentManager::downloadStarted(const kiwix::Book& book, const std::string&
 void ContentManager::removeDownload(QString bookId)
 {
     DownloadManager::removeDownload(bookId);
-    managerModel->removeDownload(bookId);
+    managerModel->setDownloadState(bookId, nullptr);
 }
 
 void ContentManager::downloadDisappeared(QString bookId)
@@ -553,13 +553,13 @@ void ContentManager::updateDownload(QString bookId, const DownloadInfo& download
     }
 }
 
-void ContentManager::downloadBook(const QString &id, QModelIndex index)
+void ContentManager::downloadBook(const QString &id, QModelIndex /*index*/)
 {
     try
     {
         downloadBook(id);
-        const auto node = static_cast<RowNode*>(index.internalPointer());
-        node->setDownloadState(DownloadManager::getDownloadState(id));
+        const auto downloadState = DownloadManager::getDownloadState(id);
+        managerModel->setDownloadState(id, downloadState);
     }
     catch ( const ContentManagerError& err )
     {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -101,6 +101,9 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
     connect(this, &DownloadManager::downloadUpdated,
             this, &ContentManager::updateDownload);
 
+    connect(this, &DownloadManager::downloadCancelled,
+            this, &ContentManager::downloadWasCancelled);
+
     connect(this, &DownloadManager::downloadDisappeared,
             this, &ContentManager::downloadDisappeared);
 
@@ -641,15 +644,12 @@ void ContentManager::cancelBook(const QString& id)
     auto text = gt("cancel-download-text");
     text = text.replace("{{ZIM}}", QString::fromStdString(mp_library->getBookById(id).getTitle()));
     showConfirmBox(gt("cancel-download"), text, mp_view, [=]() {
-        reallyCancelBook(id);
+        DownloadManager::addRequest(DownloadState::CANCEL, id);
     });
 }
 
-void ContentManager::reallyCancelBook(const QString& id)
+void ContentManager::downloadWasCancelled(const QString& id)
 {
-    if ( !DownloadManager::cancelDownload(id) )
-        return;
-
     removeDownload(id);
 
     // incompleted downloaded file should be perma deleted

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -511,9 +511,23 @@ void ContentManager::downloadBook(const QString &id)
     kiwix::Book book = getRemoteOrLocalBook(id);
     const auto downloadPath = getSettingsManager()->getDownloadDir();
 
-    std::string downloadId;
     try {
         DownloadManager::checkThatBookCanBeDownloaded(book, downloadPath);
+    } catch ( const KiwixAppError& err ) {
+        showErrorBox(err, mp_view);
+        return;
+    }
+
+    startDownload(id);
+}
+
+void ContentManager::startDownload(QString id)
+{
+    kiwix::Book book = getRemoteOrLocalBook(id);
+    const auto downloadPath = getSettingsManager()->getDownloadDir();
+
+    std::string downloadId;
+    try {
         downloadId = DownloadManager::startDownload(book, downloadPath);
     } catch ( const KiwixAppError& err ) {
         showErrorBox(err, mp_view);

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -744,25 +744,9 @@ void ContentManager::cancelBook(const QString& id)
 
 void ContentManager::reallyCancelBook(const QString& id)
 {
-    const auto downloadId = mp_library->getBookById(id).getDownloadId();
-    if ( downloadId.empty() ) {
-        // Completion of the download has been detected (and its id was reset)
-        // before the confirmation to cancel the download was granted.
+    if ( !DownloadManager::cancelDownload(id) )
         return;
-    }
 
-    auto download = mp_downloader->getDownload(downloadId);
-    try {
-        download->cancelDownload();
-    } catch (const kiwix::AriaError&) {
-        // Download has completed before the cancel request was handled.
-        // Most likely the download was already complete at the time
-        // when ContentManager::reallyCancelBook() started executing, but
-        // its completion was not yet detected (and/or handled) by the
-        // download updater thread (letting the code pass past the empty
-        // downloadId check above).
-        return;
-    }
     removeDownload(id);
 
     // incompleted downloaded file should be perma deleted

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -379,7 +379,7 @@ ContentManager::BookInfo ContentManager::getBookInfos(QString id, const QStringL
 ContentManager::BookState ContentManager::getBookState(QString bookId)
 {
     if ( const auto downloadState = DownloadManager::getDownloadState(bookId) ) {
-        return downloadState->paused
+        return downloadState->status == DownloadState::PAUSED
              ? BookState::DOWNLOAD_PAUSED
              : BookState::DOWNLOADING;
              // TODO: a download may be in error state

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -100,8 +100,6 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
       mp_remoteLibrary(kiwix::Library::create()),
       m_remoteLibraryManager()
 {
-    restoreDownloads();
-
     // mp_view will be passed to the tab who will take ownership,
     // so, we don't need to delete it.
     mp_view = new ContentManagerView();
@@ -151,18 +149,6 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
 
     if ( mp_downloader ) {
         startDownloadUpdaterThread();
-    }
-}
-
-void ContentManager::restoreDownloads()
-{
-    for ( const auto& bookId : mp_library->getBookIds() ) {
-        const kiwix::Book& book = mp_library->getBookById(bookId);
-        if ( ! book.getDownloadId().empty() ) {
-            const auto newDownload = std::make_shared<DownloadState>();
-            newDownload->paused = true;
-            m_downloads.set(bookId, newDownload);
-        }
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -467,7 +467,15 @@ void ContentManager::removeDownload(QString bookId)
 void ContentManager::downloadDisappeared(QString bookId)
 {
     removeDownload(bookId);
-    kiwix::Book bCopy(mp_library->getBookById(bookId));
+    kiwix::Book bCopy;
+    try {
+        bCopy = mp_library->getBookById(bookId);
+    } catch ( const std::out_of_range& ) {
+        // If the download has disappeared as a result of some
+        // obscure chain of events, the book may have disappeared too.
+        return;
+    }
+
     bCopy.setDownloadId("");
     mp_library->getKiwixLibrary()->addOrUpdateBook(bCopy);
     mp_library->save();

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -154,30 +154,6 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
     }
 }
 
-void DownloadManager::startDownloadUpdaterThread()
-{
-    // so that DownloadInfo can be copied across threads
-    qRegisterMetaType<DownloadInfo>("DownloadInfo");
-
-    mp_downloadUpdaterThread = QThread::create([=]() {
-       while ( mp_downloadUpdaterThread != nullptr ) {
-            updateDownloads();
-            QThread::msleep(1000);
-        }
-    });
-    mp_downloadUpdaterThread->start();
-}
-
-DownloadManager::~DownloadManager()
-{
-    if ( mp_downloadUpdaterThread )
-    {
-        QThread* t = mp_downloadUpdaterThread;
-        mp_downloadUpdaterThread = nullptr; // tell the thread to terminate
-        t->wait();
-    }
-}
-
 void ContentManager::updateModel()
 {
     const auto bookIds = getBookIds();

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -95,9 +95,9 @@ void openFileLocation(QString path, QWidget *parent = nullptr)
 
 ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, QObject *parent)
     : QObject(parent),
+      DownloadManager(downloader),
       mp_library(library),
       mp_remoteLibrary(kiwix::Library::create()),
-      mp_downloader(downloader),
       m_remoteLibraryManager()
 {
     restoreDownloads();
@@ -510,7 +510,7 @@ void ContentManager::openBook(const QString &id)
 }
 
 void ContentManager::openBookPreview(const QString &id)
-{   
+{
     try {
         QMutexLocker locker(&remoteLibraryLocker);
         const std::string &downloadUrl =

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -553,22 +553,12 @@ void ContentManager::updateDownload(QString bookId, const DownloadInfo& download
     }
 }
 
-namespace
-{
-
-std::shared_ptr<RowNode> getSharedPointer(RowNode* ptr)
-{
-    return std::static_pointer_cast<RowNode>(ptr->shared_from_this());
-}
-
-} // unnamed namespace
-
 void ContentManager::downloadBook(const QString &id, QModelIndex index)
 {
     try
     {
         downloadBook(id);
-        auto node = getSharedPointer(static_cast<RowNode*>(index.internalPointer()));
+        const auto node = static_cast<RowNode*>(index.internalPointer());
         node->setDownloadState(DownloadManager::getDownloadState(id));
     }
     catch ( const ContentManagerError& err )

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -48,8 +48,8 @@ void openFileLocation(QString path, QWidget *parent = nullptr)
 
 } // unnamed namespace
 
-ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
-    : DownloadManager(library, downloader),
+ContentManager::ContentManager(Library* library)
+    : DownloadManager(library),
       mp_library(library),
       mp_remoteLibrary(kiwix::Library::create()),
       m_remoteLibraryManager()

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -445,7 +445,7 @@ ContentManager::BookInfo ContentManager::getBookInfos(QString id, const QStringL
 
 ContentManager::BookState ContentManager::getBookState(QString bookId)
 {
-    if ( const auto downloadState = m_downloads.value(bookId) ) {
+    if ( const auto downloadState = DownloadManager::getDownloadState(bookId) ) {
         return downloadState->paused
              ? BookState::DOWNLOAD_PAUSED
              : BookState::DOWNLOADING;
@@ -562,7 +562,7 @@ void ContentManager::downloadCompleted(QString bookId, QString path)
 
 void ContentManager::updateDownload(QString bookId, const DownloadInfo& downloadInfo)
 {
-    const auto downloadState = m_downloads.value(bookId);
+    const auto downloadState = DownloadManager::getDownloadState(bookId);
     if ( downloadState ) {
         const auto downloadPath = downloadInfo["path"].toString();
         if ( downloadInfo["status"].toString() == "completed" ) {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -154,7 +154,7 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader)
     }
 }
 
-void ContentManager::startDownloadUpdaterThread()
+void DownloadManager::startDownloadUpdaterThread()
 {
     // so that DownloadInfo can be copied across threads
     qRegisterMetaType<DownloadInfo>("DownloadInfo");
@@ -168,7 +168,7 @@ void ContentManager::startDownloadUpdaterThread()
     mp_downloadUpdaterThread->start();
 }
 
-ContentManager::~ContentManager()
+DownloadManager::~DownloadManager()
 {
     if ( mp_downloadUpdaterThread )
     {

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -88,7 +88,6 @@ public slots:
     void openBook(const QString& id);
     void openBookPreview(const QString& id);
     void downloadBook(const QString& id);
-    void downloadBook(const QString& id, QModelIndex index);
     void updateLibrary();
     void setSearch(const QString& search);
     void setSortBy(const QString& sortBy, const bool sortOrderAsc);
@@ -124,6 +123,7 @@ private: // functions
     void removeDownload(QString bookId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
+    void downloadBook(kiwix::Book book, const QString& downloadPath);
 
 private: // data
     Library* mp_library;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -59,7 +59,6 @@ public: // types
 
 public: // functions
     ContentManager(Library* library, kiwix::Downloader *downloader);
-    virtual ~ContentManager();
 
     ContentManagerView* getView() { return mp_view; }
     void setLocal(bool local);
@@ -122,7 +121,6 @@ private: // functions
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
     QString getRemoteLibraryUrl() const;
 
-    void startDownloadUpdaterThread();
     std::string startDownload(const kiwix::Book& book);
     void removeDownload(QString bookId);
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
@@ -132,7 +130,6 @@ private: // functions
 private: // data
     Library* mp_library;
     kiwix::LibraryPtr mp_remoteLibrary;
-    QThread* mp_downloadUpdaterThread = nullptr;
     OpdsRequestManager m_remoteLibraryManager;
     ContentManagerView* mp_view;
     bool m_local = true;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -9,7 +9,7 @@
 #include "contentmanagermodel.h"
 #include "downloadmanagement.h"
 
-class ContentManager : public QObject, private DownloadManager
+class ContentManager : public DownloadManager
 {
     Q_OBJECT
     Q_PROPERTY(bool isLocal MEMBER m_local READ isLocal WRITE setLocal NOTIFY localChanged)
@@ -81,7 +81,6 @@ signals:
     void categoriesLoaded(QStringList);
     void languagesLoaded(LanguageList);
     void localChanged(const bool);
-    void downloadUpdated(QString bookId, const DownloadInfo& );
 
 public slots:
     QStringList getTranslations(const QStringList &keys);
@@ -105,7 +104,6 @@ public slots:
     void cancelBook(const QString& id);
     void onCustomContextMenu(const QPoint &point);
     void openBookWithIndex(const QModelIndex& index);
-    void updateDownloads();
     void updateDownload(QString bookId, const DownloadInfo& downloadInfo);
 
 private: // functions

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -130,7 +130,6 @@ private: // functions
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
-    DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
 
 private: // data

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -118,6 +118,7 @@ private: // functions
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
     QString getRemoteLibraryUrl() const;
 
+    void startDownload(QString bookId);
     void removeDownload(QString bookId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -121,7 +121,6 @@ private: // functions
     void removeDownload(QString bookId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
-    void downloadBook(kiwix::Book book, const QString& downloadPath);
 
 private: // data
     Library* mp_library;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -98,16 +98,14 @@ public slots:
     void updateCategories(const QString& content);
     void pauseBook(const QString& id, QModelIndex index);
     void resumeBook(const QString& id, QModelIndex index);
-    // cancelBook() asks for confirmation (reallyCancelBook() doesn't)
     void cancelBook(const QString& id);
     void onCustomContextMenu(const QPoint &point);
     void openBookWithIndex(const QModelIndex& index);
     void updateDownload(QString bookId, const DownloadInfo& downloadInfo);
+    void downloadWasCancelled(const QString& id);
 
 private: // functions
     QStringList getBookIds();
-    // reallyCancelBook() doesn't ask for confirmation (unlike cancelBook())
-    void reallyCancelBook(const QString& id);
     // reallyEraseBook() doesn't ask for confirmation (unlike eraseBook())
     void reallyEraseBook(const QString& id, bool moveToTrash);
     void eraseBookFilesFromComputer(const std::string& bookPath, bool moveToTrash);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -119,7 +119,7 @@ private: // functions
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
     QString getRemoteLibraryUrl() const;
 
-    void startDownload(QString bookId);
+    void startDownload(QString bookId) override;
     void removeDownload(QString bookId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -121,7 +121,6 @@ private: // functions
     const kiwix::Book& getRemoteOrLocalBook(const QString &id);
     QString getRemoteLibraryUrl() const;
 
-    std::string startDownload(const kiwix::Book& book);
     void removeDownload(QString bookId);
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
     void downloadDisappeared(QString bookId);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -130,7 +130,6 @@ private: // functions
     void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
-    void restoreDownloads();
 
 private: // data
     Library* mp_library;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -4,12 +4,12 @@
 #include <QObject>
 #include "library.h"
 #include "contentmanagerview.h"
-#include <kiwix/downloader.h>
 #include "opdsrequestmanager.h"
 #include "contenttypefilter.h"
 #include "contentmanagermodel.h"
+#include "downloadmanagement.h"
 
-class ContentManager : public QObject
+class ContentManager : public QObject, private DownloadManager
 {
     Q_OBJECT
     Q_PROPERTY(bool isLocal MEMBER m_local READ isLocal WRITE setLocal NOTIFY localChanged)
@@ -136,8 +136,6 @@ private: // functions
 private: // data
     Library* mp_library;
     kiwix::LibraryPtr mp_remoteLibrary;
-    kiwix::Downloader* mp_downloader;
-    ContentManagerModel::Downloads m_downloads;
     QThread* mp_downloadUpdaterThread = nullptr;
     OpdsRequestManager m_remoteLibraryManager;
     ContentManagerView* mp_view;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -58,7 +58,7 @@ public: // types
 
 
 public: // functions
-    ContentManager(Library* library, kiwix::Downloader *downloader);
+    ContentManager(Library* library);
 
     ContentManagerView* getView() { return mp_view; }
     void setLocal(bool local);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -58,7 +58,7 @@ public: // types
 
 
 public: // functions
-    explicit ContentManager(Library* library, kiwix::Downloader *downloader, QObject *parent = nullptr);
+    ContentManager(Library* library, kiwix::Downloader *downloader);
     virtual ~ContentManager();
 
     ContentManagerView* getView() { return mp_view; }

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -103,6 +103,7 @@ public slots:
     void openBookWithIndex(const QModelIndex& index);
     void updateDownload(QString bookId, const DownloadInfo& downloadInfo);
     void downloadWasCancelled(const QString& id);
+    void handleError(QString errSummary, QString errDetails);
 
 private: // functions
     QStringList getBookIds();

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -122,7 +122,6 @@ private: // functions
     QString getRemoteLibraryUrl() const;
 
     void removeDownload(QString bookId);
-    void downloadStarted(const kiwix::Book& book, const std::string& downloadId);
     void downloadDisappeared(QString bookId);
     void downloadCompleted(QString bookId, QString path);
 

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -129,7 +129,7 @@ void showDownloadProgress(QPainter *painter, QRect box, const DownloadState& dow
     double progress  = (double) (downloadInfo.progress) / 100;
     progress = -progress;
     auto completedLength = downloadInfo.completedLength;
-    auto downloadSpeed = downloadInfo.downloadSpeed;
+    auto downloadSpeed = downloadInfo.getDownloadSpeed();
 
     if (downloadInfo.status == DownloadState::PAUSED) {
         createResumeSymbol(painter, dcl.pauseResumeButtonRect);

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -131,7 +131,7 @@ void showDownloadProgress(QPainter *painter, QRect box, const DownloadState& dow
     auto completedLength = downloadInfo.completedLength;
     auto downloadSpeed = downloadInfo.downloadSpeed;
 
-    if (downloadInfo.paused) {
+    if (downloadInfo.status == DownloadState::PAUSED) {
         createResumeSymbol(painter, dcl.pauseResumeButtonRect);
         createCancelButton(painter, dcl.cancelButtonRect);
     } else {

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -131,7 +131,7 @@ void showDownloadProgress(QPainter *painter, QRect box, const DownloadState& dow
     auto completedLength = downloadInfo.completedLength;
     auto downloadSpeed = downloadInfo.getDownloadSpeed();
 
-    if (downloadInfo.status == DownloadState::PAUSED) {
+    if (downloadInfo.getStatus() == DownloadState::PAUSED) {
         createResumeSymbol(painter, dcl.pauseResumeButtonRect);
         createCancelButton(painter, dcl.cancelButtonRect);
     } else {

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -256,19 +256,19 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
 
     case ContentManager::BookState::DOWNLOADING:
         if ( downloadState->getStatus() == DownloadState::DOWNLOADING ) {
-        if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {
-            contentMgr.pauseBook(id, index);
-        }
+            if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {
+                contentMgr.pauseBook(id, index);
+            }
         }
         return;
 
     case ContentManager::BookState::DOWNLOAD_PAUSED:
         if ( downloadState->getStatus() == DownloadState::PAUSED ) {
-        if ( dcl.cancelButtonRect.contains(clickPoint) ) {
-             contentMgr.cancelBook(id);
-        } else if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {
-             contentMgr.resumeBook(id, index);
-        }
+            if ( dcl.cancelButtonRect.contains(clickPoint) ) {
+                 contentMgr.cancelBook(id);
+            } else if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {
+                 contentMgr.resumeBook(id, index);
+            }
         }
         return;
 

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -221,25 +221,14 @@ bool ContentManagerDelegate::editorEvent(QEvent *event, QAbstractItemModel *mode
     if(event->type() == QEvent::MouseButtonRelease )
     {
         QMouseEvent * e = (QMouseEvent *)event;
-        int clickX = portutils::getX(*e);
-        int clickY = portutils::getY(*e);
-
-        QRect r = option.rect;
-        int x,y,w,h;
-        x = r.left();
-        y = r.top();
-        w = r.width();
-        h = r.height();
-
         if (e->button() == Qt::MiddleButton && index.column() != 5) {
             KiwixApp::instance()->getContentManager()->openBookWithIndex(index);
             return true;
         }
 
-        const auto lastColumnClicked = ((index.column() == 5) && (clickX > x && clickX < x + w)
-                                                        && (clickY > y && clickY < y + h));
+        const QPoint clickPoint(portutils::getX(*e), portutils::getY(*e));
 
-        if (lastColumnClicked)
+        if ( index.column() == 5 && option.rect.contains(clickPoint, true) )
             handleLastColumnClicked(index, e, option);
     }
 

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -262,7 +262,7 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
         return contentMgr.openBook(id);
 
     case ContentManager::BookState::AVAILABLE_ONLINE:
-        return contentMgr.downloadBook(id, index);
+        return contentMgr.downloadBook(id);
 
     case ContentManager::BookState::DOWNLOADING:
         if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {

--- a/src/contentmanagerdelegate.cpp
+++ b/src/contentmanagerdelegate.cpp
@@ -134,7 +134,7 @@ void showDownloadProgress(QPainter *painter, QRect box, const DownloadState& dow
     if (downloadInfo.getStatus() == DownloadState::PAUSED) {
         createResumeSymbol(painter, dcl.pauseResumeButtonRect);
         createCancelButton(painter, dcl.cancelButtonRect);
-    } else {
+    } else if (downloadInfo.getStatus() == DownloadState::DOWNLOADING) {
         createPauseSymbol(painter, dcl.pauseResumeButtonRect);
         createDownloadStats(painter, box, downloadSpeed, completedLength);
     }
@@ -239,6 +239,7 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
 {
     const auto node = static_cast<RowNode*>(index.internalPointer());
     const auto id = node->getBookId();
+    const auto downloadState = node->getDownloadState();
 
     const int clickX = portutils::getX(*mouseEvent);
     const int clickY = portutils::getY(*mouseEvent);
@@ -254,16 +255,20 @@ void ContentManagerDelegate::handleLastColumnClicked(const QModelIndex& index, Q
         return contentMgr.downloadBook(id);
 
     case ContentManager::BookState::DOWNLOADING:
+        if ( downloadState->getStatus() == DownloadState::DOWNLOADING ) {
         if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {
             contentMgr.pauseBook(id, index);
+        }
         }
         return;
 
     case ContentManager::BookState::DOWNLOAD_PAUSED:
+        if ( downloadState->getStatus() == DownloadState::PAUSED ) {
         if ( dcl.cancelButtonRect.contains(clickPoint) ) {
              contentMgr.cancelBook(id);
         } else if ( dcl.pauseResumeButtonRect.contains(clickPoint) ) {
              contentMgr.resumeBook(id, index);
+        }
         }
         return;
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -265,14 +265,14 @@ void ContentManagerModel::triggerDataUpdateAt(QModelIndex index)
     emit dataChanged(index, index);
 }
 
-void ContentManagerModel::removeDownload(QString bookId)
+void ContentManagerModel::setDownloadState(QString bookId, std::shared_ptr<DownloadState> ds)
 {
     const auto it = bookIdToRowMap.constFind(bookId);
     if ( it == bookIdToRowMap.constEnd() )
         return;
 
     const size_t row = it.value();
-    getRowNode(row)->setDownloadState(nullptr);
+    getRowNode(row)->setDownloadState(ds);
     triggerDataUpdateAt( this->index(row, 5) );
 }
 

--- a/src/contentmanagermodel.cpp
+++ b/src/contentmanagermodel.cpp
@@ -153,7 +153,7 @@ QVariant ContentManagerModel::headerData(int section, Qt::Orientation orientatio
     }
 }
 
-void ContentManagerModel::setBooksData(const BookInfoList& data, const Downloads& downloads)
+void ContentManagerModel::setBooksData(const BookInfoList& data, const DownloadManager& downloadMgr)
 {
     rootNode = std::shared_ptr<RowNode>(new RowNode({tr("Icon"), tr("Name"), tr("Date"), tr("Size"), tr("Content Type"), tr("Download")}, "", std::weak_ptr<RowNode>()));
     beginResetModel();
@@ -162,7 +162,7 @@ void ContentManagerModel::setBooksData(const BookInfoList& data, const Downloads
         const auto rowNode = createNode(bookItem);
 
         // Restore download state during model updates (filtering, etc)
-        rowNode->setDownloadState(downloads.value(rowNode->getBookId()));
+        rowNode->setDownloadState(downloadMgr.getDownloadState(rowNode->getBookId()));
 
         bookIdToRowMap[bookItem["id"].toString()] = rootNode->childCount();
         rootNode->appendChild(rowNode);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -5,10 +5,9 @@
 #include <QModelIndex>
 #include <QVariant>
 #include <QIcon>
-#include <QMutex>
-#include <QMutexLocker>
 #include "thumbnaildownloader.h"
 #include "rownode.h"
+#include "downloadmanagement.h"
 #include <memory>
 
 class ContentManager;
@@ -24,39 +23,7 @@ public: // types
     typedef QMap<QString, QVariant> BookInfo;
     typedef QList<BookInfo>         BookInfoList;
 
-    // BookId -> DownloadState map
-    class Downloads
-    {
-    private:
-        typedef std::shared_ptr<DownloadState> DownloadStatePtr;
-        typedef QMap<QString, DownloadStatePtr> ImplType;
-
-    public:
-        void set(const QString& id, DownloadStatePtr d) {
-            const QMutexLocker threadSafetyGuarantee(&mutex);
-            impl[id] = d;
-        }
-
-        DownloadStatePtr value(const QString& id) const {
-            const QMutexLocker threadSafetyGuarantee(&mutex);
-            return impl.value(id);
-        }
-
-        QList<QString> keys() const {
-            const QMutexLocker threadSafetyGuarantee(&mutex);
-            return impl.keys();
-        }
-
-        void remove(const QString& id) {
-            const QMutexLocker threadSafetyGuarantee(&mutex);
-            impl.remove(id);
-        }
-
-    private:
-        ImplType impl;
-        mutable QMutex mutex;
-    };
-
+    typedef DownloadManager::Downloads Downloads;
 
 public: // functions
     explicit ContentManagerModel(ContentManager* contentMgr);

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -23,8 +23,6 @@ public: // types
     typedef QMap<QString, QVariant> BookInfo;
     typedef QList<BookInfo>         BookInfoList;
 
-    typedef DownloadManager::Downloads Downloads;
-
 public: // functions
     explicit ContentManagerModel(ContentManager* contentMgr);
     ~ContentManagerModel();
@@ -38,7 +36,7 @@ public: // functions
     QModelIndex parent(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-    void setBooksData(const BookInfoList& data, const Downloads& downloads);
+    void setBooksData(const BookInfoList& data, const DownloadManager& downloadMgr);
     bool hasChildren(const QModelIndex &parent) const override;
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 

--- a/src/contentmanagermodel.h
+++ b/src/contentmanagermodel.h
@@ -45,7 +45,7 @@ public: // functions
 public slots:
     void updateImage(QString bookId, QString url, QByteArray imageData);
     void triggerDataUpdateAt(QModelIndex index);
-    void removeDownload(QString bookId);
+    void setDownloadState(QString bookId, std::shared_ptr<DownloadState> ds);
     void updateDownload(QString bookId);
 
 private: // functions

--- a/src/contentmanagerview.cpp
+++ b/src/contentmanagerview.cpp
@@ -22,6 +22,12 @@ ContentManagerView::ContentManagerView(QWidget *parent)
     connect(mp_ui->m_view, &QTreeView::clicked, this, &ContentManagerView::onClicked);
     connect(mp_ui->m_view, &QTreeView::expanded, this, &ContentManagerView::onExpanded);
     connect(this, &ContentManagerView::sizeHintChanged, managerDelegate, &QStyledItemDelegate::sizeHintChanged);
+
+    // Needed to reveal the situation with downloads not being updated timely
+    // (due to aria2c becoming unresponsive when saving to slow storage)
+    QTimer *timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, [this]() { this->update(); });
+    timer->start(1000);
 }
 
 ContentManagerView::~ContentManagerView()

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -172,3 +172,8 @@ bool DownloadManager::cancelDownload(const QString& bookId)
         return false;
     }
 }
+
+void DownloadManager::removeDownload(QString bookId)
+{
+    m_downloads.remove(bookId);
+}

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -1,0 +1,34 @@
+#include "downloadmanagement.h"
+
+////////////////////////////////////////////////////////////////////////////////
+// DowloadState
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+QString convertToUnits(double bytes)
+{
+    QStringList units = {"bytes", "KB", "MB", "GB", "TB", "PB", "EB"};
+    int unitIndex = 0;
+    while (bytes >= 1024 && unitIndex < units.size()) {
+        bytes /= 1024;
+        unitIndex++;
+    }
+
+    const auto preciseBytes = QString::number(bytes, 'g', 3);
+    return preciseBytes + " " + units[unitIndex];
+}
+
+} // unnamed namespace
+
+void DownloadState::update(const DownloadInfo& downloadInfos)
+{
+    double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
+    percent *= 100;
+    percent = QString::number(percent, 'g', 3).toDouble();
+    auto completedLength = convertToUnits(downloadInfos["completedLength"].toDouble());
+    auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toDouble()) + "/s";
+    const bool paused = downloadInfos["status"] == "paused";
+    *this = {percent, completedLength, downloadSpeed, paused};
+}

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -137,6 +137,9 @@ DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
 
 std::string DownloadManager::startDownload(const kiwix::Book& book, const std::string& downloadDirPath)
 {
+    if ( ! DownloadManager::downloadingFunctionalityAvailable() )
+        throw std::runtime_error("Downloading functionality is not available");
+
     typedef std::vector<std::pair<std::string, std::string>> DownloadOptions;
 
     const std::string& url = book.getUrl();

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -99,9 +99,25 @@ void DownloadState::changeState(Action action)
 // DowloadManager
 ////////////////////////////////////////////////////////////////////////////////
 
-DownloadManager::DownloadManager(const Library* lib, kiwix::Downloader *downloader)
+namespace
+{
+
+kiwix::Downloader* createDownloader()
+{
+    try {
+        return new kiwix::Downloader();
+    } catch (std::exception& e) {
+        QMessageBox::critical(nullptr, gt("error-downloader-window-title"),
+        gt("error-downloader-launch-message") + "<br><br>" + e.what());
+        return nullptr;
+    }
+}
+
+} // unnamed namespace
+
+DownloadManager::DownloadManager(const Library* lib)
     : mp_library(lib)
-    , mp_downloader(downloader)
+    , mp_downloader(createDownloader())
 {
     restoreDownloads();
 }
@@ -122,7 +138,7 @@ DownloadManager::~DownloadManager()
 
 bool DownloadManager::downloadingFunctionalityAvailable() const
 {
-    return mp_downloader != nullptr;
+    return mp_downloader.get() != nullptr;
 }
 
 void DownloadManager::processDownloadActions()

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -32,3 +32,11 @@ void DownloadState::update(const DownloadInfo& downloadInfos)
     const bool paused = downloadInfos["status"] == "paused";
     *this = {percent, completedLength, downloadSpeed, paused};
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// DowloadManager
+////////////////////////////////////////////////////////////////////////////////
+
+DownloadManager::DownloadManager(kiwix::Downloader *downloader)
+    : mp_downloader(downloader)
+{}

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -257,13 +257,16 @@ void checkThatBookCanBeSaved(const kiwix::Book& book, QString targetDir)
 } // unnamed namespace
 
 
-std::string DownloadManager::startDownload(const kiwix::Book& book, const QString& downloadDirPath)
+void DownloadManager::checkThatBookCanBeDownloaded(const kiwix::Book& book, const QString& downloadDirPath)
 {
     if ( ! DownloadManager::downloadingFunctionalityAvailable() )
         throwDownloadUnavailableError();
 
     checkThatBookCanBeSaved(book, downloadDirPath);
+}
 
+std::string DownloadManager::startDownload(const kiwix::Book& book, const QString& downloadDirPath)
+{
     typedef std::vector<std::pair<std::string, std::string>> DownloadOptions;
 
     const std::string& url = book.getUrl();

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -95,7 +95,9 @@ void DownloadManager::startDownloadUpdaterThread()
 
     mp_downloadUpdaterThread = QThread::create([=]() {
        while ( mp_downloadUpdaterThread != nullptr ) {
-            updateDownloads();
+            for ( const auto& bookId : m_downloads.keys() ) {
+                updateDownload(bookId);
+            }
             QThread::msleep(1000);
         }
     });
@@ -114,19 +116,17 @@ void DownloadManager::restoreDownloads()
     }
 }
 
-void DownloadManager::updateDownloads()
+void DownloadManager::updateDownload(QString bookId)
 {
     DownloadInfo downloadInfo;
-    for ( const auto& bookId : m_downloads.keys() ) {
-        try {
-            downloadInfo = getDownloadInfo(bookId);
-        } catch ( ... ) {
-            emit downloadDisappeared(bookId);
-            continue;
-        }
-
-        emit downloadUpdated(bookId, downloadInfo);
+    try {
+        downloadInfo = getDownloadInfo(bookId);
+    } catch ( ... ) {
+        emit downloadDisappeared(bookId);
+        return;
     }
+
+    emit downloadUpdated(bookId, downloadInfo);
 }
 
 namespace

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -130,3 +130,11 @@ void DownloadManager::pauseDownload(const QString& bookId)
     }
 }
 
+void DownloadManager::resumeDownload(const QString& bookId)
+{
+    auto& b = mp_library->getBookById(bookId);
+    auto download = mp_downloader->getDownload(b.getDownloadId());
+    if (download->getStatus() == kiwix::Download::K_PAUSED) {
+        download->resumeDownload();
+    }
+}

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -40,7 +40,21 @@ void DownloadState::update(const DownloadInfo& downloadInfos)
 DownloadManager::DownloadManager(const Library* lib, kiwix::Downloader *downloader)
     : mp_library(lib)
     , mp_downloader(downloader)
-{}
+{
+    restoreDownloads();
+}
+
+void DownloadManager::restoreDownloads()
+{
+    for ( const auto& bookId : mp_library->getBookIds() ) {
+        const kiwix::Book& book = mp_library->getBookById(bookId);
+        if ( ! book.getDownloadId().empty() ) {
+            const auto newDownload = std::make_shared<DownloadState>();
+            newDownload->paused = true;
+            m_downloads.set(bookId, newDownload);
+        }
+    }
+}
 
 namespace
 {

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -131,7 +131,7 @@ void DownloadManager::processDownloadActions()
         const Request req = m_requestQueue.dequeue();
         if ( !req.bookId.isEmpty() ) {
             switch ( req.action ) {
-            case DownloadState::START:  /* startDownload(req.bookId); */ break;  // API problem
+            case DownloadState::START:  startDownload(req.bookId);  break;
             case DownloadState::PAUSE:  pauseDownload(req.bookId);  break;
             case DownloadState::RESUME: resumeDownload(req.bookId); break;
             case DownloadState::CANCEL: cancelDownload(req.bookId); break;
@@ -280,12 +280,15 @@ std::string DownloadManager::startDownload(const kiwix::Book& book, const QStrin
     } catch (std::exception& e) {
         throwDownloadUnavailableError();
     }
-    m_downloads.set(bookId, std::make_shared<DownloadState>());
     return downloadId;
 }
 
 void DownloadManager::addRequest(Action action, QString bookId)
 {
+    if ( action == DownloadState::START ) {
+        m_downloads.set(bookId, std::make_shared<DownloadState>());
+    }
+
     if ( const auto downloadState = getDownloadState(bookId) ) {
         m_requestQueue.enqueue({action, bookId});
         if ( action != DownloadState::UPDATE ) {

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -56,6 +56,11 @@ DownloadManager::~DownloadManager()
     }
 }
 
+bool DownloadManager::downloadingFunctionalityAvailable() const
+{
+    return mp_downloader != nullptr;
+}
+
 void DownloadManager::startDownloadUpdaterThread()
 {
     // so that DownloadInfo can be copied across threads

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -104,13 +104,16 @@ DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
     };
 }
 
-std::string DownloadManager::startDownload(const std::string& url, const std::string& downloadDirPath)
+std::string DownloadManager::startDownload(const kiwix::Book& book, const std::string& downloadDirPath)
 {
     typedef std::vector<std::pair<std::string, std::string>> DownloadOptions;
 
+    const std::string& url = book.getUrl();
+    const QString bookId = QString::fromStdString(book.getId());
     const DownloadOptions downloadOptions{{"dir", downloadDirPath}};
 
     const auto d = mp_downloader->startDownload(url, downloadOptions);
+    m_downloads.set(bookId, std::make_shared<DownloadState>());
     return d->getDid();
 }
 

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -136,7 +136,6 @@ void DownloadManager::restoreDownloads()
         const kiwix::Book& book = mp_library->getBookById(bookId);
         if ( ! book.getDownloadId().empty() ) {
             const auto newDownload = std::make_shared<DownloadState>();
-            newDownload->status = DownloadState::UNKNOWN;
             m_downloads.set(bookId, newDownload);
         }
     }

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -104,6 +104,16 @@ DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
     };
 }
 
+std::string DownloadManager::startDownload(const std::string& url, const std::string& downloadDirPath)
+{
+    typedef std::vector<std::pair<std::string, std::string>> DownloadOptions;
+
+    const DownloadOptions downloadOptions{{"dir", downloadDirPath}};
+
+    const auto d = mp_downloader->startDownload(url, downloadOptions);
+    return d->getDid();
+}
+
 void DownloadManager::pauseDownload(const QString& bookId)
 {
     const auto downloadId = mp_library->getBookById(bookId).getDownloadId();

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -56,6 +56,21 @@ void DownloadManager::restoreDownloads()
     }
 }
 
+void DownloadManager::updateDownloads()
+{
+    DownloadInfo downloadInfo;
+    for ( const auto& bookId : m_downloads.keys() ) {
+        try {
+            downloadInfo = getDownloadInfo(bookId);
+        } catch ( ... ) {
+            emit downloadDisappeared(bookId);
+            continue;
+        }
+
+        emit downloadUpdated(bookId, downloadInfo);
+    }
+}
+
 namespace
 {
 

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -1,6 +1,7 @@
 #ifndef DOWNLOADMANAGEMENT_H
 #define DOWNLOADMANAGEMENT_H
 
+#include <QObject>
 #include <QMap>
 #include <QMutex>
 #include <QMutexLocker>
@@ -27,8 +28,10 @@ public:
     void update(const DownloadInfo& info);
 };
 
-class DownloadManager
+class DownloadManager : public QObject
 {
+    Q_OBJECT
+
 public: // types
 
     // BookId -> DownloadState map
@@ -69,6 +72,11 @@ public: // functions
 
     DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
+    void updateDownloads();
+
+signals:
+    void downloadUpdated(QString bookId, const DownloadInfo& );
+    void downloadDisappeared(QString bookId);
 
 protected: // data
     const Library* const     mp_library;

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QVariant>
 
+#include <chrono>
 #include <memory>
 
 #include <kiwix/downloader.h>
@@ -18,7 +19,7 @@ typedef QMap<QString, QVariant> DownloadInfo;
 
 class DownloadState
 {
-public:
+public: // types
     enum Status {
         UNKNOWN,
         WAITING,
@@ -27,13 +28,23 @@ public:
         PAUSED
     };
 
+
+public: // data
+
     double progress = 0;
     QString completedLength;
-    QString downloadSpeed;
     Status status = UNKNOWN;
 
-public:
+public: // functions
     void update(const DownloadInfo& info);
+    QString getDownloadSpeed() const;
+
+    // time in seconds since last update
+    double timeSinceLastUpdate() const;
+
+private: // data
+    QString downloadSpeed;
+    std::chrono::steady_clock::time_point lastUpdated;
 };
 
 class DownloadManager : public QObject

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -71,7 +71,8 @@ public: // types
         DOWNLOADING,
         PAUSE_REQUESTED,
         PAUSED,
-        RESUME_REQUESTED
+        RESUME_REQUESTED,
+        CANCEL_REQUESTED
     };
 
 public: // data
@@ -157,7 +158,6 @@ public: // functions
 
     // returns the download id
     std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
-    bool cancelDownload(const QString& bookId);
     void removeDownload(QString bookId);
 
     DownloadStatePtr getDownloadState(QString bookId) const
@@ -167,6 +167,7 @@ public: // functions
 
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );
+    void downloadCancelled(QString bookId);
     void downloadDisappeared(QString bookId);
 
 private: // types
@@ -187,6 +188,7 @@ private: // functions
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
     void updateDownload(QString bookId);
+    void cancelDownload(const QString& bookId);
 
 private: // data
     const Library* const     mp_library;

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -1,0 +1,22 @@
+#ifndef DOWNLOADMANAGEMENT_H
+#define DOWNLOADMANAGEMENT_H
+
+#include <QMap>
+#include <QString>
+#include <QVariant>
+
+typedef QMap<QString, QVariant> DownloadInfo;
+
+class DownloadState
+{
+public:
+    double progress = 0;
+    QString completedLength;
+    QString downloadSpeed;
+    bool paused = false;
+
+public:
+    void update(const DownloadInfo& info);
+};
+
+#endif // DOWNLOADMANAGEMENT_H

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -144,7 +144,7 @@ private:
     };
 
 public: // functions
-    DownloadManager(const Library* lib, kiwix::Downloader *downloader);
+    explicit DownloadManager(const Library* lib);
     virtual ~DownloadManager();
 
     bool downloadingFunctionalityAvailable() const;
@@ -200,7 +200,7 @@ private: // functions
 
 private: // data
     const Library* const     mp_library;
-    kiwix::Downloader* const mp_downloader;
+    const std::unique_ptr<kiwix::Downloader> mp_downloader;
     Downloads                m_downloads;
     QThread*                 mp_downloadUpdaterThread = nullptr;
     RequestQueue             m_requestQueue;

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -11,6 +11,8 @@
 
 #include <kiwix/downloader.h>
 
+#include "library.h"
+
 typedef QMap<QString, QVariant> DownloadInfo;
 
 class DownloadState
@@ -63,9 +65,12 @@ public: // types
     };
 
 public: // functions
-    explicit DownloadManager(kiwix::Downloader *downloader);
+    DownloadManager(const Library* lib, kiwix::Downloader *downloader);
+
+    DownloadInfo getDownloadInfo(QString bookId) const;
 
 protected: // data
+    const Library* const     mp_library;
     kiwix::Downloader* const mp_downloader;
     Downloads                m_downloads;
 };

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -81,7 +81,7 @@ public: // functions
     void updateDownloads();
 
     // returns the download id
-    std::string startDownload(const kiwix::Book& book, const std::string& downloadDirPath);
+    std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
     bool cancelDownload(const QString& bookId);

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -79,6 +79,7 @@ public: // functions
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
     bool cancelDownload(const QString& bookId);
+    void removeDownload(QString bookId);
 
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -97,7 +97,6 @@ public: // functions
 
     DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
-    void updateDownloads();
 
     // returns the download id
     std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
@@ -114,6 +113,9 @@ public: // functions
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );
     void downloadDisappeared(QString bookId);
+
+private: // functions
+    void updateDownload(QString bookId);
 
 private: // data
     const Library* const     mp_library;

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -19,10 +19,18 @@ typedef QMap<QString, QVariant> DownloadInfo;
 class DownloadState
 {
 public:
+    enum Status {
+        UNKNOWN,
+        WAITING,
+        DOWNLOAD_ERROR,
+        DOWNLOADING,
+        PAUSED
+    };
+
     double progress = 0;
     QString completedLength;
     QString downloadSpeed;
-    bool paused = false;
+    Status status = UNKNOWN;
 
 public:
     void update(const DownloadInfo& info);

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -70,6 +70,9 @@ private:
 
 public: // functions
     DownloadManager(const Library* lib, kiwix::Downloader *downloader);
+    virtual ~DownloadManager();
+
+    void startDownloadUpdaterThread();
 
     DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
@@ -97,6 +100,7 @@ protected: // data
 
 private:
     Downloads                m_downloads;
+    QThread*                 mp_downloadUpdaterThread = nullptr;
 };
 
 #endif // DOWNLOADMANAGEMENT_H

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -84,6 +84,13 @@ public: // functions
     QString getDownloadSpeed() const;
     Status getStatus() const { return status; }
     void changeState(Action action);
+    bool stateChangeHasBeenRequested() const
+    {
+       return status == PAUSE_REQUESTED
+           || status == RESUME_REQUESTED
+           || status == CANCEL_REQUESTED;
+    }
+    bool isLateUpdateInfo(const DownloadInfo& info) const;
 
     // time in seconds since last update
     double timeSinceLastUpdate() const;

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -156,6 +156,10 @@ public: // functions
 
     void addRequest(Action action, QString bookId);
 
+    // Throws a KiwixAppError in case of any foreseeable problem preventing a
+    // successful download
+    void checkThatBookCanBeDownloaded(const kiwix::Book& book, const QString& downloadDirPath);
+
     // returns the download id
     std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
     void removeDownload(QString bookId);

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -74,6 +74,7 @@ public: // functions
     void restoreDownloads();
     void updateDownloads();
     void pauseDownload(const QString& bookId);
+    void resumeDownload(const QString& bookId);
 
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -62,21 +62,21 @@ public: // types
         PAUSED
     };
 
-
 public: // data
 
     double progress = 0;
     QString completedLength;
-    Status status = UNKNOWN;
 
 public: // functions
     void update(const DownloadInfo& info);
     QString getDownloadSpeed() const;
+    Status getStatus() const { return status; }
 
     // time in seconds since last update
     double timeSinceLastUpdate() const;
 
 private: // data
+    Status status = UNKNOWN;
     QString downloadSpeed;
     std::chrono::steady_clock::time_point lastUpdated;
 };

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -54,12 +54,22 @@ private: // data
 class DownloadState
 {
 public: // types
+    enum Action {
+        START,
+        PAUSE,
+        RESUME,
+        CANCEL,
+        UPDATE
+    };
+
     enum Status {
         UNKNOWN,
         WAITING,
         DOWNLOAD_ERROR,
         DOWNLOADING,
-        PAUSED
+        PAUSE_REQUESTED,
+        PAUSED,
+        RESUME_REQUESTED
     };
 
 public: // data
@@ -71,6 +81,7 @@ public: // functions
     void update(const DownloadInfo& info);
     QString getDownloadSpeed() const;
     Status getStatus() const { return status; }
+    void changeState(Action action);
 
     // time in seconds since last update
     double timeSinceLastUpdate() const;
@@ -87,15 +98,7 @@ class DownloadManager : public QObject
 
 public: // types
     typedef std::shared_ptr<DownloadState> DownloadStatePtr;
-
-    enum Action
-    {
-        START,
-        PAUSE,
-        RESUME,
-        CANCEL,
-        UPDATE
-    };
+    typedef DownloadState::Action Action;
 
 private:
     // BookId -> DownloadState map

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -160,8 +160,6 @@ public: // functions
     // successful download
     void checkThatBookCanBeDownloaded(const kiwix::Book& book, const QString& downloadDirPath);
 
-    // returns the download id
-    std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
     void removeDownload(QString bookId);
 
     DownloadStatePtr getDownloadState(QString bookId) const
@@ -174,6 +172,10 @@ signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );
     void downloadCancelled(QString bookId);
     void downloadDisappeared(QString bookId);
+
+protected:
+    // returns the download id
+    std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
 
 private: // types
     struct Request
@@ -190,6 +192,7 @@ private: // types
 
 private: // functions
     void processDownloadActions();
+    virtual void startDownload(QString bookId) = 0;
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
     void updateDownload(QString bookId);

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -73,6 +73,9 @@ public: // functions
     DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
     void updateDownloads();
+
+    // returns the download id
+    std::string startDownload(const std::string& url, const std::string& downloadDirPath);
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
 

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -68,6 +68,7 @@ public: // functions
     DownloadManager(const Library* lib, kiwix::Downloader *downloader);
 
     DownloadInfo getDownloadInfo(QString bookId) const;
+    void restoreDownloads();
 
 protected: // data
     const Library* const     mp_library;

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -72,6 +72,8 @@ public: // functions
     DownloadManager(const Library* lib, kiwix::Downloader *downloader);
     virtual ~DownloadManager();
 
+    bool downloadingFunctionalityAvailable() const;
+
     void startDownloadUpdaterThread();
 
     DownloadInfo getDownloadInfo(QString bookId) const;
@@ -94,11 +96,9 @@ signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );
     void downloadDisappeared(QString bookId);
 
-protected: // data
+private: // data
     const Library* const     mp_library;
     kiwix::Downloader* const mp_downloader;
-
-private:
     Downloads                m_downloads;
     QThread*                 mp_downloadUpdaterThread = nullptr;
 };

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -170,6 +170,7 @@ public: // functions
     }
 
 signals:
+    void error(QString errSummary, QString errDetails);
     void downloadUpdated(QString bookId, const DownloadInfo& );
     void downloadCancelled(QString bookId);
     void downloadDisappeared(QString bookId);

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -9,6 +9,8 @@
 
 #include <memory>
 
+#include <kiwix/downloader.h>
+
 typedef QMap<QString, QVariant> DownloadInfo;
 
 class DownloadState
@@ -59,6 +61,13 @@ public: // types
         ImplType impl;
         mutable QMutex mutex;
     };
+
+public: // functions
+    explicit DownloadManager(kiwix::Downloader *downloader);
+
+protected: // data
+    kiwix::Downloader* const mp_downloader;
+    Downloads                m_downloads;
 };
 
 #endif // DOWNLOADMANAGEMENT_H

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -88,6 +88,15 @@ class DownloadManager : public QObject
 public: // types
     typedef std::shared_ptr<DownloadState> DownloadStatePtr;
 
+    enum Action
+    {
+        START,
+        PAUSE,
+        RESUME,
+        CANCEL,
+        UPDATE
+    };
+
 private:
     // BookId -> DownloadState map
     class Downloads
@@ -132,10 +141,10 @@ public: // functions
     DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
 
+    void addRequest(Action action, QString bookId);
+
     // returns the download id
     std::string startDownload(const kiwix::Book& book, const QString& downloadDirPath);
-    void pauseDownload(const QString& bookId);
-    void resumeDownload(const QString& bookId);
     bool cancelDownload(const QString& bookId);
     void removeDownload(QString bookId);
 
@@ -149,10 +158,18 @@ signals:
     void downloadDisappeared(QString bookId);
 
 private: // types
-    typedef ThreadSafeQueue<QString> RequestQueue;
+    struct Request
+    {
+        Action  action;
+        QString bookId;
+    };
+
+    typedef ThreadSafeQueue<Request> RequestQueue;
 
 private: // functions
     void processDownloadActions();
+    void pauseDownload(const QString& bookId);
+    void resumeDownload(const QString& bookId);
     void updateDownload(QString bookId);
 
 private: // data

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -35,6 +35,7 @@ class DownloadManager : public QObject
 public: // types
     typedef std::shared_ptr<DownloadState> DownloadStatePtr;
 
+private:
     // BookId -> DownloadState map
     class Downloads
     {

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -78,6 +78,7 @@ public: // functions
     std::string startDownload(const std::string& url, const std::string& downloadDirPath);
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
+    bool cancelDownload(const QString& bookId);
 
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -33,12 +33,12 @@ class DownloadManager : public QObject
     Q_OBJECT
 
 public: // types
+    typedef std::shared_ptr<DownloadState> DownloadStatePtr;
 
     // BookId -> DownloadState map
     class Downloads
     {
     private:
-        typedef std::shared_ptr<DownloadState> DownloadStatePtr;
         typedef QMap<QString, DownloadStatePtr> ImplType;
 
     public:
@@ -80,6 +80,11 @@ public: // functions
     void resumeDownload(const QString& bookId);
     bool cancelDownload(const QString& bookId);
     void removeDownload(QString bookId);
+
+    DownloadStatePtr getDownloadState(QString bookId) const
+    {
+        return m_downloads.value(bookId);
+    }
 
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -76,7 +76,7 @@ public: // functions
     void updateDownloads();
 
     // returns the download id
-    std::string startDownload(const std::string& url, const std::string& downloadDirPath);
+    std::string startDownload(const kiwix::Book& book, const std::string& downloadDirPath);
     void pauseDownload(const QString& bookId);
     void resumeDownload(const QString& bookId);
     bool cancelDownload(const QString& bookId);
@@ -94,6 +94,8 @@ signals:
 protected: // data
     const Library* const     mp_library;
     kiwix::Downloader* const mp_downloader;
+
+private:
     Downloads                m_downloads;
 };
 

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -73,6 +73,7 @@ public: // functions
     DownloadInfo getDownloadInfo(QString bookId) const;
     void restoreDownloads();
     void updateDownloads();
+    void pauseDownload(const QString& bookId);
 
 signals:
     void downloadUpdated(QString bookId, const DownloadInfo& );

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -28,7 +28,6 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
       m_profile(),
       m_libraryDirectory(findLibraryDirectory()),
       m_library(m_libraryDirectory),
-      mp_downloader(nullptr),
       mp_manager(nullptr),
       mp_mainWindow(nullptr),
       mp_nameMapper(std::make_shared<kiwix::UpdatableNameMapper>(m_library.getKiwixLibrary(), false)),
@@ -66,13 +65,7 @@ void KiwixApp::loadAndInstallTranslations(QTranslator& translator, const QString
 
 void KiwixApp::init()
 {
-    try {
-        mp_downloader = new kiwix::Downloader();
-    } catch (std::exception& e) {
-        QMessageBox::critical(nullptr, gt("error-downloader-window-title"),
-        gt("error-downloader-launch-message") + "<br><br>" + e.what());
-    }
-    mp_manager = new ContentManager(&m_library, mp_downloader);
+    mp_manager = new ContentManager(&m_library);
     mp_manager->setLocal(!m_library.getBookIds().isEmpty());
 
     auto icon = QIcon();
@@ -130,9 +123,6 @@ void KiwixApp::init()
 KiwixApp::~KiwixApp()
 {
     m_server.stop();
-    if (mp_downloader) {
-        delete mp_downloader;
-    }
     if (mp_manager) {
         delete mp_manager;
     }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -131,12 +131,6 @@ KiwixApp::~KiwixApp()
 {
     m_server.stop();
     if (mp_downloader) {
-        try {
-            mp_downloader->close();
-        } catch (const std::exception& err) {
-            std::cerr << "ERROR: Failed to save the downloader state: "
-                      << err.what() << std::endl;
-        }
         delete mp_downloader;
     }
     if (mp_manager) {
@@ -234,7 +228,7 @@ void KiwixApp::openZimFile(const QString &zimfile)
     QString _zimfile;
     if (zimfile.isEmpty()) {
         QString importDir = mp_session->value("zim-import-dir").toString();
-        if (importDir.isEmpty()) { 
+        if (importDir.isEmpty()) {
             importDir = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
             if (importDir.isEmpty()) { importDir = QDir::currentPath(); }
         }

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -78,7 +78,6 @@ public:
     Library* getLibrary() { return &m_library; }
     MainWindow* getMainWindow() { return mp_mainWindow; }
     ContentManager* getContentManager() { return mp_manager; }
-    kiwix::Downloader* getDownloader() { return mp_downloader; }
     TabBar* getTabWidget() { return getMainWindow()->getTabBar(); }
     QAction* getAction(Actions action);
     QString getLibraryDirectory() { return m_libraryDirectory; };
@@ -113,7 +112,6 @@ private:
     KProfile m_profile;
     QString m_libraryDirectory;
     Library m_library;
-    kiwix::Downloader* mp_downloader;
     ContentManager* mp_manager;
     MainWindow* mp_mainWindow;
     QErrorMessage* mp_errorDialog;

--- a/src/kiwixconfirmbox.h
+++ b/src/kiwixconfirmbox.h
@@ -44,4 +44,24 @@ void showConfirmBox(QString title, QString text, QWidget *parent,
     });
 }
 
+class KiwixAppError : public std::runtime_error
+{
+public:
+    KiwixAppError(const QString& summary, const QString& details)
+        : std::runtime_error(summary.toStdString())
+        , m_details(details)
+    {}
+
+    QString summary() const { return QString::fromStdString(what()); }
+    QString details() const { return m_details; }
+
+private:
+    QString m_details;
+};
+
+inline void showErrorBox(const KiwixAppError& err, QWidget *parent = nullptr)
+{
+    showInfoBox(err.summary(), err.details(), parent);
+}
+
 #endif // KIWIXCONFIRMBOX_H

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -116,7 +116,10 @@ void Library::addBookBeingDownloaded(const kiwix::Book& book, QString downloadDi
     const QString downloadUrl = QString::fromStdString(book.getUrl());
 
     // XXX: This works if the URL is a direct link to a ZIM file
-    // XXX: rather than to a torrent or a metalink file
+    // XXX: rather than to a torrent or a metalink file. In those cases
+    // XXX: the file name of the download will be discovered after the
+    // XXX: the metalink or torrent file is downloaded. Then the real
+    // XXX: file name of a book must be set via updateBookBeingDownloaded();
     const QString fileName = downloadUrl.split('/').back();
 
     const QString path = QDir(downloadDir).absoluteFilePath(fileName);
@@ -125,6 +128,18 @@ void Library::addBookBeingDownloaded(const kiwix::Book& book, QString downloadDi
     kiwix::Book bookCopy(book);
     bookCopy.setPath(pseudoPathOfAFileBeingDownloaded(stlPath));
     addBookToLibrary(bookCopy);
+}
+
+void Library::updateBookBeingDownloaded(const QString& bookId, const QString& bookPath)
+{
+    const kiwix::Book& book = getBookById(bookId);
+    const auto bookPseudoPath = pseudoPathOfAFileBeingDownloaded(bookPath.toStdString());
+    if ( bookPseudoPath != book.getPath() ) {
+        kiwix::Book bookCopy(book);
+        bookCopy.setPath(bookPseudoPath);
+        mp_library->addOrUpdateBook(bookCopy);
+        save();
+    }
 }
 
 bool Library::isBeingDownloadedByUs(QString path) const

--- a/src/library.h
+++ b/src/library.h
@@ -40,6 +40,7 @@ public:
     void addBookBeingDownloaded(const kiwix::Book& book, QString downloadDir);
     bool isBeingDownloadedByUs(QString path) const;
     void updateBookBeingDownloaded(const QString& bookId, const QString& bookPath);
+    std::string getBookFilePath(const QString& bookId) const;
     void removeBookFromLibraryById(const QString& id);
     void addBookmark(kiwix::Bookmark& bookmark);
     void removeBookmark(const QString& zimId, const QString& url);

--- a/src/library.h
+++ b/src/library.h
@@ -39,6 +39,7 @@ public:
     void addBookToLibrary(kiwix::Book& book);
     void addBookBeingDownloaded(const kiwix::Book& book, QString downloadDir);
     bool isBeingDownloadedByUs(QString path) const;
+    void updateBookBeingDownloaded(const QString& bookId, const QString& bookPath);
     void removeBookFromLibraryById(const QString& id);
     void addBookmark(kiwix::Bookmark& bookmark);
     void removeBookmark(const QString& zimId, const QString& url);

--- a/src/rownode.cpp
+++ b/src/rownode.cpp
@@ -4,40 +4,6 @@
 #include "descriptionnode.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-// DowloadState
-////////////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-QString convertToUnits(double bytes)
-{
-    QStringList units = {"bytes", "KB", "MB", "GB", "TB", "PB", "EB"};
-    int unitIndex = 0;
-    while (bytes >= 1024 && unitIndex < units.size()) {
-        bytes /= 1024;
-        unitIndex++;
-    }
-
-    const auto preciseBytes = QString::number(bytes, 'g', 3);
-    return preciseBytes + " " + units[unitIndex];
-}
-
-} // unnamed namespace
-
-void DownloadState::update(const DownloadInfo& downloadInfos)
-{
-    double percent = downloadInfos["completedLength"].toDouble() / downloadInfos["totalLength"].toDouble();
-    percent *= 100;
-    percent = QString::number(percent, 'g', 3).toDouble();
-    auto completedLength = convertToUnits(downloadInfos["completedLength"].toDouble());
-    auto downloadSpeed = convertToUnits(downloadInfos["downloadSpeed"].toDouble()) + "/s";
-    const bool paused = downloadInfos["status"] == "paused";
-    *this = {percent, completedLength, downloadSpeed, paused};
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 // RowNode
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rownode.h
+++ b/src/rownode.h
@@ -5,20 +5,7 @@
 #include <QList>
 #include <QIcon>
 #include "kiwix/book.h"
-
-typedef QMap<QString, QVariant> DownloadInfo;
-
-class DownloadState
-{
-public:
-    double progress = 0;
-    QString completedLength;
-    QString downloadSpeed;
-    bool paused = false;
-
-public:
-    void update(const DownloadInfo& info);
-};
+#include "downloadmanagement.h"
 
 class RowNode : public Node
 {


### PR DESCRIPTION
Should fix #1094.

This PR solves issues caused by the fact that aria2c is a single threaded application (processing incoming data, including RPC requests, using the polled I/O approach) and it becomes unresponsive when saving to slow storage (such as old USB sticks).

The solution is based on issuing all (with one exception, see footnote ¹) requests to aria2c asynchronously, on a separate working thread. Before this PR only download status updates were processed asynchronously. Now download actions (start, pause, resume, cancel) are also executed asynchronously. 

Now, after the user initiates a download action (for example, by clicking the download button) all download-related actions for that book are disabled until the response to that request is received.

The PR starts with a lot of refactoring, consolidating most of the download-related code in a separate pair of h/cpp source files.
It also contains a few minor otherwise unrelated fixes/improvements.

This PR depends on kiwix/libkiwix#1097 - mainly through some code that was moved from `kiwix-desktop` to `libkiwix`, though that part could in principle be extracted into a separate PR that may be merged later on.

----

¹ The only place where aria2c requests are executed in the main thread is during the creation of `kiwix::Downloader`. That loophole is worked around by kiwix/libkiwix#1097 (on which this PR also depends in one of the last commits) - all downloads are paused by modifying the aria2 session file so that aria2c stays idle and thus responsive.