### PR TITLE
Eliminated emit of Library class signals from other objects

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -133,6 +133,8 @@ ContentManager::ContentManager(Library* library, kiwix::Downloader* downloader, 
     setCurrentCategoryFilter(getSettingsManager()->getCategoryList());
     setCurrentContentTypeFilter(getSettingsManager()->getContentType());
     connect(mp_library, &Library::booksChanged, this, [=]() {emit(this->booksChanged());});
+    connect(this, &ContentManager::libraryBooksChanged, mp_library, &Library::booksChanged);
+    connect(this, &ContentManager::libraryBookmarksChanged, mp_library, &Library::bookmarksChanged);
     connect(this, &ContentManager::filterParamsChanged, this, &ContentManager::updateLibrary);
     connect(this, &ContentManager::booksChanged, this, [=]() {
         updateModel();
@@ -568,7 +570,7 @@ void ContentManager::downloadDisappeared(QString bookId)
     bCopy.setDownloadId("");
     mp_library->getKiwixLibrary()->addOrUpdateBook(bCopy);
     mp_library->save();
-    emit(mp_library->booksChanged());
+    emit libraryBooksChanged();
 }
 
 void ContentManager::downloadCompleted(QString bookId, QString path)
@@ -586,7 +588,7 @@ void ContentManager::downloadCompleted(QString bookId, QString path)
     if (!m_local) {
         emit(oneBookChanged(bookId));
     } else {
-        emit(mp_library->booksChanged());
+        emit libraryBooksChanged();
     }
 }
 
@@ -756,7 +758,7 @@ void ContentManager::reallyEraseBook(const QString& id, bool moveToTrash)
     eraseBookFilesFromComputer(book.getPath(), moveToTrash);
     mp_library->removeBookFromLibraryById(id);
     mp_library->save();
-    emit mp_library->bookmarksChanged();
+    emit libraryBookmarksChanged();
     if (m_local) {
         emit(bookRemoved(id));
     } else {

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -73,6 +73,8 @@ public: // functions
 signals:
     void filterParamsChanged();
     void booksChanged();
+    void libraryBooksChanged();
+    void libraryBookmarksChanged();
     void oneBookChanged(const QString&);
     void bookRemoved(const QString&);
     void downloadsChanged();

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -74,6 +74,7 @@ void KiwixApp::init()
     }
     mp_manager = new ContentManager(&m_library, mp_downloader);
     mp_manager->setLocal(!m_library.getBookIds().isEmpty());
+    connect(this, &KiwixApp::libraryBooksChanged, &m_library, &Library::booksChanged);
 
     auto icon = QIcon();
     icon.addFile(":/icons/kiwix-app-icons-square.svg");
@@ -509,7 +510,7 @@ void KiwixApp::createActions()
 void KiwixApp::postInit() {
     connect(getTabWidget(), &TabBar::tabDisplayed,
             this, &KiwixApp::handleItemsState);
-    emit(m_library.booksChanged());
+    emit libraryBooksChanged();
     connect(&m_library, &Library::booksChanged, this, &KiwixApp::updateNameMapper);
     handleItemsState(TabType::LibraryTab);
 }

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -92,6 +92,9 @@ public:
     void saveWindowState();
     void restoreWindowState();
 
+signals:
+    void libraryBooksChanged();
+
 public slots:
     void newTab();
     void openZimFile(const QString& zimfile="");

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -16,9 +16,7 @@ class LibraryManipulator: public kiwix::LibraryManipulator {
     {}
     virtual ~LibraryManipulator() {}
     bool addBookToLibrary(kiwix::Book book) {
-        auto ret = mp_library->mp_library->addBook(book);
-        emit(mp_library->booksChanged());
-        return ret;
+        return mp_library->addBookToLibraryWithSignal(book);
     }
     void addBookmarkToLibrary(kiwix::Bookmark bookmark) {
         mp_library->mp_library->addBookmark(bookmark);
@@ -95,6 +93,12 @@ QStringList Library::listBookIds(const kiwix::Filter& filter, kiwix::supportedLi
 void Library::addBookToLibrary(kiwix::Book &book)
 {
     mp_library->addBook(book);
+}
+
+bool Library::addBookToLibraryWithSignal(kiwix::Book &book) {
+    auto ret = mp_library->addBook(book);
+    emit(booksChanged());
+    return ret;
 }
 
 void Library::removeBookFromLibraryById(const QString& id) {

--- a/src/library.h
+++ b/src/library.h
@@ -37,6 +37,7 @@ public:
     QStringList getLibraryZimsFromDir(QString dir) const;
     void setMonitorDirZims(QString monitorDir, QStringList zimList);
     void addBookToLibrary(kiwix::Book& book);
+    bool addBookToLibraryWithSignal(kiwix::Book& book);
     void addBookBeingDownloaded(const kiwix::Book& book, QString downloadDir);
     bool isBeingDownloadedByUs(QString path) const;
     void removeBookFromLibraryById(const QString& id);


### PR DESCRIPTION
Fix #540

Change:
 - Created member function in Library class to emit signals
 - Other classes simply use these if they would like to emit such signals.
