### PR TITLE
Implement Basic Text to Speech

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends: debhelper-compat (= 13),
  pkg-config,
  qtbase5-dev,
  qtwebengine5-dev,
+ libqt5texttospeech5-dev,
  libkiwix-dev (>= 14.0.0), libkiwix-dev (<< 15.0.0),
  libzim-dev (>= 9.0.0), libzim-dev (<< 10.0.0),
 Standards-Version: 4.5.0

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -7,7 +7,7 @@
 QT       += core gui network
 QT       += webenginewidgets webchannel
 QT       += printsupport
-QT       += texttospeech
+qtHaveModule(texttospeech): QT += texttospeech
 
 # Avoid stripping incompatible files, due to false identification as executables, on WSL
 DETECT_WSL = $$system(test -f /proc/sys/fs/binfmt_misc/WSLInterop && echo true || echo false)
@@ -94,7 +94,8 @@ SOURCES += \
     src/fullscreennotification.cpp \
     src/zimview.cpp \
     src/multizimbutton.cpp \
-    src/texttospeechbar.cpp \
+
+qtHaveModule(texttospeech): SOURCES += src/texttospeechbar.cpp \
 
 HEADERS += \
     src/choiceitem.h \
@@ -150,7 +151,8 @@ HEADERS += \
     src/css_constants.h \
     src/multizimbutton.h \
     src/kiwixwebchannelobject.h \
-    src/texttospeechbar.h \
+
+qtHaveModule(texttospeech): HEADERS += src/texttospeechbar.h \
 
 FORMS += \
     src/choiceitem.ui \
@@ -165,7 +167,8 @@ FORMS += \
     ui/localkiwixserver.ui \
     ui/settings.ui \
     src/tableofcontentbar.ui \
-    src/texttospeechbar.ui \
+
+qtHaveModule(texttospeech): FORMS += src/texttospeechbar.ui \
 
 include(subprojects/QtSingleApplication/src/qtsingleapplication.pri)
 CODECFORSRC = UTF-8

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -165,6 +165,7 @@ FORMS += \
     ui/localkiwixserver.ui \
     ui/settings.ui \
     src/tableofcontentbar.ui \
+    src/texttospeechbar.ui \
 
 include(subprojects/QtSingleApplication/src/qtsingleapplication.pri)
 CODECFORSRC = UTF-8

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -7,6 +7,7 @@
 QT       += core gui network
 QT       += webenginewidgets webchannel
 QT       += printsupport
+QT       += texttospeech
 
 # Avoid stripping incompatible files, due to false identification as executables, on WSL
 DETECT_WSL = $$system(test -f /proc/sys/fs/binfmt_misc/WSLInterop && echo true || echo false)
@@ -93,6 +94,7 @@ SOURCES += \
     src/fullscreennotification.cpp \
     src/zimview.cpp \
     src/multizimbutton.cpp \
+    src/texttospeechbar.cpp \
 
 HEADERS += \
     src/choiceitem.h \
@@ -148,6 +150,7 @@ HEADERS += \
     src/css_constants.h \
     src/multizimbutton.h \
     src/kiwixwebchannelobject.h \
+    src/texttospeechbar.h \
 
 FORMS += \
     src/choiceitem.ui \

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -462,3 +462,64 @@ ContentTypeFilter {
 #tableofcontentbar QScrollBar::handle {
     background-color: grey;
 }
+
+/* ----------------------------------------
+    Text to Speech Page
+*/
+
+TextToSpeechBar {
+    border-top: 1px solid #ccc;
+}
+
+TextToSpeechBar #closeButton {
+    outline: none;
+    max-height: 36px;
+    max-width: 36px;
+    border: 1px solid #ccc;
+    border-radius: 0;
+}
+
+TextToSpeechBar #stopButton {
+    outline: none;
+    max-height: 36px;
+    padding: 0px 10px;
+    
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 0;
+}
+
+TextToSpeechBar #stopButton:hover {
+    background-color: #D9E9FF;
+    border: 1px solid #3366CC;
+}
+
+TextToSpeechBar #stopButton:disabled {
+    color: grey;
+    background-color: darkgrey;
+}
+
+TextToSpeechBar QComboBox::drop-down {
+    height: 22px;
+    width: 15px;
+    padding: 0px 2px;
+    margin: 0px;
+
+    image: url(":/icons/drop-down.svg");
+    background-color: white;
+}
+
+TextToSpeechBar QComboBox {
+    background-color: white;
+    border: 1px solid #ccc;
+}
+
+TextToSpeechBar QAbstractItemView QScrollBar {
+    width: 5px;
+    border: none;
+    outline: none;
+}
+
+TextToSpeechBar QAbstractItemView QScrollBar::handle {
+    background-color: grey;
+}

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -178,5 +178,7 @@
     "read-text": "Read selected text",
     "read-stop": "Stop reading",
     "stop": "Stop",
-    "voice": "Voice"
+    "voice": "Voice",
+    "select-read-voice": "Select reading voice",
+    "select-read-language": "Select reading language"
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -176,5 +176,6 @@
     "search-options": "Search Options",
     "read-article": "Read article",
     "read-text": "Read selected text",
+    "read-stop": "Stop reading",
     "stop": "Stop"
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -177,5 +177,6 @@
     "read-article": "Read article",
     "read-text": "Read selected text",
     "read-stop": "Stop reading",
-    "stop": "Stop"
+    "stop": "Stop",
+    "voice": "Voice"
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -173,5 +173,7 @@
     "scroll-next-tab": "Scroll to next tab",
     "scroll-previous-tab": "Scroll to previous tab",
     "kiwix-search": "Kiwix search",
-    "search-options": "Search Options"
+    "search-options": "Search Options",
+    "read-article": "Read article",
+    "read-text": "Read selected text"
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -175,5 +175,6 @@
     "kiwix-search": "Kiwix search",
     "search-options": "Search Options",
     "read-article": "Read article",
-    "read-text": "Read selected text"
+    "read-text": "Read selected text",
+    "stop": "Stop"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -183,5 +183,6 @@
 	"kiwix-search": "Title text for a list of search results, which notes to the user those are from Kiwix's Search Engine",
 	"search-options": "The term for a collection of additional search filtering options to help users narrow down search results.",
 	"read-article": "Represents the action of letting the computer read out all the text in the current article.",
-	"read-text": "Represents the action of letting the computer read out the selected text on the article."
+	"read-text": "Represents the action of letting the computer read out the selected text on the article.",
+	"stop": "{{Identical|Stop}}"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -181,5 +181,7 @@
 	"scroll-next-tab": "Represents the action of scrolling to the next tab of the current tab which toward the end of the tab bar.",
 	"scroll-previous-tab": "Represents the action of scrolling to the previous tab of the current tab which toward the start of the tab bar.",
 	"kiwix-search": "Title text for a list of search results, which notes to the user those are from Kiwix's Search Engine",
-	"search-options": "The term for a collection of additional search filtering options to help users narrow down search results."
+	"search-options": "The term for a collection of additional search filtering options to help users narrow down search results.",
+	"read-article": "Represents the action of letting the computer read out all the text in the current article.",
+	"read-text": "Represents the action of letting the computer read out the selected text on the article."
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -184,5 +184,6 @@
 	"search-options": "The term for a collection of additional search filtering options to help users narrow down search results.",
 	"read-article": "Represents the action of letting the computer read out all the text in the current article.",
 	"read-text": "Represents the action of letting the computer read out the selected text on the article.",
+	"read-stop": "Represents the action of stopping the on-going reading.",
 	"stop": "{{Identical|Stop}}"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -185,5 +185,6 @@
 	"read-article": "Represents the action of letting the computer read out all the text in the current article.",
 	"read-text": "Represents the action of letting the computer read out the selected text on the article.",
 	"read-stop": "Represents the action of stopping the on-going reading.",
-	"stop": "{{Identical|Stop}}"
+	"stop": "{{Identical|Stop}}",
+	"voice": "{{Identical|Voice}}"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -186,5 +186,7 @@
 	"read-text": "Represents the action of letting the computer read out the selected text on the article.",
 	"read-stop": "Represents the action of stopping the on-going reading.",
 	"stop": "{{Identical|Stop}}",
-	"voice": "{{Identical|Voice}}"
+	"voice": "{{Identical|Voice}}",
+	"select-read-voice": "Represents the action of opening the voice selection for text-to-speech.",
+	"select-read-language": "Represents the action of opening the language selection for text-to-speech."
 }

--- a/resources/icons/drop-down.svg
+++ b/resources/icons/drop-down.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 1024 1024" class="icon"  version="1.1" xmlns="http://www.w3.org/2000/svg"><path d="M903.232 256l56.768 50.432L512 768 64 306.432 120.768 256 512 659.072z" fill="#000000" /></svg>

--- a/resources/icons/stop-circle.svg
+++ b/resources/icons/stop-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><rect x="9" y="9" width="6" height="6"></rect></svg>

--- a/resources/kiwix.qrc
+++ b/resources/kiwix.qrc
@@ -66,5 +66,6 @@
         <file>icons/home-button.svg</file>
         <file>icons/more-vertical.svg</file>
         <file>icons/caret-left-solid.svg</file>
+        <file>icons/stop-circle.svg</file>
     </qresource>
 </RCC>

--- a/resources/kiwix.qrc
+++ b/resources/kiwix.qrc
@@ -67,5 +67,6 @@
         <file>icons/more-vertical.svg</file>
         <file>icons/caret-left-solid.svg</file>
         <file>icons/stop-circle.svg</file>
+        <file>icons/drop-down.svg</file>
     </qresource>
 </RCC>

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -545,6 +545,11 @@ void KiwixApp::saveWindowState()
   mp_session->setValue("windowState", getMainWindow()->saveState());
 }
 
+void KiwixApp::saveVoiceName(const QString& langName, const QString& voiceName)
+{
+  mp_session->setValue("voice/" + langName, voiceName);
+}
+
 void KiwixApp::restoreWindowState()
 {
   getMainWindow()->restoreGeometry(mp_session->value("geometry").toByteArray());
@@ -559,6 +564,11 @@ void KiwixApp::saveCurrentTabIndex()
 void KiwixApp::savePrevSaveDir(const QString &prevSaveDir)
 {
   mp_session->setValue("prevSaveDir", prevSaveDir);
+}
+
+QString KiwixApp::getSavedVoiceName(const QString& langName) const
+{
+  return mp_session->value("voice/" + langName, "").toString();
 }
 
 QString KiwixApp::getPrevSaveDir() const

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -392,6 +392,10 @@ void KiwixApp::createActions()
     CREATE_ACTION_SHORTCUT(ReadArticleAction, gt("read-article"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_A));
     CREATE_ACTION_SHORTCUT(ReadTextAction, gt("read-text"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_S));
     CREATE_ACTION_SHORTCUT(ReadStopAction, gt("read-stop"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_X));
+    CREATE_ACTION_SHORTCUT(ToggleTTSLanguageAction, gt("select-read-language"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_L));
+    CREATE_ACTION_SHORTCUT(ToggleTTSVoiceAction, gt("select-read-voice"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_V));
+    mpa_actions[ToggleTTSLanguageAction]->setCheckable(true);
+    mpa_actions[ToggleTTSVoiceAction]->setCheckable(true);
 
     CREATE_ACTION_ICON_SHORTCUT(PrintAction, "print", gt("print"), QKeySequence::Print);
     connect(mpa_actions[PrintAction], &QAction::triggered,

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -389,6 +389,9 @@ void KiwixApp::createActions()
     DISABLE_ACTION(HistoryBackAction);
     DISABLE_ACTION(HistoryForwardAction);
 
+    CREATE_ACTION_SHORTCUT(ReadArticleAction, gt("read-article"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_A));
+    CREATE_ACTION_SHORTCUT(ReadTextAction, gt("read-text"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_S));
+
     CREATE_ACTION_ICON_SHORTCUT(PrintAction, "print", gt("print"), QKeySequence::Print);
     connect(mpa_actions[PrintAction], &QAction::triggered,
             this, &KiwixApp::printPage);

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -391,6 +391,7 @@ void KiwixApp::createActions()
 
     CREATE_ACTION_SHORTCUT(ReadArticleAction, gt("read-article"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_A));
     CREATE_ACTION_SHORTCUT(ReadTextAction, gt("read-text"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_S));
+    CREATE_ACTION_SHORTCUT(ReadStopAction, gt("read-stop"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_X));
 
     CREATE_ACTION_ICON_SHORTCUT(PrintAction, "print", gt("print"), QKeySequence::Print);
     connect(mpa_actions[PrintAction], &QAction::triggered,

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -57,6 +57,7 @@ public:
         HistoryForwardAction,
         ReadTextAction,
         ReadArticleAction,
+        ReadStopAction,
         HelpAction,
         FeedbackAction,
         ReportBugAction,

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -98,9 +98,11 @@ public:
     QString parseStyleFromFile(QString filePath);
     void saveListOfOpenTabs();
     void saveWindowState();
+    void saveVoiceName(const QString& langName, const QString& voiceName);
     void restoreWindowState();
     void saveCurrentTabIndex();
     void savePrevSaveDir(const QString& prevSaveDir);
+    QString getSavedVoiceName(const QString& langName) const;
     QString getPrevSaveDir() const;
 
 public slots:

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -55,6 +55,8 @@ public:
         PreviousTabAction,
         HistoryBackAction,
         HistoryForwardAction,
+        ReadTextAction,
+        ReadArticleAction,
         HelpAction,
         FeedbackAction,
         ReportBugAction,

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -48,6 +48,8 @@ public:
         ToggleTOCAction,
         ToggleReadingListAction,
         ToggleAddBookmarkAction,
+        ToggleTTSLanguageAction,
+        ToggleTTSVoiceAction,
         ZoomInAction,
         ZoomOutAction,
         ZoomResetAction,

--- a/src/mainmenu.cpp
+++ b/src/mainmenu.cpp
@@ -36,6 +36,8 @@ MainMenu::MainMenu(QWidget *parent) :
     m_editMenu.ADD_ACTION(FindInPageAction);
     m_editMenu.ADD_ACTION(ToggleAddBookmarkAction);
     m_editMenu.ADD_ACTION(OpenMultiZimAction);
+    m_editMenu.ADD_ACTION(ReadArticleAction);
+    m_editMenu.ADD_ACTION(ReadTextAction);
     addMenu(&m_editMenu);
 
     m_viewMenu.setTitle(gt("view"));

--- a/src/mainmenu.cpp
+++ b/src/mainmenu.cpp
@@ -45,6 +45,8 @@ MainMenu::MainMenu(QWidget *parent) :
     m_viewMenu.ADD_ACTION(ToggleFullscreenAction);
     m_viewMenu.ADD_ACTION(ToggleTOCAction);
     m_viewMenu.ADD_ACTION(ToggleReadingListAction);
+    m_viewMenu.ADD_ACTION(ToggleTTSLanguageAction);
+    m_viewMenu.ADD_ACTION(ToggleTTSVoiceAction);
     m_viewMenu.ADD_ACTION(ZoomInAction);
     m_viewMenu.ADD_ACTION(ZoomOutAction);
     m_viewMenu.ADD_ACTION(ZoomResetAction);

--- a/src/mainmenu.cpp
+++ b/src/mainmenu.cpp
@@ -36,9 +36,11 @@ MainMenu::MainMenu(QWidget *parent) :
     m_editMenu.ADD_ACTION(FindInPageAction);
     m_editMenu.ADD_ACTION(ToggleAddBookmarkAction);
     m_editMenu.ADD_ACTION(OpenMultiZimAction);
+#if defined(QT_TEXTTOSPEECH_LIB)
     m_editMenu.ADD_ACTION(ReadArticleAction);
     m_editMenu.ADD_ACTION(ReadTextAction);
     m_editMenu.ADD_ACTION(ReadStopAction);
+#endif
     addMenu(&m_editMenu);
 
     m_viewMenu.setTitle(gt("view"));

--- a/src/mainmenu.cpp
+++ b/src/mainmenu.cpp
@@ -38,6 +38,7 @@ MainMenu::MainMenu(QWidget *parent) :
     m_editMenu.ADD_ACTION(OpenMultiZimAction);
     m_editMenu.ADD_ACTION(ReadArticleAction);
     m_editMenu.ADD_ACTION(ReadTextAction);
+    m_editMenu.ADD_ACTION(ReadStopAction);
     addMenu(&m_editMenu);
 
     m_viewMenu.setTitle(gt("view"));

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -109,3 +109,10 @@ void ComboBoxLineEdit::preventSelection()
 {
     setSelection(0, 0);
 }
+
+void ComboBoxLineEdit::mouseReleaseEvent(QMouseEvent *)
+{
+    const auto combo = qobject_cast<QComboBox*>(parent());
+    if(combo)
+        combo->showPopup();
+}

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -37,6 +37,7 @@ void TextToSpeechBar::setupLanguageComboBox()
 {
     ui->langLabel->setText(gt("language"));
     ui->langComboBox->setMaxVisibleItems(10);
+    ui->langComboBox->setLineEdit(new ComboBoxLineEdit(ui->langComboBox));
 
     QLocale current = QLocale::system();
     for (const auto& locale : m_speech.availableLocales())
@@ -93,4 +94,18 @@ void TextToSpeechBar::keyPressEvent(QKeyEvent *event)
 void TextToSpeechBar::onStateChanged(QTextToSpeech::State state)
 {
     ui->stopButton->setEnabled(state != QTextToSpeech::Ready);
+}
+
+ComboBoxLineEdit::ComboBoxLineEdit(QWidget *parent) : QLineEdit(parent)
+{
+    setFrame(false);
+
+    /* Work around to both have max visible item and a read-only combobox.*/
+    setReadOnly(true);
+    connect(this, &QLineEdit::selectionChanged, this, &ComboBoxLineEdit::preventSelection);
+}
+
+void ComboBoxLineEdit::preventSelection()
+{
+    setSelection(0, 0);
 }

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -34,6 +34,19 @@ void TextToSpeechBar::stop()
     m_speech.stop();
 }
 
+void TextToSpeechBar::setLocale(const QLocale& locale)
+{
+    for (int i = 0; i < ui->langComboBox->count(); i++)
+    {
+        if (ui->langComboBox->itemData(i).toLocale().language() == locale.language())
+        {
+            ui->langComboBox->setCurrentIndex(i);
+            languageSelected(i);
+            return;
+        }
+    }
+}
+
 void TextToSpeechBar::setupLanguageComboBox()
 {
     ui->langLabel->setText(gt("language"));

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -13,6 +13,8 @@ TextToSpeechBar::TextToSpeechBar(QWidget *parent)
 
     ui->stopButton->setText(gt("stop"));
     ui->stopButton->setDisabled(true);
+    connect(KiwixApp::instance()->getAction(KiwixApp::ReadStopAction), &QAction::triggered,
+            this, &TextToSpeechBar::stop);
     connect(ui->stopButton, &QPushButton::pressed, this,
             &TextToSpeechBar::stop);
 }

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -26,7 +26,8 @@ TextToSpeechBar::TextToSpeechBar(QWidget *parent)
 
 void TextToSpeechBar::speak(const QString &text)
 {
-    m_speech.say(text);
+    m_text = text;
+    m_speech.say(m_text);
 }
 
 void TextToSpeechBar::stop()
@@ -149,6 +150,8 @@ void TextToSpeechBar::voiceSelected(int index)
     KiwixApp::instance()->saveVoiceName(currentLang, voice.name());
 
     m_speech.setVoice(voice);
+    if (m_speech.state() == QTextToSpeech::Speaking)
+        speak(m_text);
 }
 
 void TextToSpeechBar::keyPressEvent(QKeyEvent *event)

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -1,12 +1,33 @@
 #include "texttospeechbar.h"
+#include "kiwixapp.h"
+#include "ui_texttospeechbar.h"
 
 TextToSpeechBar::TextToSpeechBar(QWidget *parent)
-    : QFrame(parent)
+    : QFrame(parent), ui(new Ui::TextToSpeechBar)
 {
+    ui->setupUi(this);
+
     m_speech.setLocale(QLocale::system().language());
+    connect(&m_speech, &QTextToSpeech::stateChanged, this,
+            &TextToSpeechBar::onStateChanged);
+
+    ui->stopButton->setText(gt("stop"));
+    ui->stopButton->setDisabled(true);
+    connect(ui->stopButton, &QPushButton::pressed, this,
+            &TextToSpeechBar::stop);
 }
 
 void TextToSpeechBar::speak(const QString &text)
 {
     m_speech.say(text);
+}
+
+void TextToSpeechBar::stop()
+{
+    m_speech.stop();
+}
+
+void TextToSpeechBar::onStateChanged(QTextToSpeech::State state)
+{
+    ui->stopButton->setEnabled(state != QTextToSpeech::Ready);
 }

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -1,0 +1,12 @@
+#include "texttospeechbar.h"
+
+TextToSpeechBar::TextToSpeechBar(QWidget *parent)
+    : QFrame(parent)
+{
+    m_speech.setLocale(QLocale::system().language());
+}
+
+void TextToSpeechBar::speak(const QString &text)
+{
+    m_speech.say(text);
+}

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -49,6 +49,17 @@ void TextToSpeechBar::speechShow()
     setFocus();
 }
 
+void TextToSpeechBar::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Escape)
+    {
+        speechClose();
+        return;
+    }
+    
+    QFrame::keyPressEvent(event);
+}
+
 void TextToSpeechBar::onStateChanged(QTextToSpeech::State state)
 {
     ui->stopButton->setEnabled(state != QTextToSpeech::Ready);

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -17,6 +17,8 @@ TextToSpeechBar::TextToSpeechBar(QWidget *parent)
             this, &TextToSpeechBar::stop);
     connect(ui->stopButton, &QPushButton::pressed, this,
             &TextToSpeechBar::stop);
+    connect(ui->closeButton, &QPushButton::pressed,
+                this, &TextToSpeechBar::speechClose);
 }
 
 void TextToSpeechBar::speak(const QString &text)
@@ -27,6 +29,24 @@ void TextToSpeechBar::speak(const QString &text)
 void TextToSpeechBar::stop()
 {
     m_speech.stop();
+}
+
+void TextToSpeechBar::speechClose()
+{
+    /* Prevent webview from scrolling to up to the top after losing focus. */
+    const auto current = KiwixApp::instance()->getTabWidget()->currentWebView();
+    if (!current)
+        return;
+
+    current->setFocus();
+    m_speech.stop();
+    close();
+}
+
+void TextToSpeechBar::speechShow()
+{
+    show();
+    setFocus();
 }
 
 void TextToSpeechBar::onStateChanged(QTextToSpeech::State state)

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -12,7 +12,9 @@ TextToSpeechBar::TextToSpeechBar(QWidget *parent)
 
     ui->stopButton->setText(gt("stop"));
     ui->stopButton->setDisabled(true);
-    connect(KiwixApp::instance()->getAction(KiwixApp::ReadStopAction), &QAction::triggered,
+
+    const auto app = KiwixApp::instance();
+    connect(app->getAction(KiwixApp::ReadStopAction), &QAction::triggered,
             this, &TextToSpeechBar::stop);
     connect(ui->stopButton, &QPushButton::pressed, this,
             &TextToSpeechBar::stop);
@@ -22,6 +24,10 @@ TextToSpeechBar::TextToSpeechBar(QWidget *parent)
     setupVoiceComboBox();
     setupLanguageComboBox();
     languageSelected(ui->langComboBox->currentIndex());
+    connect(app->getAction(KiwixApp::ToggleTTSLanguageAction), &QAction::triggered,
+            this, &TextToSpeechBar::toggleLanguage);
+    connect(app->getAction(KiwixApp::ToggleTTSVoiceAction), &QAction::triggered,
+            this, &TextToSpeechBar::toggleVoice);
 }
 
 void TextToSpeechBar::speak(const QString &text)
@@ -134,6 +140,30 @@ void TextToSpeechBar::speechShow()
 {
     show();
     setFocus();
+}
+
+void TextToSpeechBar::toggleVoice()
+{
+    const auto zimView = KiwixApp::instance()->getTabWidget()->currentZimView();
+    if (!zimView || zimView->getTextToSpeechBar() != this)
+        return;
+
+    if (isHidden())
+        speechShow();
+
+    ui->voiceComboBox->showPopup();
+}
+
+void TextToSpeechBar::toggleLanguage()
+{
+    const auto zimView = KiwixApp::instance()->getTabWidget()->currentZimView();
+    if (!zimView || zimView->getTextToSpeechBar() != this)
+        return;
+
+    if (isHidden())
+        speechShow();
+
+    ui->langComboBox->showPopup();
 }
 
 void TextToSpeechBar::languageSelected(int index)

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -19,6 +19,8 @@ public:
 
 public slots:
     void onStateChanged(QTextToSpeech::State state);
+    void speechClose();
+    void speechShow();
 
 private:
     QTextToSpeech m_speech;

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -4,6 +4,10 @@
 #include <QTextToSpeech>
 #include <QFrame>
 
+namespace Ui {
+class TextToSpeechBar;
+}
+
 class TextToSpeechBar : public QFrame
 {
     Q_OBJECT
@@ -11,9 +15,14 @@ public:
     explicit TextToSpeechBar(QWidget *parent = nullptr);
 
     void speak(const QString& text);
+    void stop();
+
+public slots:
+    void onStateChanged(QTextToSpeech::State state);
 
 private:
     QTextToSpeech m_speech;
+    Ui::TextToSpeechBar *ui;
 };
 
 #endif // TEXTTOSPEECHMANAGER_H

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -3,10 +3,21 @@
 
 #include <QTextToSpeech>
 #include <QFrame>
+#include <QLineEdit>
 
 namespace Ui {
 class TextToSpeechBar;
 }
+
+class ComboBoxLineEdit : public QLineEdit
+{
+    Q_OBJECT
+public:
+    explicit ComboBoxLineEdit(QWidget *parent = 0);
+
+public slots:
+    void preventSelection();
+};
 
 class TextToSpeechBar : public QFrame
 {

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -42,6 +42,8 @@ public slots:
     void onStateChanged(QTextToSpeech::State state);
     void speechClose();
     void speechShow();
+    void toggleVoice();
+    void toggleLanguage();
     void languageSelected(int index);
     void voiceSelected(int index);
 

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -17,6 +17,9 @@ public:
 
 public slots:
     void preventSelection();
+
+protected:
+    void mouseReleaseEvent(QMouseEvent *);
 };
 
 class TextToSpeechBar : public QFrame

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -30,6 +30,7 @@ public:
 
     void speak(const QString& text);
     void stop();
+    void setLocale(const QLocale& locale);
 
     void setupLanguageComboBox();
     void setupVoiceComboBox();

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -1,0 +1,19 @@
+#ifndef TEXTTOSPEECHMANAGER_H
+#define TEXTTOSPEECHMANAGER_H
+
+#include <QTextToSpeech>
+#include <QFrame>
+
+class TextToSpeechBar : public QFrame
+{
+    Q_OBJECT
+public:
+    explicit TextToSpeechBar(QWidget *parent = nullptr);
+
+    void speak(const QString& text);
+
+private:
+    QTextToSpeech m_speech;
+};
+
+#endif // TEXTTOSPEECHMANAGER_H

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -52,6 +52,7 @@ private:
     QTextToSpeech m_speech;
     Ui::TextToSpeechBar *ui;
     QVector<QVoice> m_voices;
+    QString m_text;
 };
 
 #endif // TEXTTOSPEECHMANAGER_H

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -36,6 +36,8 @@ public:
     void setupVoiceComboBox();
     void resetVoiceComboBox();
 
+    int getVoiceIndex();
+
 public slots:
     void onStateChanged(QTextToSpeech::State state);
     void speechClose();

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -32,12 +32,15 @@ public:
     void stop();
 
     void setupLanguageComboBox();
+    void setupVoiceComboBox();
+    void resetVoiceComboBox();
 
 public slots:
     void onStateChanged(QTextToSpeech::State state);
     void speechClose();
     void speechShow();
     void languageSelected(int index);
+    void voiceSelected(int index);
 
 protected:
     void keyPressEvent(QKeyEvent *event);
@@ -45,6 +48,7 @@ protected:
 private:
     QTextToSpeech m_speech;
     Ui::TextToSpeechBar *ui;
+    QVector<QVoice> m_voices;
 };
 
 #endif // TEXTTOSPEECHMANAGER_H

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -22,6 +22,9 @@ public slots:
     void speechClose();
     void speechShow();
 
+protected:
+    void keyPressEvent(QKeyEvent *event);
+
 private:
     QTextToSpeech m_speech;
     Ui::TextToSpeechBar *ui;

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -17,10 +17,13 @@ public:
     void speak(const QString& text);
     void stop();
 
+    void setupLanguageComboBox();
+
 public slots:
     void onStateChanged(QTextToSpeech::State state);
     void speechClose();
     void speechShow();
+    void languageSelected(int index);
 
 protected:
     void keyPressEvent(QKeyEvent *event);

--- a/src/texttospeechbar.ui
+++ b/src/texttospeechbar.ui
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TextToSpeechBar</class>
+ <widget class="QFrame" name="TextToSpeechBar">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>833</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Frame</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="stopButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../resources/kiwix.qrc">
+       <normaloff>:/icons/stop-circle.svg</normaloff>:/icons/stop-circle.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../resources/kiwix.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/texttospeechbar.ui
+++ b/src/texttospeechbar.ui
@@ -38,6 +38,36 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="voiceLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="voiceComboBox">
+     <property name="editable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QPushButton" name="stopButton">
      <property name="enabled">
       <bool>true</bool>

--- a/src/texttospeechbar.ui
+++ b/src/texttospeechbar.ui
@@ -21,17 +21,21 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QLabel" name="langLabel">
+     <property name="text">
+      <string/>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="langComboBox">
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
      </property>
-    </spacer>
+     <property name="editable">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QPushButton" name="stopButton">
@@ -57,7 +61,7 @@
     </widget>
    </item>
    <item>
-    <spacer name="horizontalSpacer_2">
+    <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>

--- a/src/texttospeechbar.ui
+++ b/src/texttospeechbar.ui
@@ -69,6 +69,23 @@
      </property>
     </spacer>
    </item>
+   <item>
+    <widget class="QPushButton" name="closeButton">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../resources/kiwix.qrc">
+       <normaloff>:/icons/close.svg</normaloff>:/icons/close.svg</iconset>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources>

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -308,10 +308,12 @@ void WebView::contextMenuEvent(QContextMenuEvent *event)
         menu = createLinkContextMenu();
     }
 
+#if defined(QT_TEXTTOSPEECH_LIB)
     const auto app = KiwixApp::instance();
     menu->addAction(app->getAction(KiwixApp::ReadArticleAction));
     if (page()->hasSelection())
         menu->addAction(app->getAction(KiwixApp::ReadTextAction));
+#endif
 
     menu->exec(event->globalPos());
 }

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -307,6 +307,12 @@ void WebView::contextMenuEvent(QContextMenuEvent *event)
     } else {
         menu = createLinkContextMenu();
     }
+
+    const auto app = KiwixApp::instance();
+    menu->addAction(app->getAction(KiwixApp::ReadArticleAction));
+    if (page()->hasSelection())
+        menu->addAction(app->getAction(KiwixApp::ReadTextAction));
+
     menu->exec(event->globalPos());
 }
 

--- a/src/zimview.cpp
+++ b/src/zimview.cpp
@@ -20,6 +20,7 @@ ZimView::ZimView(TabBar *tabBar, QWidget *parent)
     layout->setSpacing(0);
     setLayout(layout); // now 'mp_webView' has 'this' as the parent QObject
     mp_findInPageBar->hide();
+    mp_ttsBar->hide();
     auto app = KiwixApp::instance();
     connect(app->getAction(KiwixApp::ReadArticleAction), &QAction::triggered, this, &ZimView::readArticle);
     connect(app->getAction(KiwixApp::ReadTextAction), &QAction::triggered, this, &ZimView::readSelectedText);
@@ -115,6 +116,7 @@ void ZimView::readArticle()
 
     mp_webView->page()->toPlainText([=](const QString& articleText){
         mp_ttsBar->speak(articleText);
+        mp_ttsBar->speechShow();
     });
 }
 
@@ -124,4 +126,5 @@ void ZimView::readSelectedText()
         return;
 
     mp_ttsBar->speak(mp_webView->page()->selectedText());
+    mp_ttsBar->speechShow();
 }

--- a/src/zimview.cpp
+++ b/src/zimview.cpp
@@ -101,6 +101,7 @@ ZimView::ZimView(TabBar *tabBar, QWidget *parent)
                     QToolTip::showText(pos, link);
                 }
             });
+    connect(mp_webView, &WebView::zimIdChanged, this, &ZimView::setSpeechLocaleByZimId);
 }
 
 void ZimView::openFindInPageBar()
@@ -127,4 +128,19 @@ void ZimView::readSelectedText()
 
     mp_ttsBar->speak(mp_webView->page()->selectedText());
     mp_ttsBar->speechShow();
+}
+
+void ZimView::setSpeechLocaleByZimId(const QString& zimId)
+{
+    try
+    {
+        const auto book = KiwixApp::instance()->getLibrary()->getBookById(zimId);
+        const auto iso3 = QString::fromStdString(book.getLanguages().at(0));
+        const auto iso2 = iso3.chopped(1);
+
+        /* Try both 3 letter and 2 letter name. */
+        const auto iso2Locale = QLocale(iso2);
+        const bool isValidISO2 = iso2Locale.language() != QLocale::C;
+        mp_ttsBar->setLocale(isValidISO2 ? iso2Locale : QLocale(iso3));
+    } catch (...) { /* Blank */ }
 }

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -22,6 +22,7 @@ public:
 public slots:
     void readArticle();
     void readSelectedText();
+    void setSpeechLocaleByZimId(const QString& zimId);
 
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -7,6 +7,7 @@
 class FindInPageBar;
 class TabBar;
 class WebView;
+class TextToSpeechBar;
 
 class ZimView : public QWidget
 {
@@ -18,6 +19,10 @@ public:
     FindInPageBar *getFindInPageBar() { return mp_findInPageBar; }
     void openFindInPageBar();
 
+public slots:
+    void readArticle();
+    void readSelectedText();
+
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
 
@@ -25,6 +30,7 @@ private:
     WebView *mp_webView;
     TabBar *mp_tabBar;
     FindInPageBar *mp_findInPageBar;
+    TextToSpeechBar *mp_ttsBar;
 };
 
 #endif // ZIMVIEW_H

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -17,6 +17,7 @@ public:
 
     WebView *getWebView() { return mp_webView; }
     FindInPageBar *getFindInPageBar() { return mp_findInPageBar; }
+    TextToSpeechBar *getTextToSpeechBar() { return mp_ttsBar; }
     void openFindInPageBar();
 
 public slots:

--- a/src/zimview.h
+++ b/src/zimview.h
@@ -7,7 +7,10 @@
 class FindInPageBar;
 class TabBar;
 class WebView;
+
+#if defined(QT_TEXTTOSPEECH_LIB)
 class TextToSpeechBar;
+#endif
 
 class ZimView : public QWidget
 {
@@ -17,13 +20,17 @@ public:
 
     WebView *getWebView() { return mp_webView; }
     FindInPageBar *getFindInPageBar() { return mp_findInPageBar; }
+#if defined(QT_TEXTTOSPEECH_LIB)
     TextToSpeechBar *getTextToSpeechBar() { return mp_ttsBar; }
+#endif
     void openFindInPageBar();
 
 public slots:
+#if defined(QT_TEXTTOSPEECH_LIB)
     void readArticle();
     void readSelectedText();
     void setSpeechLocaleByZimId(const QString& zimId);
+#endif
 
 signals:
     void webActionEnabledChanged(QWebEnginePage::WebAction action, bool enabled);
@@ -32,7 +39,10 @@ private:
     WebView *mp_webView;
     TabBar *mp_tabBar;
     FindInPageBar *mp_findInPageBar;
+
+#if defined(QT_TEXTTOSPEECH_LIB)
     TextToSpeechBar *mp_ttsBar;
+#endif
 };
 
 #endif // ZIMVIEW_H


### PR DESCRIPTION
Fix #44

Changes:
- Reading the entire or selected text on a web page in different languages.
- The reading can be triggered in the Edit Menu, Shortcut, and right-click on a page.
- TTS UI to select languages and voices, and stop the reading.
- Voice configurations are remembered between sessions.
- Language determined by Zim's Locale.

Shortcut:
- ALT + SHIFT + A: read article
- ALT + SHIFT + S: read selection
- ALT + SHIFT + X: stop reading
- ALT + SHIFT + V: open voice selector
- ALT + SHIFT + L: open language selector