### PR TITLE
Smarter directory monitoring

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -905,10 +905,18 @@ void ContentManager::handleDisappearedZimFiles(const QString& dirPath, const QSt
 size_t ContentManager::handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames)
 {
     size_t countOfSuccessfullyAddedZims = 0;
+    for (const auto& file : fileNames) {
+        const bool addedToLib = handleZimFileInMonitoredDir(dirPath, file);
+        countOfSuccessfullyAddedZims += addedToLib;
+    }
+    return countOfSuccessfullyAddedZims;
+}
+
+int ContentManager::handleZimFileInMonitoredDir(QString dirPath, QString file)
+{
     const auto kiwixLib = mp_library->getKiwixLibrary();
     kiwix::Manager manager(kiwixLib);
     auto& zimsInDir = m_knownZimsInDir[dirPath];
-    for (const auto& file : fileNames) {
         const auto bookPath = QDir::toNativeSeparators(dirPath + "/" + file);
         DBGOUT("directory monitoring: file appeared: " << bookPath);
         if ( mp_library->isBeingDownloadedByUs(bookPath) ) {
@@ -916,12 +924,11 @@ size_t ContentManager::handleNewZimFiles(const QString& dirPath, const QStringSe
         } else if ( manager.addBookFromPath(bookPath.toStdString()) ) {
             DBGOUT("                      and was added to the library");
             zimsInDir.insert(file);
-            ++countOfSuccessfullyAddedZims;
+            return 1;
         } else {
             DBGOUT("                      but could not be added to the library");
         }
-    }
-    return countOfSuccessfullyAddedZims;
+    return 0;
 }
 
 void ContentManager::updateLibraryFromDir(QString dirPath)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -855,9 +855,28 @@ void ContentManager::setSortBy(const QString& sortBy, const bool sortOrderAsc)
     emit(booksChanged());
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Directory monitoring stuff
+////////////////////////////////////////////////////////////////////////////////
+
 void ContentManager::setMonitorDirZims(QString monitorDir, Library::QStringSet zimList)
 {
     m_knownZimsInDir[monitorDir] = zimList;
+}
+
+void ContentManager::setMonitoredDirectories(QStringSet dirList)
+{
+    for (auto path : m_watcher.directories()) {
+        m_watcher.removePath(path);
+    }
+    for (auto dir : dirList) {
+        if (dir != "") {
+            const auto zimsInDir = mp_library->getLibraryZimsFromDir(dir);
+            setMonitorDirZims(dir, zimsInDir);
+            m_watcher.addPath(dir);
+            asyncUpdateLibraryFromDir(dir);
+        }
+    }
 }
 
 void ContentManager::asyncUpdateLibraryFromDir(QString dir)

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -962,12 +962,12 @@ int ContentManager::handleZimFileInMonitoredDir(QString dir, QString fileName)
 
     MonitoredZimFileInfo zfi = getMonitoredZimFileInfo(dir, fileName);
     if ( zfi.status == MonitoredZimFileInfo::PROCESS_NOW ) {
-    kiwix::Manager manager(mp_library->getKiwixLibrary());
-    const bool addedToLib = manager.addBookFromPath(bookPath.toStdString());
-    zfi.status = addedToLib
-               ? MonitoredZimFileInfo::ADDED_TO_THE_LIBRARY
-               : MonitoredZimFileInfo::COULD_NOT_BE_ADDED_TO_THE_LIBRARY;
-    m_knownZimsInDir[dir].insert(fileName, zfi);
+        kiwix::Manager manager(mp_library->getKiwixLibrary());
+        const bool addedToLib = manager.addBookFromPath(bookPath.toStdString());
+        zfi.status = addedToLib
+                   ? MonitoredZimFileInfo::ADDED_TO_THE_LIBRARY
+                   : MonitoredZimFileInfo::COULD_NOT_BE_ADDED_TO_THE_LIBRARY;
+        m_knownZimsInDir[dir].insert(fileName, zfi);
     }
     return zfi.status;
 }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -895,7 +895,11 @@ void ContentManager::updateLibraryFromDir(QString monitorDir)
         } else {
             DBGOUT("ContentManager::updateLibraryFromDir(): "
                    << "file appeared: " << bookPath);
-            needsRefresh |= manager.addBookFromPath(bookPath.toStdString());
+            const bool added = manager.addBookFromPath(bookPath.toStdString());
+            DBGOUT("                                        "
+                   << (added ? "and was added" : "but could not be added")
+                   << " to the library");
+            needsRefresh |= added;
         }
     }
     if (needsRefresh) {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -951,11 +951,16 @@ int ContentManager::handleZimFileInMonitoredDir(QString dir, QString fileName)
     }
 }
 
+ContentManager::QStringSet ContentManager::getLibraryZims(QString dirPath) const
+{
+    return m_knownZimsInDir[dirPath];
+}
+
 void ContentManager::updateLibraryFromDir(QString dirPath)
 {
     QMutexLocker locker(&m_updateFromDirMutex);
     const QDir dir(dirPath);
-    const QStringSet zimsPresentInLib = m_knownZimsInDir[dirPath];
+    const QStringSet zimsPresentInLib = getLibraryZims(dirPath);
 
     QStringSet zimsInDir;
     for (const auto &file : dir.entryList({"*.zim"})) {

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -118,6 +118,9 @@ ContentManager::ContentManager(Library* library)
     if ( DownloadManager::downloadingFunctionalityAvailable() ) {
         startDownloadUpdaterThread();
     }
+
+    connect(&m_watcher, &QFileSystemWatcher::directoryChanged,
+            this, &ContentManager::asyncUpdateLibraryFromDir);
 }
 
 void ContentManager::updateModel()

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -942,6 +942,16 @@ bool ContentManager::handleZimFileInMonitoredDirLogged(QString dir, QString file
     return status == MonitoredZimFileInfo::ADDED_TO_THE_LIBRARY;
 }
 
+ContentManager::MonitoredZimFileInfo ContentManager::getMonitoredZimFileInfo(QString dir, QString fileName) const
+{
+    Q_UNUSED(dir);
+    Q_UNUSED(fileName);
+    // TODO: implement properly
+    MonitoredZimFileInfo zfi;
+    zfi.status = MonitoredZimFileInfo::PROCESS_NOW;
+    return zfi;
+}
+
 int ContentManager::handleZimFileInMonitoredDir(QString dir, QString fileName)
 {
     const auto bookPath = QDir::toNativeSeparators(dir + "/" + fileName);
@@ -950,13 +960,15 @@ int ContentManager::handleZimFileInMonitoredDir(QString dir, QString fileName)
         return MonitoredZimFileInfo::BEING_DOWNLOADED_BY_US;
     }
 
-    MonitoredZimFileInfo zfi;
+    MonitoredZimFileInfo zfi = getMonitoredZimFileInfo(dir, fileName);
+    if ( zfi.status == MonitoredZimFileInfo::PROCESS_NOW ) {
     kiwix::Manager manager(mp_library->getKiwixLibrary());
     const bool addedToLib = manager.addBookFromPath(bookPath.toStdString());
     zfi.status = addedToLib
                ? MonitoredZimFileInfo::ADDED_TO_THE_LIBRARY
                : MonitoredZimFileInfo::COULD_NOT_BE_ADDED_TO_THE_LIBRARY;
     m_knownZimsInDir[dir].insert(fileName, zfi);
+    }
     return zfi.status;
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -859,11 +859,6 @@ void ContentManager::setSortBy(const QString& sortBy, const bool sortOrderAsc)
 // Directory monitoring stuff
 ////////////////////////////////////////////////////////////////////////////////
 
-void ContentManager::setMonitorDirZims(QString monitorDir, Library::QStringSet zimList)
-{
-    m_knownZimsInDir[monitorDir] = zimList;
-}
-
 void ContentManager::setMonitoredDirectories(QStringSet dirList)
 {
     for (auto path : m_watcher.directories()) {
@@ -871,8 +866,7 @@ void ContentManager::setMonitoredDirectories(QStringSet dirList)
     }
     for (auto dir : dirList) {
         if (dir != "") {
-            const auto zimsInDir = mp_library->getLibraryZimsFromDir(dir);
-            setMonitorDirZims(dir, zimsInDir);
+            m_knownZimsInDir[dir] = mp_library->getLibraryZimsFromDir(dir);
             m_watcher.addPath(dir);
             asyncUpdateLibraryFromDir(dir);
         }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -905,7 +905,7 @@ void ContentManager::updateLibraryFromDir(QString monitorDir)
             const bool added = manager.addBookFromPath(bookPath.toStdString());
             DBGOUT("                     "
                    << (added ? "and was added" : "but could not be added")
-                   << "to the library");
+                   << " to the library");
             needsRefresh |= added;
         }
     }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -912,18 +912,16 @@ size_t ContentManager::handleNewZimFiles(const QString& dirPath, const QStringSe
     return countOfSuccessfullyAddedZims;
 }
 
-int ContentManager::handleZimFileInMonitoredDir(QString dirPath, QString file)
+int ContentManager::handleZimFileInMonitoredDir(QString dir, QString fileName)
 {
-    const auto kiwixLib = mp_library->getKiwixLibrary();
-    kiwix::Manager manager(kiwixLib);
-    auto& zimsInDir = m_knownZimsInDir[dirPath];
-    const auto bookPath = QDir::toNativeSeparators(dirPath + "/" + file);
+    const auto bookPath = QDir::toNativeSeparators(dir + "/" + fileName);
+    kiwix::Manager manager(mp_library->getKiwixLibrary());
     DBGOUT("directory monitoring: file appeared: " << bookPath);
     if ( mp_library->isBeingDownloadedByUs(bookPath) ) {
         DBGOUT("                      it is being downloaded by us, ignoring...");
     } else if ( manager.addBookFromPath(bookPath.toStdString()) ) {
         DBGOUT("                      and was added to the library");
-        zimsInDir.insert(file);
+        m_knownZimsInDir[dir].insert(fileName);
         return 1;
     } else {
         DBGOUT("                      but could not be added to the library");

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -23,7 +23,7 @@
 #include <QDesktopServices>
 
 #ifndef QT_NO_DEBUG
-#define DBGOUT(X) qDebug() << "DBG: " << X
+#define DBGOUT(X) qDebug().nospace() << "DBG: " << X
 #else
 #define DBGOUT(X)
 #endif

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -916,7 +916,8 @@ void ContentManager::updateLibraryFromDir(QString dirPath)
     if (!removedZims.empty() || !successfullyAddedZims.empty()) {
         mp_library->save();
         emit(booksChanged());
-        setMonitorDirZims(dirPath, zimsInDir);
+        const QStringSet problematicZims = zimsNotInLib - successfullyAddedZims;
+        setMonitorDirZims(dirPath, zimsInDir - problematicZims);
     }
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -917,17 +917,17 @@ int ContentManager::handleZimFileInMonitoredDir(QString dirPath, QString file)
     const auto kiwixLib = mp_library->getKiwixLibrary();
     kiwix::Manager manager(kiwixLib);
     auto& zimsInDir = m_knownZimsInDir[dirPath];
-        const auto bookPath = QDir::toNativeSeparators(dirPath + "/" + file);
-        DBGOUT("directory monitoring: file appeared: " << bookPath);
-        if ( mp_library->isBeingDownloadedByUs(bookPath) ) {
-            DBGOUT("                      it is being downloaded by us, ignoring...");
-        } else if ( manager.addBookFromPath(bookPath.toStdString()) ) {
-            DBGOUT("                      and was added to the library");
-            zimsInDir.insert(file);
-            return 1;
-        } else {
-            DBGOUT("                      but could not be added to the library");
-        }
+    const auto bookPath = QDir::toNativeSeparators(dirPath + "/" + file);
+    DBGOUT("directory monitoring: file appeared: " << bookPath);
+    if ( mp_library->isBeingDownloadedByUs(bookPath) ) {
+        DBGOUT("                      it is being downloaded by us, ignoring...");
+    } else if ( manager.addBookFromPath(bookPath.toStdString()) ) {
+        DBGOUT("                      and was added to the library");
+        zimsInDir.insert(file);
+        return 1;
+    } else {
+        DBGOUT("                      but could not be added to the library");
+    }
     return 0;
 }
 

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -864,6 +864,7 @@ void ContentManager::setMonitoredDirectories(QStringSet dirList)
     for (auto path : m_watcher.directories()) {
         m_watcher.removePath(path);
     }
+    m_knownZimsInDir.clear();
     for (auto dir : dirList) {
         if (dir != "") {
             m_knownZimsInDir[dir] = mp_library->getLibraryZimsFromDir(dir);

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -22,6 +22,12 @@
 #include "contentmanagerheader.h"
 #include <QDesktopServices>
 
+#ifndef QT_NO_DEBUG
+#define DBGOUT(X) qDebug() << "DBG: " << X
+#else
+#define DBGOUT(X)
+#endif
+
 namespace
 {
 
@@ -876,20 +882,19 @@ void ContentManager::updateLibraryFromDir(QString monitorDir)
     bool needsRefresh = !removedZims.empty();
     for (auto bookPath : removedZims) {
         try {
-            // qDebug() << "DBG: ContentManager::updateLibraryFromDir(): "
-            //          << "file disappeared: " << bookPath;
+            DBGOUT("ContentManager::updateLibraryFromDir(): "
+                    << "file disappeared: " << bookPath);
             const auto book = kiwixLib->getBookByPath(bookPath.toStdString());
             handleDisappearedZimFile(QString::fromStdString(book.getId()));
         } catch (...) {}
     }
     for (auto bookPath : addedZims) {
         if ( mp_library->isBeingDownloadedByUs(bookPath) ) {
-            // qDebug() << "DBG: ContentManager::updateLibraryFromDir(): "
-            //          << bookPath
-            //          << " ignored since it is being downloaded by us.";
+            DBGOUT("ContentManager::updateLibraryFromDir(): " << bookPath
+                    << " ignored since it is being downloaded by us.");
         } else {
-            // qDebug() << "DBG: ContentManager::updateLibraryFromDir(): "
-            //          << "file appeared: " << bookPath;
+            DBGOUT("ContentManager::updateLibraryFromDir(): "
+                   << "file appeared: " << bookPath);
             needsRefresh |= manager.addBookFromPath(bookPath.toStdString());
         }
     }

--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -945,16 +945,19 @@ bool ContentManager::handleZimFileInMonitoredDirLogged(QString dir, QString file
 int ContentManager::handleZimFileInMonitoredDir(QString dir, QString fileName)
 {
     const auto bookPath = QDir::toNativeSeparators(dir + "/" + fileName);
-    kiwix::Manager manager(mp_library->getKiwixLibrary());
 
     if ( mp_library->isBeingDownloadedByUs(bookPath) ) {
         return MonitoredZimFileInfo::BEING_DOWNLOADED_BY_US;
-    } else if ( manager.addBookFromPath(bookPath.toStdString()) ) {
-        m_knownZimsInDir[dir].insert(fileName, MonitoredZimFileInfo());
-        return MonitoredZimFileInfo::ADDED_TO_THE_LIBRARY;
-    } else {
-        return MonitoredZimFileInfo::COULD_NOT_BE_ADDED_TO_THE_LIBRARY;
     }
+
+    MonitoredZimFileInfo zfi;
+    kiwix::Manager manager(mp_library->getKiwixLibrary());
+    const bool addedToLib = manager.addBookFromPath(bookPath.toStdString());
+    zfi.status = addedToLib
+               ? MonitoredZimFileInfo::ADDED_TO_THE_LIBRARY
+               : MonitoredZimFileInfo::COULD_NOT_BE_ADDED_TO_THE_LIBRARY;
+    m_knownZimsInDir[dir].insert(fileName, zfi);
+    return zfi.status;
 }
 
 ContentManager::QStringSet ContentManager::getLibraryZims(QString dirPath) const

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -122,7 +122,11 @@ private: // types
             // the attempt to add the file to the library failed
             COULD_NOT_BE_ADDED_TO_THE_LIBRARY
         };
+
+        ZimFileStatus status = ADDED_TO_THE_LIBRARY;
     };
+
+    typedef QMap<QString, MonitoredZimFileInfo> ZimFileName2InfoMap;
 
 private: // functions
     QStringList getBookIds();
@@ -171,7 +175,7 @@ private: // data
 
     QFileSystemWatcher m_watcher;
     QMutex m_updateFromDirMutex;
-    QMap<QString, QStringSet> m_knownZimsInDir;
+    QMap<QString, ZimFileName2InfoMap> m_knownZimsInDir;
 };
 
 #endif // CONTENTMANAGER_H

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -71,7 +71,6 @@ public: // functions
     LanguageList getLanguages() const { return m_languages; }
 
     void setMonitoredDirectories(QStringSet dirList);
-    void asyncUpdateLibraryFromDir(QString dir);
 
 signals:
     void filterParamsChanged();
@@ -117,6 +116,7 @@ private: // functions
     void updateModel();
     void setCategories();
     void setLanguages();
+    void asyncUpdateLibraryFromDir(QString dir);
     void updateLibraryFromDir(QString dir);
     void handleDisappearedZimFiles(const QString& dirPath, const QStringSet& fileNames);
     size_t handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -108,6 +108,22 @@ public slots:
     void downloadWasCancelled(const QString& id);
     void handleError(QString errSummary, QString errDetails);
 
+private: // types
+    struct MonitoredZimFileInfo
+    {
+        enum ZimFileStatus
+        {
+            // the file is known to be downloaded by our own download manager
+            BEING_DOWNLOADED_BY_US,
+
+            // the file was added the library successfully
+            ADDED_TO_THE_LIBRARY,
+
+            // the attempt to add the file to the library failed
+            COULD_NOT_BE_ADDED_TO_THE_LIBRARY
+        };
+    };
+
 private: // functions
     QStringList getBookIds();
     // reallyEraseBook() doesn't ask for confirmation (unlike eraseBook())
@@ -120,6 +136,7 @@ private: // functions
     void updateLibraryFromDir(QString dir);
     void handleDisappearedZimFiles(const QString& dirPath, const QStringSet& fileNames);
     size_t handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);
+    bool handleZimFileInMonitoredDirLogged(QString dirPath, QString fileName);
     int handleZimFileInMonitoredDir(QString dirPath, QString fileName);
     bool handleDisappearedBook(QString bookId);
 

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -119,8 +119,8 @@ private: // functions
     void setLanguages();
     void updateLibraryFromDir(QString dir);
     void handleDisappearedZimFiles(const QString& dirPath, const QStringSet& fileNames);
-    QStringSet handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);
-    void handleDisappearedZimFile(QString bookId);
+    size_t handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);
+    bool handleDisappearedBook(QString bookId);
 
     // Get the book with the specified id from
     // the remote or local library (in that order).

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -70,6 +70,7 @@ public: // functions
     QStringList getCategories() const { return m_categories; }
     LanguageList getLanguages() const { return m_languages; }
 
+    void setMonitoredDirectories(QStringSet dirList);
     void setMonitorDirZims(QString monitorDir, QStringSet zimList);
     void asyncUpdateLibraryFromDir(QString dir);
 
@@ -150,6 +151,7 @@ private: // data
     ContentManagerModel *managerModel;
     QMutex remoteLibraryLocker;
 
+    QFileSystemWatcher m_watcher;
     QMutex m_updateFromDirMutex;
     QMap<QString, QStringSet> m_knownZimsInDir;
 };

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -19,6 +19,7 @@ public: // types
     typedef QList<QPair<QString, QString>> FilterList;
     typedef ContentManagerModel::BookInfo     BookInfo;
     typedef ContentManagerModel::BookInfoList BookInfoList;
+    typedef Library::QStringSet QStringSet;
 
     enum class BookState
     {
@@ -69,7 +70,7 @@ public: // functions
     QStringList getCategories() const { return m_categories; }
     LanguageList getLanguages() const { return m_languages; }
 
-    void setMonitorDirZims(QString monitorDir, Library::QStringSet zimList);
+    void setMonitorDirZims(QString monitorDir, QStringSet zimList);
     void asyncUpdateLibraryFromDir(QString dir);
 
 signals:
@@ -117,6 +118,7 @@ private: // functions
     void setCategories();
     void setLanguages();
     void updateLibraryFromDir(QString dir);
+    void handleDisappearedZimFiles(const QStringSet& zimPaths);
     void handleDisappearedZimFile(QString bookId);
 
     // Get the book with the specified id from
@@ -148,7 +150,7 @@ private: // data
     QMutex remoteLibraryLocker;
 
     QMutex m_updateFromDirMutex;
-    QMap<QString, Library::QStringSet> m_knownZimsInDir;
+    QMap<QString, QStringSet> m_knownZimsInDir;
 };
 
 #endif // CONTENTMANAGER_H

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -113,6 +113,9 @@ private: // types
     {
         enum ZimFileStatus
         {
+            // try to add this file to the library right away
+            NO_INFO,
+
             // the file is known to be downloaded by our own download manager
             BEING_DOWNLOADED_BY_US,
 
@@ -123,7 +126,7 @@ private: // types
             COULD_NOT_BE_ADDED_TO_THE_LIBRARY
         };
 
-        ZimFileStatus status = ADDED_TO_THE_LIBRARY;
+        ZimFileStatus status = NO_INFO;
     };
 
     typedef QMap<QString, MonitoredZimFileInfo> ZimFileName2InfoMap;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -132,6 +132,7 @@ private: // functions
     void updateModel();
     void setCategories();
     void setLanguages();
+    QStringSet getLibraryZims(QString dirPath) const;
     void asyncUpdateLibraryFromDir(QString dir);
     void updateLibraryFromDir(QString dir);
     void handleDisappearedZimFiles(const QString& dirPath, const QStringSet& fileNames);

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -120,6 +120,7 @@ private: // functions
     void updateLibraryFromDir(QString dir);
     void handleDisappearedZimFiles(const QString& dirPath, const QStringSet& fileNames);
     size_t handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);
+    int handleZimFileInMonitoredDir(QString dirPath, QString fileName);
     bool handleDisappearedBook(QString bookId);
 
     // Get the book with the specified id from

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -116,7 +116,7 @@ private: // types
             // the file is known to be downloaded by our own download manager
             BEING_DOWNLOADED_BY_US,
 
-            // the file was added the library successfully
+            // the file was added to the library successfully
             ADDED_TO_THE_LIBRARY,
 
             // the attempt to add the file to the library failed

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -114,7 +114,7 @@ private: // types
         enum ZimFileStatus
         {
             // try to add this file to the library right away
-            NO_INFO,
+            PROCESS_NOW,
 
             // the file is known to be downloaded by our own download manager
             BEING_DOWNLOADED_BY_US,
@@ -126,7 +126,7 @@ private: // types
             COULD_NOT_BE_ADDED_TO_THE_LIBRARY
         };
 
-        ZimFileStatus status = NO_INFO;
+        ZimFileStatus status = PROCESS_NOW;
     };
 
     typedef QMap<QString, MonitoredZimFileInfo> ZimFileName2InfoMap;
@@ -146,6 +146,7 @@ private: // functions
     size_t handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);
     bool handleZimFileInMonitoredDirLogged(QString dirPath, QString fileName);
     int handleZimFileInMonitoredDir(QString dirPath, QString fileName);
+    MonitoredZimFileInfo getMonitoredZimFileInfo(QString dir, QString fileName) const;
     bool handleDisappearedBook(QString bookId);
 
     // Get the book with the specified id from

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -118,8 +118,8 @@ private: // functions
     void setCategories();
     void setLanguages();
     void updateLibraryFromDir(QString dir);
-    void handleDisappearedZimFiles(const QStringSet& zimPaths);
-    QStringSet handleNewZimFiles(const QStringSet& zimPaths);
+    void handleDisappearedZimFiles(const QString& dirPath, const QStringSet& fileNames);
+    QStringSet handleNewZimFiles(const QString& dirPath, const QStringSet& fileNames);
     void handleDisappearedZimFile(QString bookId);
 
     // Get the book with the specified id from

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -123,10 +123,17 @@ private: // types
             ADDED_TO_THE_LIBRARY,
 
             // the attempt to add the file to the library failed
-            COULD_NOT_BE_ADDED_TO_THE_LIBRARY
+            COULD_NOT_BE_ADDED_TO_THE_LIBRARY,
+
+            // the file couldn't be added to the library earlier and hasn't
+            // changed since then
+            UNCHANGED_KNOWN_BAD_ZIM_FILE
         };
 
+        void updateStatus(const MonitoredZimFileInfo& prevInfo);
+
         ZimFileStatus status = PROCESS_NOW;
+        QDateTime lastModified;
     };
 
     typedef QMap<QString, MonitoredZimFileInfo> ZimFileName2InfoMap;

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -119,6 +119,7 @@ private: // functions
     void setLanguages();
     void updateLibraryFromDir(QString dir);
     void handleDisappearedZimFiles(const QStringSet& zimPaths);
+    QStringSet handleNewZimFiles(const QStringSet& zimPaths);
     void handleDisappearedZimFile(QString bookId);
 
     // Get the book with the specified id from

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -127,9 +127,16 @@ private: // types
 
             // the file couldn't be added to the library earlier and hasn't
             // changed since then
-            UNCHANGED_KNOWN_BAD_ZIM_FILE
+            UNCHANGED_KNOWN_BAD_ZIM_FILE,
+
+            // try to add this file to the library at a later time
+            PROCESS_LATER,
+
+            // this file is known to be enqueued for later processing
+            DEFERRED_PROCESSING_ALREADY_PENDING
         };
 
+        bool fileKeepsBeingModified() const;
         void updateStatus(const MonitoredZimFileInfo& prevInfo);
 
         ZimFileStatus status = PROCESS_NOW;
@@ -154,6 +161,8 @@ private: // functions
     bool handleZimFileInMonitoredDirLogged(QString dirPath, QString fileName);
     int handleZimFileInMonitoredDir(QString dirPath, QString fileName);
     MonitoredZimFileInfo getMonitoredZimFileInfo(QString dir, QString fileName) const;
+    void deferHandlingOfZimFileInMonitoredDir(QString dir, QString fileName);
+    void handleZimFileInMonitoredDirDeferred(QString dirPath, QString fileName);
     bool handleDisappearedBook(QString bookId);
 
     // Get the book with the specified id from

--- a/src/contentmanager.h
+++ b/src/contentmanager.h
@@ -71,7 +71,6 @@ public: // functions
     LanguageList getLanguages() const { return m_languages; }
 
     void setMonitoredDirectories(QStringSet dirList);
-    void setMonitorDirZims(QString monitorDir, QStringSet zimList);
     void asyncUpdateLibraryFromDir(QString dir);
 
 signals:

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -119,6 +119,14 @@ void KiwixApp::setupDirectoryMonitoring()
     QString monitorDir = m_settingsManager.getMonitorDir();
     QString downloadDir = m_settingsManager.getDownloadDir();
     auto dirList = QSet<QString>({monitorDir, downloadDir});
+    setMonitoredDirectories(dirList);
+}
+
+void KiwixApp::setMonitoredDirectories(QSet<QString> dirList)
+{
+    for (auto path : m_watcher.directories()) {
+        m_watcher.removePath(path);
+    }
     for (auto dir : dirList) {
         if (dir != "") {
             const auto zimsInDir = m_library.getLibraryZimsFromDir(dir);
@@ -345,9 +353,6 @@ bool KiwixApp::isCurrentArticleBookmarked()
 
 void KiwixApp::setMonitorDir(const QString &dir) {
     m_settingsManager.setMonitorDir(dir);
-    for (auto path : m_watcher.directories()) {
-        m_watcher.removePath(path);
-    }
     setupDirectoryMonitoring();
 }
 

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -104,9 +104,6 @@ void KiwixApp::init()
             this->openZimFile(message);
         }
     });
-    connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, [=](QString monitorDir) {
-        mp_manager->asyncUpdateLibraryFromDir(monitorDir);
-    });
 
     /* Restore Tabs before directory monitoring to ensure we know what tabs user had. */
     restoreTabs();
@@ -119,20 +116,20 @@ void KiwixApp::setupDirectoryMonitoring()
     QString monitorDir = m_settingsManager.getMonitorDir();
     QString downloadDir = m_settingsManager.getDownloadDir();
     auto dirList = QSet<QString>({monitorDir, downloadDir});
-    setMonitoredDirectories(dirList);
+    mp_manager->setMonitoredDirectories(dirList);
 }
 
-void KiwixApp::setMonitoredDirectories(QSet<QString> dirList)
+void ContentManager::setMonitoredDirectories(QStringSet dirList)
 {
     for (auto path : m_watcher.directories()) {
         m_watcher.removePath(path);
     }
     for (auto dir : dirList) {
         if (dir != "") {
-            const auto zimsInDir = m_library.getLibraryZimsFromDir(dir);
-            mp_manager->setMonitorDirZims(dir, zimsInDir);
+            const auto zimsInDir = mp_library->getLibraryZimsFromDir(dir);
+            setMonitorDirZims(dir, zimsInDir);
             m_watcher.addPath(dir);
-            mp_manager->asyncUpdateLibraryFromDir(dir);
+            asyncUpdateLibraryFromDir(dir);
         }
     }
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -119,21 +119,6 @@ void KiwixApp::setupDirectoryMonitoring()
     mp_manager->setMonitoredDirectories(dirList);
 }
 
-void ContentManager::setMonitoredDirectories(QStringSet dirList)
-{
-    for (auto path : m_watcher.directories()) {
-        m_watcher.removePath(path);
-    }
-    for (auto dir : dirList) {
-        if (dir != "") {
-            const auto zimsInDir = mp_library->getLibraryZimsFromDir(dir);
-            setMonitorDirZims(dir, zimsInDir);
-            m_watcher.addPath(dir);
-            asyncUpdateLibraryFromDir(dir);
-        }
-    }
-}
-
 KiwixApp::~KiwixApp()
 {
     m_server.stop();

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -128,6 +128,7 @@ private:
     QAction*     mpa_actions[MAX_ACTION];
 
     void setupDirectoryMonitoring();
+    void setMonitoredDirectories(QSet<QString> dirList);
     QString findLibraryDirectory();
     void restoreTabs();
     void loadAndInstallTranslations(QTranslator& translator, const QString& filename, const QString& directory);

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -122,13 +122,11 @@ private:
     std::shared_ptr<kiwix::UpdatableNameMapper> mp_nameMapper;
     kiwix::Server m_server;
     Translation m_translation;
-    QFileSystemWatcher m_watcher;
     QSettings* mp_session;
 
     QAction*     mpa_actions[MAX_ACTION];
 
     void setupDirectoryMonitoring();
-    void setMonitoredDirectories(QSet<QString> dirList);
     QString findLibraryDirectory();
     void restoreTabs();
     void loadAndInstallTranslations(QTranslator& translator, const QString& filename, const QString& directory);

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -201,9 +201,9 @@ Library::QStringSet Library::getLibraryZimsFromDir(QString dir) const
         auto filePath = QString::fromStdString(getBookById(str).getPath());
         if ( filePath.endsWith(BEINGDOWNLOADEDSUFFIX) )
                 continue;
-        QDir absoluteDir = QFileInfo(filePath).absoluteDir();
-        if (absoluteDir == dir) {
-            zimsInDir.insert(filePath);
+        const QFileInfo fileInfo(filePath);
+        if (fileInfo.absoluteDir() == dir) {
+            zimsInDir.insert(fileInfo.fileName());
         }
     }
     return zimsInDir;


### PR DESCRIPTION
Fixes #1150

This is the best attempt at fixing #1150.

Directory monitoring was enhanced to work as follows:

- if adding a new file from a monitored directory fails, attempts to add it are repeated on further updates to that file until the file is good enough to be added to the library. Note that this doesn't mean that the ZIM file under question if perfectly valid, since adding to the library depends on minimal data from the ZIM file and will succeed as long as there are no issues with that data. If the file is still being downloaded by an external tool, opening that ZIM file for browsing may fail (then it will be dropped from the library) or certain content from it may fail to be loaded/displayed (the latter scenario has been addressed by #1174).
- care has been taken to minimize attempts to add a new ZIM file while the chances of succeeding at it are low.

The PR starts with refactoring - all code responsible for directory monitoring is transferred to `ContentManager` and cleaned up and only after that enhancement to that functionality is made.