### PR TITLE
Settings monitor path QOL improvements

### DIFF
--- a/resources/css/_settingsManager.css
+++ b/resources/css/_settingsManager.css
@@ -43,12 +43,12 @@ QPushButton:hover {
     color: white;
 }
 
-#downloadDirPathCopy {
+#downloadDirPathCopy, #monitorDirPathCopy {
     background-color: none;
     border: 1px solid transparent;
 }
 
-#downloadDirPathCopy:hover {
+#downloadDirPathCopy:hover, #monitorDirPathCopy:hover {
     background-color: #D9E9FF;
     border: 1px solid #3366CC;
     border-radius: 3px;

--- a/src/settingsview.cpp
+++ b/src/settingsview.cpp
@@ -40,11 +40,11 @@ SettingsView::SettingsView(QWidget *parent)
     connect(ui->resetButton, &QPushButton::clicked, this, &SettingsView::resetDownloadDir);
     connect(ui->monitorBrowse, &QPushButton::clicked, this, &SettingsView::browseMonitorDir);
     connect(ui->monitorClear, &QPushButton::clicked, this, &SettingsView::clearMonitorDir);
-    connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::downloadDirChanged, this, &SettingsView::onDownloadDirChanged);
-    connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::monitorDirChanged, this, &SettingsView::onMonitorDirChanged);
-    connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::zoomChanged, this, &SettingsView::onZoomChanged);
-    connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::moveToTrashChanged, this, &SettingsView::onMoveToTrashChanged);
-    connect(KiwixApp::instance()->getSettingsManager(), &SettingsManager::reopenTabChanged, this, &SettingsView::onReopenTabChanged);
+    connect(settingsMgr, &SettingsManager::downloadDirChanged, this, &SettingsView::onDownloadDirChanged);
+    connect(settingsMgr, &SettingsManager::monitorDirChanged, this, &SettingsView::onMonitorDirChanged);
+    connect(settingsMgr, &SettingsManager::zoomChanged, this, &SettingsView::onZoomChanged);
+    connect(settingsMgr, &SettingsManager::moveToTrashChanged, this, &SettingsView::onMoveToTrashChanged);
+    connect(settingsMgr, &SettingsManager::reopenTabChanged, this, &SettingsView::onReopenTabChanged);
     ui->settingsLabel->setText(gt("settings"));
     ui->zoomPercentLabel->setText(gt("zoom-level-setting"));
     ui->downloadDirLabel->setText(gt("download-directory-setting"));

--- a/src/settingsview.h
+++ b/src/settingsview.h
@@ -2,6 +2,7 @@
 #define SETTINGSVIEW_H
 
 #include <QWidget>
+#include <QPushButton>
 namespace Ui {
 class Settings;
 }
@@ -23,7 +24,7 @@ public:
     void setMoveToTrash(bool moveToTrash);
     void setReopenTab(bool reopen);
     void onDownloadDirChanged(const QString &dir);
-    void copyDownloadPathToClipboard();
+    void copySettingsPathToClipboard(QString pathToCopy, QPushButton* button);
     void onMonitorDirChanged(const QString &dir);
     void onZoomChanged(qreal zoomFactor);
     void onMoveToTrashChanged(bool moveToTrash);

--- a/ui/settings.ui
+++ b/ui/settings.ui
@@ -258,6 +258,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QPushButton" name="monitorDirPathCopy">
+            <property name="text">
+             <string></string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>


### PR DESCRIPTION
Closes #1113 

Added functionality for the monitor path in settings:

- Tooltip when hovering over, to show the full path.
- Copy to clipboard icon, with a disappearing tooltip to indicate success.
- Truncation of the path in case it exceeds a limit. `...` replaces the hidden path, to allow for better readability of the directory's path.