### PR TITLE
Correctly include stdexcept.

### DIFF
--- a/src/kiwixconfirmbox.h
+++ b/src/kiwixconfirmbox.h
@@ -3,6 +3,8 @@
 
 #include <QDialog>
 
+#include <stdexcept>
+
 namespace Ui {
 class kiwixconfirmbox;
 }


### PR DESCRIPTION
`std::runtime_error` is defined in `<stdexcept>`.
We must correctly include it before using `std::runtime_error`

Fix the CI (See https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/50304531 for a error log)