### PR TITLE
Fixed Tab and Bookmark Right to Left Layout Drawing

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -177,8 +177,7 @@ QTabWidget::pane {
 }
 
 QTabBar::tab {
-    border: none;
-    border-right: 1px solid #ccc;
+    border: 1px solid #ccc;
     border-radius: 0;
     padding: 2px;
 }
@@ -191,10 +190,6 @@ QTabBar::tab:selected {
 QTabBar::tab:first {
     padding-top: 6px;
     padding-left: 5px;
-}
-
-QTabBar::tab:last {
-    border: none;
 }
 
 QTabBar::tab:last QToolButton {

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -176,15 +176,17 @@ QTabWidget::pane {
     border-top: 1px solid #ccc;
 }
 
+/* paintEvent of src/tabbar.cpp references the value of border and padding */
 QTabBar::tab {
     border: 1px solid #ccc;
     border-radius: 0;
-    padding: 2px;
+    padding: 4px;
+    padding-top: 6px;
 }
 
 QTabBar::tab:selected {
     background-color: white;
-    border-bottom: 2px solid white;
+    border-bottom: 1px solid white;
 }
 
 QTabBar::tab:first {

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -69,7 +69,8 @@ SearchBar > QToolButton {
 }
 
 SearchBar > BookmarkButton {
-    margin-right: 4px;   
+    margin-right: 3px;
+    margin-left: 3px; 
 }
 
 SearchBar > QToolButton:pressed,

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -425,8 +425,22 @@ void TabBar::paintEvent(QPaintEvent *e)
         bool textRightToLeft = tab_title.isRightToLeft();
         bool appRightToLeft = QWidget::isRightToLeft();
 
+        // See QTabBar::tab::padding value in resources/css/style.css
+        const int padding = 4;
         QRect tabTextRect = style()->subElementRect(QStyle::SE_TabBarTabText, &tabopt, this);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        // See QTabBar::tab::border value in resources/css/style.css
+        const int border = 1;
 
+        // Add Padding to left, right. Padding is 4px. Add 5 to account for 
+        // Extra pixel from border.
+        tabTextRect.setX(tabTextRect.x() + padding + border);
+        tabTextRect.setWidth(tabTextRect.width() - padding - border);
+#else
+        // Qt6 correctly adds left and right padding but now incorrectly adds
+        // top or bottom padding.
+        tabTextRect.setY(tabTextRect.y() - padding);
+#endif
         QRect fontTextRect = fontMetrics().boundingRect(tab_title);
 
         if (fontTextRect.width() > tabTextRect.width())

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -422,6 +422,8 @@ void TabBar::paintEvent(QPaintEvent *e)
         initStyleOption(&tabopt, i);
 
         bool need_fade_out = false;
+        bool textRightToLeft = tab_title.isRightToLeft();
+        bool appRightToLeft = QWidget::isRightToLeft();
 
         QRect tabTextRect = style()->subElementRect(QStyle::SE_TabBarTabText, &tabopt, this);
 
@@ -429,8 +431,6 @@ void TabBar::paintEvent(QPaintEvent *e)
 
         if (fontTextRect.width() > tabTextRect.width())
             need_fade_out = true;
-
-        bool right_to_left = tab_title.isRightToLeft();
 
         if (need_fade_out) {
             // draw the most of tab text extent with the normal color,
@@ -444,7 +444,7 @@ void TabBar::paintEvent(QPaintEvent *e)
             const int mid_Y = tabTextRect.center().y();
             QLinearGradient gr;
 
-            if (right_to_left) {
+            if (textRightToLeft) {
                 // arabic right-to-left text
                 gr.setStart(tabTextRect.x(), mid_Y);
                 gr.setFinalStop(tabTextRect.x() + 0.2 * tabTextRect.width(), mid_Y);
@@ -463,7 +463,13 @@ void TabBar::paintEvent(QPaintEvent *e)
 
         int align = Qt::AlignVCenter;
         if (need_fade_out) {
-            align |= (right_to_left)? Qt::AlignRight : Qt::AlignLeft;
+            /* 
+               We align LTR text in LTR app to the left, while RTL text in RTL app
+               to the right. Since Qt mirror alignment, we can simply do ALignLeft
+               for both cases. When text and app direction doesn't match, we flip
+               the text alignment.
+            */
+            align |= (textRightToLeft == appRightToLeft) ? Qt::AlignLeft : Qt::AlignRight;
         }
 
         style()->drawItemText(&p, tabTextRect, align,


### PR DESCRIPTION
Improve #594 Fix #1142 

Changes:
- Tab text alignment in RTL mode fixed. It was showing the tail of the title instead of the start.
- The left border of tabs was missing in RTL. Now each tab has both a left and right border. This makes the border a little thicker than before, but better UX than no border.
- I forgot to add the border on both sides when I refactored the search bar, which meant it has no left border in RTL mode. Fixed
- Title text now also has 2px padding.