### PR TITLE
Pre-download check for largest supported file size

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -128,6 +128,7 @@
     "delete-book-text": "Are you sure you want to delete <b>{{ZIM}}</b>?",
     "download-storage-error": "Storage Error",
     "download-storage-error-text": "The system doesn't have enough storage available.",
+    "download-exceeds-max-file-size": "Download size exceeds the max file size supported by the target filesystem.",
     "download-dir-missing": "Download directory doesn't exist.",
     "download-dir-not-writable": "Download directory is not writable.",
     "download-unavailable": "Download Unavailable",

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -136,6 +136,7 @@
 	"delete-book-text": "A question to confirm the action to delete an existing ZIM file.",
 	"download-storage-error": "Error title text displayed when something is wrong with the directory of storage for ZIM files",
 	"download-storage-error-text": "Error description text for when something is wrong with the directory of storage for ZIM files.",
+	"download-exceeds-max-file-size": "Error text for the case when the download size exceeds the maximum files size of the filesystem where the download is going to be saved. Reported before the download is started.",
 	"download-dir-missing": "Error text displayed when it turns out that the download directory doesn't exist.",
 	"download-dir-not-writable": "Error text displayed when files cannot be created/saved in the download directory due to permissions",
 	"download-unavailable": "Error title text displayed when the downloading functionality is not available.",


### PR DESCRIPTION
Fixes #1148

This PR contains a tentative value for the FAT32 as it may be reported by `QStorageInfo::fileSystemType()` under Windows. I don't have easy access to a usable software development environment under that OS (mine dates back to 2016 and the simplest attempts to make it work failed).