### PR TITLE
Remembers Previous Current Tab Index From Last Session

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -207,7 +207,10 @@ void KiwixApp::restoreTabs()
     {
       for (const auto &zimUrl : tabsToOpen)
       {
-        openUrl(QUrl(zimUrl));
+        if (zimUrl.isEmpty())
+          getTabWidget()->createNewTab(true, true);
+        else
+          openUrl(QUrl(zimUrl));
       }
     }
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -207,13 +207,7 @@ void KiwixApp::restoreTabs()
     {
       for (const auto &zimUrl : tabsToOpen)
       {
-        try
-        {
-          /* Throws exception if zim file cannot be found */
-          m_library.getArchive(QUrl(zimUrl).host().split('.')[0]);
-          openUrl(QUrl(zimUrl));
-        }
-        catch (std::exception &e) { /* Blank */ }
+        openUrl(QUrl(zimUrl));
       }
     }
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -215,6 +215,9 @@ void KiwixApp::restoreTabs()
           openUrl(QUrl(zimUrl));
       }
     }
+
+    /* Restore current tab index. */
+    getTabWidget()->setCurrentIndex(mp_session->value("currentTabIndex", 0).toInt());
 }
 
 KiwixApp *KiwixApp::instance()
@@ -568,4 +571,9 @@ void KiwixApp::restoreWindowState()
 {
   getMainWindow()->restoreGeometry(mp_session->value("geometry").toByteArray());
   getMainWindow()->restoreState(mp_session->value("windowState").toByteArray());
+}
+
+void KiwixApp::saveCurrentTabIndex()
+{
+  return mp_session->setValue("currentTabIndex", getTabWidget()->currentIndex());
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -207,7 +207,9 @@ void KiwixApp::restoreTabs()
     {
       for (const auto &zimUrl : tabsToOpen)
       {
-        if (zimUrl.isEmpty())
+        if (zimUrl == "SettingsTab")
+          getTabWidget()->openOrSwitchToSettingsTab();
+        else if (zimUrl.isEmpty())
           getTabWidget()->createNewTab(true, true);
         else
           openUrl(QUrl(zimUrl));

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -91,6 +91,7 @@ public:
     void saveListOfOpenTabs();
     void saveWindowState();
     void restoreWindowState();
+    void saveCurrentTabIndex();
 
 public slots:
     void newTab();

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -338,6 +338,8 @@ void TabBar::onCurrentChanged(int index)
         // In the future, other types of tabs can be added.
         // For example, About dialog, or Kiwix Server control panel.
     }
+
+    KiwixApp::instance()->saveCurrentTabIndex();
 }
 
 void TabBar::fullScreenRequested(QWebEngineFullScreenRequest request)

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -163,6 +163,7 @@ ZimView* TabBar::createNewTab(bool setCurrent, bool nextToCurrentTab)
     connect(tab, &ZimView::webActionEnabledChanged,
             this, &TabBar::onWebviewHistoryActionChanged);
 
+    KiwixApp::instance()->saveListOfOpenTabs();
     return tab;
 }
 

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -81,6 +81,7 @@ void TabBar::openOrSwitchToSettingsTab()
     insertTab(index,QIcon(":/icons/settings.svg"), gt("settings"));
     setCloseTabButton(index);
     setCurrentIndex(index);
+    KiwixApp::instance()->saveListOfOpenTabs();
 }
 
 void TabBar::setStackedWidget(QStackedWidget *widget) {
@@ -275,6 +276,8 @@ QStringList TabBar::getTabUrls() const {
     {
         if (ZimView* zv = qobject_cast<ZimView*>(mp_stackedWidget->widget(index)))
             idList.push_back(zv->getWebView()->url().url());
+        else if (qobject_cast<SettingsView*>(mp_stackedWidget->widget(index)))
+            idList.push_back("SettingsTab");
     }
     return idList;
 }


### PR DESCRIPTION
Fix #1073 
Changes:
- Blank and Settings tabs are now saved and reopened on startup.
- The current tab index from the previous session is recorded and restored.