### PR TITLE
Corrected version for checkStateChanged

### DIFF
--- a/src/contenttypefilter.cpp
+++ b/src/contenttypefilter.cpp
@@ -12,7 +12,7 @@ ContentTypeFilter::ContentTypeFilter(QString name, QWidget *parent)
     m_states[Qt::Checked] = gt("no");
     setText(gt(m_name) + " : " + m_states[checkState()]);
     setStyleSheet("* { color: #666666; }");
-    #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
         connect(this, &QCheckBox::checkStateChanged, this, &ContentTypeFilter::onStateChanged);
     #else
         connect(this, &QCheckBox::stateChanged, this, &ContentTypeFilter::onStateChanged);


### PR DESCRIPTION
Follow up for #1199

The `checkStateChanged` method is introduced in Qt 6.7 instead of 6.0, as per the [documentation](https://doc.qt.io/qt-6/qcheckbox.html):

> (since 6.7) void	[checkStateChanged](https://doc.qt.io/qt-6/qcheckbox.html#checkStateChanged)(Qt::CheckState state)