### PR TITLE
Option to disable sandbox on Windows network drive

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -177,5 +177,6 @@
     "export-reading-list": "Export reading list",
     "export-reading-list-error": "An error has occured during export of the reading list.",
     "import-reading-list": "Import reading list",
-    "import-reading-list-error": "An error has occured during import of the reading list."
+    "import-reading-list-error": "An error has occured during import of the reading list.",
+    "disable-sandbox": "Application was launched from a network drive. This is known to cause compatibility issues due to the sandbox. Do you want to take the risks and disable it?"
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,8 +26,9 @@ int main(int argc, char *argv[])
     std::string driveLetter = kiwix::getExecutablePath().substr(0, 3);
     UINT driveType = GetDriveTypeA(driveLetter.c_str());
     if(driveType == DRIVE_REMOTE) {
-        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArray("--no-sandbox"));
-        qInfo() << "Disabled sandbox";
+        int msgboxID = MessageBoxA(NULL, gt("disable-sandbox"), gt("about-kiwix-desktop-title"), MB_YESNO | MB_ICONQUESTION);
+        if (msgboxID == IDYES)
+            qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArray("--no-sandbox"));
     }
 #endif
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
This adds the dialog menu to give the user the option to disable the sandbox when the application is run from a Windows network drive.

Fixes #885 

P.S. Previous commit (disabling the sandbox) has been tested on nightly and seems to work as intended.