### PR TITLE
Migrate getDataDirectory from libkiwix to kiwix-desktop

### DIFF
--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -105,7 +105,7 @@ namespace
 kiwix::Downloader* createDownloader()
 {
     try {
-        return new kiwix::Downloader();
+        return new kiwix::Downloader(getDataDirectory().toStdString());
     } catch (std::exception& e) {
         QMessageBox::critical(nullptr, gt("error-downloader-window-title"),
         gt("error-downloader-launch-message") + "<br><br>" + e.what());
@@ -283,19 +283,17 @@ void DownloadManager::checkThatBookCanBeDownloaded(const kiwix::Book& book, cons
 
 std::string DownloadManager::startDownload(const kiwix::Book& book, const QString& downloadDirPath)
 {
-    typedef std::vector<std::pair<std::string, std::string>> DownloadOptions;
-
     const std::string& url = book.getUrl();
     const QString bookId = QString::fromStdString(book.getId());
-    const DownloadOptions downloadOptions{{"dir", downloadDirPath.toStdString()}};
 
     std::string downloadId;
     try {
-        const auto d = mp_downloader->startDownload(url, downloadOptions);
+        const auto d = mp_downloader->startDownload(url, downloadDirPath.toStdString());
         downloadId = d->getDid();
     } catch (std::exception& e) {
         throwDownloadUnavailableError();
     }
+    
     return downloadId;
 }
 

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -157,7 +157,7 @@ QString KiwixApp::findLibraryDirectory()
     return currentDataDir;
 
   // Check for default dataDirectory.
-  currentDataDir = QString::fromStdString(kiwix::getDataDirectory());
+  currentDataDir = getDataDirectory();
   libraryFile = QFileInfo(currentDataDir, "library.xml");
   if (libraryFile.exists())
     return currentDataDir;

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -7,6 +7,16 @@
 #include <QLocale>
 #include <QList>
 
+QString getDataDirectory()
+{
+    QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    
+    if (!dataDir.isEmpty() && QDir().mkpath(dataDir))
+        return dataDir;
+    
+    return QString::fromStdString(kiwix::getCurrentDirectory());
+}
+
 SettingsManager::SettingsManager(QObject *parent)
     : QObject(parent),
     m_settings("Kiwix", "Kiwix-desktop"),
@@ -152,7 +162,7 @@ void SettingsManager::initSettings()
 {
     m_kiwixServerPort = m_settings.value("localKiwixServer/port", 8080).toInt();
     m_zoomFactor = m_settings.value("view/zoomFactor", 1).toDouble();
-    m_downloadDir = m_settings.value("download/dir", QString::fromStdString(kiwix::getDataDirectory())).toString();
+    m_downloadDir = m_settings.value("download/dir", getDataDirectory()).toString();
     m_kiwixServerIpAddress = m_settings.value("localKiwixServer/ipAddress", QString("0.0.0.0")).toString();
     m_monitorDir = m_settings.value("monitor/dir", QString("")).toString();
     m_moveToTrash = m_settings.value("moveToTrash", true).toBool();

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -77,4 +77,5 @@ private:
     QList<QVariant> m_contentTypeList;
 };
 
+QString getDataDirectory();
 #endif // SETTINGSMANAGER_H

--- a/src/settingsview.cpp
+++ b/src/settingsview.cpp
@@ -109,7 +109,7 @@ bool SettingsView::confirmDialogMonitorDir(const QString &dir) {
 
 void SettingsView::resetDownloadDir()
 {
-    auto dir = QString::fromStdString(kiwix::getDataDirectory());
+    auto dir = getDataDirectory();
     const auto &downloadDir = KiwixApp::instance()->getSettingsManager()->getDownloadDir();
     if (dir == downloadDir) {
         return;


### PR DESCRIPTION
This migrates the `getDataDirectory()` function from libkiwix, after some cleanups.
 - Also removes `KIWIX_DATA_DIR`

Fixes kiwix/libkiwix#1087 
Fixes kiwix/libkiwix#1085

Blocked by https://github.com/kiwix/libkiwix/pull/1107