### PR TITLE
Download path setting QOL improvements

### DIFF
--- a/resources/css/_settingsManager.css
+++ b/resources/css/_settingsManager.css
@@ -43,6 +43,17 @@ QPushButton:hover {
     color: white;
 }
 
+#downloadDirPathCopy {
+    background-color: none;
+    border: 1px solid transparent;
+}
+
+#downloadDirPathCopy:hover {
+    background-color: #D9E9FF;
+    border: 1px solid #3366CC;
+    border-radius: 3px;
+}
+
 #monitorDirLabel {
     padding-right: 0;
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -135,6 +135,7 @@
     "monitor-dir-dialog-title":"Are you sure you want to change the monitor directory?",
     "monitor-dir-dialog-msg":"The new monitor directory path will be:\n{{DIRECTORY}}",
     "monitor-clear-dir-dialog-title":"Are you sure you want to clear the monitor directory?",
+    "path-was-copied": "Path was copied",
     "monitor-clear-dir-dialog-msg":"This will stop checking the monitor directory for new ZIM files.",
     "monitor-directory-tooltip":"All ZIM files in this directory will be automatically added to the library.",
     "next-tab":"Move to next tab",

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -174,5 +174,6 @@
 	"clear-filter": "Represents the action of clearing the filters selected for a filter type.",
 	"no-details": "A content type for Zim files representing it only has an introduction.",
 	"no-pictures": "A content type for Zim files that does not contain pictures.",
-	"no-videos": "A content type for Zim files that does not contain videos."
+	"no-videos": "A content type for Zim files that does not contain videos.",
+	"path-was-copied": "Tooltip confirming that the download path from settings was copied."
 }

--- a/resources/icons/copy.svg
+++ b/resources/icons/copy.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-copy" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z"/>
+  <rect x="8" y="8" width="12" height="12" rx="2" />
+  <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2" />
+</svg>
+
+

--- a/resources/kiwix.qrc
+++ b/resources/kiwix.qrc
@@ -16,6 +16,7 @@
         <file>icons/star.svg</file>
         <file>icons/search.svg</file>
         <file>icons/close.svg</file>
+        <file>icons/copy.svg</file>
         <file>icons/star-active.svg</file>
         <file>icons/search-inactive.svg</file>
         <file>icons/checkbox-indeterminate.svg</file>

--- a/src/settingsview.h
+++ b/src/settingsview.h
@@ -23,6 +23,7 @@ public:
     void setMoveToTrash(bool moveToTrash);
     void setReopenTab(bool reopen);
     void onDownloadDirChanged(const QString &dir);
+    void copyDownloadPathToClipboard();
     void onMonitorDirChanged(const QString &dir);
     void onZoomChanged(qreal zoomFactor);
     void onMoveToTrashChanged(bool moveToTrash);

--- a/ui/settings.ui
+++ b/ui/settings.ui
@@ -142,6 +142,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QPushButton" name="downloadDirPathCopy">
+            <property name="text">
+             <string></string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>


### PR DESCRIPTION
Fixes #1113 

Added functionality for the download path in settings:
- Tooltip when hovering over, to show the full path.
- Copy to clipboard icon, with a disappearing popup to indicate success.
- Truncation of the path in case it exceeds a limit. `...` replaces the hidden path, to allow for better readability of the directory's path.