### PR TITLE
Remove old version category session data on startup

### DIFF
--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -186,5 +186,13 @@ void SettingsManager::initSettings()
     m_langList = m_settings.value("language", defaultLangVariant).toList();
 
     m_categoryList = m_settings.value("category", {}).toStringList();
+
+    /* Older versions used to save both the category identifier/code and its
+     * name as shown to the user (separated by the | symbol). Now we store only
+     * the category identifier from which the name is generated after loading.
+     * In order to avoid user confusion we drop entries stored in the old format
+     */
+    setCategory(m_categoryList.filter(QRegularExpression(R"(^[^|]*$)")));
+
     m_contentTypeList = m_settings.value("contentType", {}).toList();
 }


### PR DESCRIPTION
Follow up from #1175

We remove category session data from older versions to avoid user confusion. Category Pairs separated by '|' is from the older versions.

Here is a session file from older versions to test. Replace the file `Kiwix-desktop.conf` in `~/.config/Kiwix` with this.
[Kiwix-desktop.zip](https://github.com/user-attachments/files/16825133/Kiwix-desktop.zip)
 