### PR TITLE
Monitor data directory on portable mode

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -166,6 +166,7 @@
     "import-reading-list-error": "An error has occured during import of the reading list.",
     "disable-sandbox": "Application was launched from a network drive. This is known to cause compatibility issues due to the sandbox. Do you want to take the risks and disable it?",
     "save-page-as": "Save As...",
+    "portable-disabled-tooltip": "Function disabled in portable mode",
     "scroll-next-tab": "Scroll to next tab",
     "scroll-previous-tab": "Scroll to previous tab"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -173,6 +173,7 @@
 	"import-reading-list": "Represents the action of importing a reading list from a file.",
 	"import-reading-list-error": "Error description text for when importing a reading list from a file failed.",
 	"save-page-as": "Represents the action of saving the current tab content to a file chosen by the user.",
+	"portable-disabled-tooltip": "Tooltip used to explain disabled components in the portable version.",
 	"scroll-next-tab": "Represents the action of scrolling to the next tab of the current tab which toward the end of the tab bar.",
 	"scroll-previous-tab": "Represents the action of scrolling to the previous tab of the current tab which toward the start of the tab bar."
 }

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -186,12 +186,15 @@ void SettingsManager::setContentType(FilterList contentTypeList)
 
 void SettingsManager::initSettings()
 {
+    if(isPortableMode()) {
+        m_downloadDir = m_monitorDir = getDataDirectory();
+    } else {
+        m_downloadDir = m_settings.value("download/dir", getDataDirectory()).toString();
+        m_monitorDir = m_settings.value("monitor/dir", QString("")).toString();
+    }
     m_kiwixServerPort = m_settings.value("localKiwixServer/port", 8080).toInt();
     m_zoomFactor = m_settings.value("view/zoomFactor", 1).toDouble();
-    QString dataDir = getDataDirectory();
-    m_downloadDir = isPortableMode() ? dataDir : m_settings.value("download/dir", dataDir).toString();
     m_kiwixServerIpAddress = m_settings.value("localKiwixServer/ipAddress", QString("0.0.0.0")).toString();
-    m_monitorDir = m_settings.value("monitor/dir", QString("")).toString();
     m_moveToTrash = m_settings.value("moveToTrash", true).toBool();
     m_reopenTab = m_settings.value("reopenTab", false).toBool();
     QString defaultLang = QLocale::languageToString(QLocale().language()) + '|' + QLocale().name().split("_").at(0);

--- a/src/settingsview.cpp
+++ b/src/settingsview.cpp
@@ -18,6 +18,14 @@ namespace
         }
         return input;
     }
+
+    void disableInPortableMode(QWidget* w)
+    {
+        w->setEnabled(false); 
+        QString disabledStyle = "color: gray;";
+        w->setStyleSheet(disabledStyle);
+        w->setToolTip(gt("portable-disabled-tooltip"));
+    }
 }
 
 SettingsView::SettingsView(QWidget *parent)
@@ -62,6 +70,12 @@ SettingsView::SettingsView(QWidget *parent)
     ui->monitorHelp->setToolTip(gt("monitor-directory-tooltip"));
     ui->moveToTrashLabel->setText(gt("move-files-to-trash"));
     ui->reopenTabLabel->setText(gt("open-previous-tabs-at-startup"));
+    if(isPortableMode()) {
+        disableInPortableMode(ui->browseButton);
+        disableInPortableMode(ui->resetButton);
+        disableInPortableMode(ui->monitorBrowse);
+        disableInPortableMode(ui->monitorClear);
+    }
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     ui->line_5->hide();
     ui->moveToTrashLabel->hide();


### PR DESCRIPTION
This simplifies the creation of a portable USB by automatically monitoring the data directory in portable mode. This way we allow the user to just place needed .zim files in the data folder and the app will handle the rest.

- Adds also immutability to the monitor and download paths through settings on portable mode

Fixes #461 