### PR TITLE
Disable sandbox when run from Windows network share

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,10 @@
 #include <QCommandLineParser>
 #include <iostream>
 #include <sstream>
+#ifdef Q_OS_WIN
+    #include <kiwix/tools.h>
+    #include <windows.h>
+#endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
   #include <QWebEngineUrlScheme>
 #endif
@@ -18,6 +22,15 @@ int main(int argc, char *argv[])
     }
 // End of hack ^^^
 
+#ifdef Q_OS_WIN
+    std::string driveLetter = kiwix::getExecutablePath().substr(0, 3);
+    qInfo() << driverLetter;
+    UINT driveType = GetDriveTypeA(driveLetter.c_str());
+    if(driveType == DRIVE_REMOTE) {
+        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArray("--no-sandbox"));
+        qInfo() << "Disabled sandbox";
+    }
+#endif
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     // High DPI Scaling is enabled by default in Qt6. This attribute no longer exists in 6.0 and later
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
This aims to close #885 by adding the `--no-sandbox` command line argument.

This allows the user to manage the risk and turn off the sandbox for example when running from a network mounted drive on Windows.

Also, so as to apply the no sandbox flag before the KiwixApp has been instantiated, the argument check is being done with the usual way of checking `argv` instead of using `QCommandLineParser` which runs on `KiwixApp::a`.