### PR TITLE
Added Custom File-Not-Found page for Tabs

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -168,5 +168,8 @@
     "no-pictures": "No Pictures",
     "no-videos": "No Videos",
     "open-previous-tabs-at-startup": "Open previous tabs at startup",
-    "preview-book-in-web-browser": "Preview book in web browser"
+    "preview-book-in-web-browser": "Preview book in web browser",
+    "file-not-found-title": "ZIM File Not Found",
+    "file-not-found-text": "ZIM file doesn't exist or is not readable",
+    "zim-id": "ZIM Id"
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -171,5 +171,7 @@
     "preview-book-in-web-browser": "Preview book in web browser",
     "file-not-found-title": "ZIM File Not Found",
     "file-not-found-text": "ZIM file doesn't exist or is not readable",
-    "zim-id": "ZIM Id"
+    "zim-id": "Zim Id",
+    "zim-name": "Zim Name",
+    "zim-path": "Zim File Path"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -178,5 +178,7 @@
 	"path-was-copied": "Tooltip confirming that the download path from settings was copied.",
 	"file-not-found-title": "Error title text displayed when the desktop application cannot find the Zim file needed to display the web page.",
 	"file-not-found-text": "Error description text for when the desktop application cannot find the Zim file needed to display the web page.",
-	"zim-id": "The term for the unique identifier of a zim file."
+	"zim-id": "The term for the unique identifier of a zim file.",
+	"zim-name": "The term for the name of a Zim file",
+	"zim-path": "The term for the path of a Zim file"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -175,5 +175,8 @@
 	"no-details": "A content type for Zim files representing it only has an introduction.",
 	"no-pictures": "A content type for Zim files that does not contain pictures.",
 	"no-videos": "A content type for Zim files that does not contain videos.",
-	"path-was-copied": "Tooltip confirming that the download path from settings was copied."
+	"path-was-copied": "Tooltip confirming that the download path from settings was copied.",
+	"file-not-found-title": "Error title text displayed when the desktop application cannot find the Zim file needed to display the web page.",
+	"file-not-found-text": "Error description text for when the desktop application cannot find the Zim file needed to display the web page.",
+	"zim-id": "The term for the unique identifier of a zim file."
 }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -906,5 +906,6 @@ void ContentManager::updateLibraryFromDir(QString monitorDir)
 
 void ContentManager::handleDisappearedZimFile(QString bookId)
 {
-    mp_library->removeBookFromLibraryById(bookId);
+    if (!KiwixApp::instance()->getTabWidget()->getTabZimIds().contains(bookId))
+        mp_library->removeBookFromLibraryById(bookId);
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -106,10 +106,10 @@ void KiwixApp::init()
         mp_manager->asyncUpdateLibraryFromDir(monitorDir);
     });
 
-    setupDirectoryMonitoring();
-
+    /* Restore Tabs before directory monitoring to ensure we know what tabs user had. */
     restoreTabs();
     restoreWindowState();
+    setupDirectoryMonitoring();
 }
 
 void KiwixApp::setupDirectoryMonitoring()

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -284,6 +284,15 @@ QStringList TabBar::getTabUrls() const {
     return idList;
 }
 
+QStringList TabBar::getTabZimIds() const
+{ 
+    QStringList idList;
+    for (int index = 0; index <= mp_stackedWidget->count(); index++)
+        if (ZimView* zv = qobject_cast<ZimView*>(mp_stackedWidget->widget(index)))
+            idList.push_back(zv->getWebView()->zimId());
+    return idList;
+}
+
 void TabBar::closeTab(int index)
 {
     // The first and last tabs (i.e. the library tab and the + (new tab) button)

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -50,6 +50,7 @@ public:
     void openFindInPageBar();
     void closeTabsByZimId(const QString &id);
     QStringList getTabUrls() const;
+    QStringList getTabZimIds() const;
 
 protected:
     void mousePressEvent(QMouseEvent *event);

--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -44,7 +44,7 @@ UrlSchemeHandler::handleContentRequest(QWebEngineUrlRequestJob *request)
     try {
       archive = library->getArchive(zim_id);
     } catch (std::out_of_range& e) {
-      request->fail(QWebEngineUrlRequestJob::UrlNotFound);
+      replyZimNotFoundPage(request, zim_id);
       return;
     }
     try {
@@ -173,6 +173,31 @@ UrlSchemeHandler::handleSearchRequest(QWebEngineUrlRequestJob* request)
     QBuffer *buffer = new QBuffer;
     buffer->setData(content.data(), content.size());
     connect(request, &QObject::destroyed, buffer, &QObject::deleteLater);
+    request->reply("text/html", buffer);
+}
+
+void
+UrlSchemeHandler::replyZimNotFoundPage(QWebEngineUrlRequestJob *request,
+                                       const QString &zimId)
+{
+    QBuffer *buffer = new QBuffer;
+    QString contentHtml = "<section><div>"
+                          "<h1>" +
+                          gt("file-not-found-title") +
+                          "</h1>"
+                          "<p>" +
+                          gt("file-not-found-text") +
+                          "</p>"
+                          "<p>" +
+                          gt("zim-id") + ": <b>" + zimId +
+                          "</b></p>"
+                          "</div></section>";
+
+    buffer->open(QIODevice::WriteOnly);
+    buffer->write(contentHtml.toStdString().c_str());
+    buffer->close();
+
+    connect(request, SIGNAL(destroyed()), buffer, SLOT(deleteLater()));
     request->reply("text/html", buffer);
 }
 

--- a/src/urlschemehandler.cpp
+++ b/src/urlschemehandler.cpp
@@ -181,6 +181,15 @@ UrlSchemeHandler::replyZimNotFoundPage(QWebEngineUrlRequestJob *request,
                                        const QString &zimId)
 {
     QBuffer *buffer = new QBuffer;
+    QString path = "N/A", name = "N/A";
+    try 
+    {
+        auto& book = KiwixApp::instance()->getLibrary()->getBookById(zimId);
+        path = QString::fromStdString(book.getPath());
+        name = QString::fromStdString(book.getName());
+    }
+    catch (...) { /* Blank */ }
+
     QString contentHtml = "<section><div>"
                           "<h1>" +
                           gt("file-not-found-title") +
@@ -190,6 +199,12 @@ UrlSchemeHandler::replyZimNotFoundPage(QWebEngineUrlRequestJob *request,
                           "</p>"
                           "<p>" +
                           gt("zim-id") + ": <b>" + zimId +
+                          "</b></p>"
+                          "<p>" +
+                          gt("zim-name") + ": <b>" + name +
+                          "</b></p>"
+                          "<p>" +
+                          gt("zim-path") + ": <b>" + path +
                           "</b></p>"
                           "</div></section>";
 

--- a/src/urlschemehandler.h
+++ b/src/urlschemehandler.h
@@ -13,6 +13,8 @@ private:
     void handleMetaRequest(QWebEngineUrlRequestJob *request);
     void handleContentRequest(QWebEngineUrlRequestJob *request);
     void handleSearchRequest(QWebEngineUrlRequestJob *request);
+
+    void replyZimNotFoundPage(QWebEngineUrlRequestJob *request, const QString& zimId);
 };
 
 #endif // URLSCHEMEHANDLER_H


### PR DESCRIPTION
Fix #1073
Follow-up from #1120.

Changes:
- Custom file-not-found page when tabs have Urls that point to non-existing Zim files.
- Now displays the bookmarks of the non-existing Zim files. Previously they were marked as invalid and not added.