### PR TITLE
Implement portable mode

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -143,6 +143,10 @@ void KiwixApp::newTab()
 QString KiwixApp::findLibraryDirectory()
 {
     auto currentDataDir = QString::fromStdString(kiwix::removeLastPathElement(kiwix::getExecutablePath()));
+    
+    if (isPortableMode())
+        return currentDataDir + QDir::separator() + "data";
+
     // Check for library.xml in the same directory as the executable.
     auto libraryFile = QFileInfo(currentDataDir, "library.xml");
     if (libraryFile.exists())

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -9,6 +9,11 @@
 
 QString getDataDirectory()
 {
+    if (isPortableMode()) {
+        auto currentDataDir = QString::fromStdString(kiwix::removeLastPathElement(kiwix::getExecutablePath()));
+        return currentDataDir + QDir::separator() + "data";
+    }
+
     QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     
     if (!dataDir.isEmpty() && QDir().mkpath(dataDir))
@@ -17,9 +22,30 @@ QString getDataDirectory()
     return QString::fromStdString(kiwix::getCurrentDirectory());
 }
 
+bool isPortableMode() 
+{
+    auto currentDataDir = QString::fromStdString(kiwix::removeLastPathElement(kiwix::getExecutablePath()));
+    auto portableFile = QFileInfo(currentDataDir, ".portable");
+    
+    return portableFile.exists();
+}
+
+namespace {
+
+QString getSettingsConfPath() 
+{
+    QString confDirectory = isPortableMode() ? 
+                            getDataDirectory() :
+                            QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation); 
+
+    return confDirectory + QDir::separator() + "Kiwix-desktop.conf";
+}
+
+}
+
 SettingsManager::SettingsManager(QObject *parent)
     : QObject(parent),
-    m_settings("Kiwix", "Kiwix-desktop"),
+    m_settings(getSettingsConfPath(), QSettings::NativeFormat),
     m_view(nullptr)
 {
     initSettings();
@@ -162,7 +188,8 @@ void SettingsManager::initSettings()
 {
     m_kiwixServerPort = m_settings.value("localKiwixServer/port", 8080).toInt();
     m_zoomFactor = m_settings.value("view/zoomFactor", 1).toDouble();
-    m_downloadDir = m_settings.value("download/dir", getDataDirectory()).toString();
+    QString dataDir = getDataDirectory();
+    m_downloadDir = isPortableMode() ? dataDir : m_settings.value("download/dir", dataDir).toString();
     m_kiwixServerIpAddress = m_settings.value("localKiwixServer/ipAddress", QString("0.0.0.0")).toString();
     m_monitorDir = m_settings.value("monitor/dir", QString("")).toString();
     m_moveToTrash = m_settings.value("moveToTrash", true).toBool();

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -78,4 +78,6 @@ private:
 };
 
 QString getDataDirectory();
+bool isPortableMode();
+
 #endif // SETTINGSMANAGER_H


### PR DESCRIPTION
This adds a check for the `.portable` file besides the executable. If it exists all application files will be saved in the `data` directory.

Fixes #1166
