### PR TITLE
Fix network share launch popup

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -210,7 +210,6 @@ QMAKE_CFLAGS += $$PKGCONFIG_CFLAGS
 
 win32 {
   LIBS += $$system(python scripts/pkg-config-wrapper.py --libs $$PKGCONFIG_OPTION $$DEPS_DEFINITION)
-  LIBS += -lUser32
 }
 
 RESOURCES += \

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -164,7 +164,7 @@
     "export-reading-list-error": "An error has occured during export of the reading list.",
     "import-reading-list": "Import reading list",
     "import-reading-list-error": "An error has occured during import of the reading list.",
-    "disable-sandbox": "Application was launched from a network drive. This is known to cause compatibility issues due to the sandbox. Do you want to take the risks and disable it?",
+    "disable-sandbox": "Kiwix has been launched from a network drive. This is known to cause compatibility issues with the browsing sandboxing. As a result, the sandbox will be disabled. Do you want to continue?",
     "save-page-as": "Save As...",
     "portable-disabled-tooltip": "Function disabled in portable mode",
     "scroll-next-tab": "Scroll to next tab",

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -174,6 +174,7 @@
 	"import-reading-list-error": "Error description text for when importing a reading list from a file failed.",
 	"save-page-as": "Represents the action of saving the current tab content to a file chosen by the user.",
 	"portable-disabled-tooltip": "Tooltip used to explain disabled components in the portable version.",
+	"disable-sandbox": "Question description text for when disabling the sandbox feature (Windows network drive), asking the user if he wants to proceed.", 
 	"scroll-next-tab": "Represents the action of scrolling to the next tab of the current tab which toward the end of the tab bar.",
 	"scroll-previous-tab": "Represents the action of scrolling to the previous tab of the current tab which toward the start of the tab bar."
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,15 +25,7 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_WIN
     std::string driveLetter = kiwix::getExecutablePath().substr(0, 3);
     UINT driveType = GetDriveTypeA(driveLetter.c_str());
-    if(driveType == DRIVE_REMOTE) {
-        const std::wstring messageStr = gt("disable-sandbox").toStdWString();
-        const std::wstring titleStr = gt("about-kiwix-desktop-title").toStdWString();
-        const wchar_t* message = messageStr.c_str();
-        const wchar_t* title = titleStr.c_str();
-        int msgboxID = MessageBoxExW(NULL, message, title, MB_YESNO | MB_ICONQUESTION, 0);
-        if (msgboxID == IDYES)
-            qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArray("--no-sandbox"));
-    }
+    if(driveType == DRIVE_REMOTE) qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArray("--no-sandbox"));
 #endif
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     // High DPI Scaling is enabled by default in Qt6. This attribute no longer exists in 6.0 and later
@@ -65,6 +57,12 @@ int main(int argc, char *argv[])
         return 0;
     }
     a.init();
+#ifdef Q_OS_WIN
+    if(driveType == DRIVE_REMOTE) {
+        int result = QMessageBox::question(nullptr, gt("about-kiwix-desktop-title"), gt("disable-sandbox"), QMessageBox::Yes | QMessageBox::No);
+        if (result == QMessageBox::No) return 0;
+    }
+#endif
     for (QString zimfile : positionalArguments) {
         a.openZimFile(zimfile);
     }


### PR DESCRIPTION
This fixes the faulty implementation of the popup asking the user if he wants to use the app with no sandbox, when launched from a Windows network share.

Now, in such case, the sandbox will be disabled automatically, the app will start and then prompt the user if he wants to proceed acknowledging the fact.

Fixes #885 