### PR TITLE
Implement Endless Zim Search Suggestions

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -61,6 +61,7 @@ SOURCES += \
     src/kiwixloader.cpp \
     src/rownode.cpp \
     src/suggestionlistworker.cpp \
+    src/suggestionlistmodel.cpp \
     src/thumbnaildownloader.cpp \
     src/translation.cpp \
     src/main.cpp \
@@ -109,6 +110,7 @@ HEADERS += \
     src/node.h \
     src/rownode.h \
     src/suggestionlistworker.h \
+    src/suggestionlistmodel.h \
     src/thumbnaildownloader.h \
     src/translation.h \
     src/mainwindow.h \

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -171,5 +171,6 @@
     "save-page-as": "Save As...",
     "portable-disabled-tooltip": "Function disabled in portable mode",
     "scroll-next-tab": "Scroll to next tab",
-    "scroll-previous-tab": "Scroll to previous tab"
+    "scroll-previous-tab": "Scroll to previous tab",
+    "kiwix-search": "Kiwix search"
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -179,5 +179,6 @@
 	"save-page-as": "Represents the action of saving the current tab content to a file chosen by the user.",
 	"portable-disabled-tooltip": "Tooltip used to explain disabled components in the portable version.",
 	"scroll-next-tab": "Represents the action of scrolling to the next tab of the current tab which toward the end of the tab bar.",
-	"scroll-previous-tab": "Represents the action of scrolling to the previous tab of the current tab which toward the start of the tab bar."
+	"scroll-previous-tab": "Represents the action of scrolling to the previous tab of the current tab which toward the start of the tab bar.",
+	"kiwix-search": "Title text for a list of search results, which notes to the user those are from Kiwix's Search Engine"
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -3,6 +3,7 @@
 
 #include <kiwix/manager.h>
 #include <kiwix/tools.h>
+#include <zim/item.h>
 
 #include <QtDebug>
 #include <QtConcurrent/QtConcurrentRun>
@@ -70,6 +71,24 @@ std::shared_ptr<zim::Archive> Library::getArchive(const QString &zimId)
 std::shared_ptr<zim::Searcher> Library::getSearcher(const QString &zimId)
 {
     return mp_library->getSearcherById(zimId.toStdString());
+}
+
+QIcon Library::getBookIcon(const QString &zimId)
+{
+    static QIcon defaultIcon = QIcon(":/icons/placeholder-icon.png");
+    try
+    {
+        const auto& book = getBookById(zimId);
+        const auto illustration = book.getIllustration(48);
+        const auto& content = illustration->getData();
+        QPixmap pixmap;
+        pixmap.loadFromData((const uchar*)content.data(), content.size());
+        return QIcon(pixmap);
+    } 
+    catch (...) 
+    {
+        return defaultIcon;
+    }
 }
 
 QStringList Library::getBookIds() const

--- a/src/library.h
+++ b/src/library.h
@@ -12,6 +12,7 @@
 #include <QSharedPointer>
 #include <QMap>
 #include <QMutex>
+#include <QIcon>
 
 #define TQS(v) (QString::fromStdString(v))
 #define FORWARD_GETTER(METH) QString METH() const { return TQS(mp_book->METH()); }
@@ -33,6 +34,7 @@ public:
     QString openBookFromPath(const QString& zimPath);
     std::shared_ptr<zim::Archive> getArchive(const QString& zimId);
     std::shared_ptr<zim::Searcher> getSearcher(const QString& zimId);
+    QIcon getBookIcon(const QString& zimId);
     QStringList getBookIds() const;
     QStringList listBookIds(const kiwix::Filter& filter, kiwix::supportedListSortBy sortBy, bool ascending) const;
     const std::vector<kiwix::Bookmark> getBookmarks(bool onlyValidBookmarks = false) const { return mp_library->getBookmarks(onlyValidBookmarks); }

--- a/src/readinglistbar.cpp
+++ b/src/readinglistbar.cpp
@@ -57,28 +57,16 @@ void ReadingListBar::setupList()
     auto listWidget = ui->listWidget;
     listWidget->clear();
     for(auto& bookmark:bookmarks) {
-        std::shared_ptr<zim::Archive> archive;
+        const auto zimId = QString::fromStdString(bookmark.getBookId());
         try {
-            archive = library->getArchive(QString::fromStdString(bookmark.getBookId()));
+            library->getArchive(zimId);
         } catch (std::out_of_range& e) {
             continue;
         }
-        try {
-            auto illustration = archive->getIllustrationItem(48);
-            std::string content = illustration.getData();
-            std::string mimeType = illustration.getMimetype();
-            QPixmap pixmap;
-            pixmap.loadFromData(reinterpret_cast<const uchar*>(content.data()), content.size());
-            auto icon = QIcon(pixmap);
-            new QListWidgetItem(
-                icon,
-                QString::fromStdString(bookmark.getTitle()),
-                listWidget);
-        } catch (zim::EntryNotFound& e) {
-            new QListWidgetItem(
-                QString::fromStdString(bookmark.getTitle()),
-                listWidget);
-        }
+        new QListWidgetItem(
+            library->getBookIcon(zimId),
+            QString::fromStdString(bookmark.getTitle()),
+            listWidget);
     }
 }
 

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -172,7 +172,8 @@ void SearchBarLineEdit::focusInEvent( QFocusEvent* event)
         event->reason() == Qt::MouseFocusReason ||
         event->reason() == Qt::ShortcutFocusReason) {
         connect(&m_completer, QOverload<const QModelIndex &>::of(&QCompleter::activated),
-        this, QOverload<const QModelIndex &>::of(&SearchBarLineEdit::openCompletion));
+                this, QOverload<const QModelIndex &>::of(&SearchBarLineEdit::openCompletion),
+                Qt::UniqueConnection);
     }
     QLineEdit::focusInEvent(event);
 }

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -80,7 +80,7 @@ SearchBarLineEdit::SearchBarLineEdit(QWidget *parent) :
     m_suggestionView->setRootIsDecorated(false);
     m_suggestionView->setStyleSheet(KiwixApp::instance()->parseStyleFromFile(":/css/popup.css"));
 
-    connect(m_completer.popup()->verticalScrollBar(), &QScrollBar::valueChanged,
+    connect(m_suggestionView->verticalScrollBar(), &QScrollBar::valueChanged,
             this, &SearchBarLineEdit::onScroll);
 
     qRegisterMetaType<QList<SuggestionData>>("QList<SuggestionData>");
@@ -119,7 +119,7 @@ SearchBarLineEdit::SearchBarLineEdit(QWidget *parent) :
 
 void SearchBarLineEdit::hideSuggestions()
 {
-    m_completer.popup()->hide();
+    m_suggestionView->hide();
 }
 
 bool SearchBarLineEdit::eventFilter(QObject *, QEvent *event)
@@ -222,15 +222,15 @@ void SearchBarLineEdit::onScroll(int value)
        to intercept the scrolling in eventFilter so, until we find out how, this
        code is here to stay.
     */
-    if (!m_completer.popup()->currentIndex().isValid())
+    if (!m_suggestionView->currentIndex().isValid())
     {
-        const auto old = m_completer.popup()->verticalScrollBar()->blockSignals(true);
-        m_completer.popup()->scrollToBottom();
-        m_completer.popup()->verticalScrollBar()->blockSignals(old);
+        const auto old = m_suggestionView->verticalScrollBar()->blockSignals(true);
+        m_suggestionView->scrollToBottom();
+        m_suggestionView->verticalScrollBar()->blockSignals(old);
         return;
     }
 
-    const auto suggestionScroller = m_completer.popup()->verticalScrollBar();
+    const auto suggestionScroller = m_suggestionView->verticalScrollBar();
     const auto scrollMin = suggestionScroller->minimum();
     const auto scrollMax = suggestionScroller->maximum();
     const bool scrolledToEnd = value == suggestionScroller->maximum();
@@ -277,8 +277,8 @@ void SearchBarLineEdit::onInitialSuggestions(int)
         m_completer.complete();
 
         /* Make row 0 appear but do not highlight it */
-        const auto completerFirstIdx = m_completer.popup()->model()->index(0, 0);
-        const auto completerSelModel = m_completer.popup()->selectionModel();
+        const auto completerFirstIdx = m_suggestionView->model()->index(0, 0);
+        const auto completerSelModel = m_suggestionView->selectionModel();
         completerSelModel->setCurrentIndex(completerFirstIdx, QItemSelectionModel::Current);
     }
 }
@@ -286,9 +286,9 @@ void SearchBarLineEdit::onInitialSuggestions(int)
 void SearchBarLineEdit::onAdditionalSuggestions(int start)
 {
     /* Set selection to be at the last row of the previous list */
-    const auto completerStartIdx = m_completer.popup()->model()->index(start, 0);
-    m_completer.popup()->setCurrentIndex(completerStartIdx);
-    m_completer.popup()->show();
+    const auto completerStartIdx = m_suggestionView->model()->index(start, 0);
+    m_suggestionView->setCurrentIndex(completerStartIdx);
+    m_suggestionView->show();
 }
 
 void SearchBarLineEdit::fetchSuggestions(NewSuggestionHandlerFuncPtr callback)

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -162,7 +162,7 @@ void SearchBarLineEdit::updateCompletion()
         return;
     }
     m_token++;
-    auto suggestionWorker = new SuggestionListWorker(m_searchbarInput, m_token, this);
+    auto suggestionWorker = new SuggestionListWorker(m_searchbarInput, m_token, 0, this);
     connect(suggestionWorker, &SuggestionListWorker::searchFinished, this,
     [=] (const QList<SuggestionData>& suggestionList, int token) {
         if (token != m_token) {

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -49,7 +49,7 @@ void BookmarkButton::on_buttonClicked()
 
 SearchBarLineEdit::SearchBarLineEdit(QWidget *parent) :
     QLineEdit(parent),
-    m_completer(&m_completionModel, this)
+    m_completer(&m_suggestionModel, this)
 {
     setAlignment(KiwixApp::isRightToLeft() ? Qt::AlignRight : Qt::AlignLeft);
     mp_typingTimer = new QTimer(this);
@@ -111,8 +111,7 @@ void SearchBarLineEdit::hideSuggestions()
 
 void SearchBarLineEdit::clearSuggestions()
 {
-    QStringList empty;
-    m_completionModel.setStringList(empty);
+    m_suggestionModel.resetSuggestions();
     m_urlList.clear();
 }
 
@@ -175,7 +174,7 @@ void SearchBarLineEdit::updateCompletion()
             openCompletion(suggestions.first(), 0);
             return;
         }
-        m_completionModel.setStringList(suggestions);
+        m_suggestionModel.append(suggestions);
         m_completer.complete();
     });
     connect(suggestionWorker, &SuggestionListWorker::finished, suggestionWorker, &QObject::deleteLater);

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -274,7 +274,7 @@ void SearchBarLineEdit::onAdditionalSuggestions(int start)
 
 void SearchBarLineEdit::fetchSuggestions(NewSuggestionHandlerFuncPtr callback)
 {
-    const int start = m_suggestionModel.rowCount();
+    const int start = m_suggestionModel.countOfRegularSuggestions();
     const auto suggestionWorker = new SuggestionListWorker(m_searchbarInput, m_token, start, this);
     connect(suggestionWorker, &SuggestionListWorker::searchFinished, this,
             [=] (const QList<SuggestionData>& suggestionList, int token) {
@@ -296,11 +296,13 @@ QModelIndex SearchBarLineEdit::getDefaulSuggestionIndex() const
         return firstSuggestionIndex;
 
     /* If the first entry matches the typed text, use it as default, otherwise
-       use the last entry which is the fulltext search. */
+       use the last entry if fulltext search exist. */
     const auto firstSuggestionText = firstSuggestionIndex.data().toString();
     if (this->text().compare(firstSuggestionText, Qt::CaseInsensitive) == 0)
         return firstSuggestionIndex;
-    return m_suggestionModel.index(m_suggestionModel.rowCount() - 1);
+    else if (m_suggestionModel.hasFullTextSearchSuggestion())
+        return m_suggestionModel.index(m_suggestionModel.rowCount() - 1);
+    return QModelIndex();
 }
 
 SearchBar::SearchBar(QWidget *parent) :

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -171,7 +171,7 @@ void SearchBarLineEdit::updateCompletion()
 
         m_suggestionModel.append(suggestionList);
         if (m_returnPressed) {
-            openCompletion(suggestionList.first().text, 0);
+            openCompletion(m_suggestionModel.index(0));
             return;
         }
         m_completer.complete();
@@ -182,20 +182,18 @@ void SearchBarLineEdit::updateCompletion()
 
 void SearchBarLineEdit::openCompletion(const QModelIndex &index)
 {
-    if (m_suggestionModel.rowCount() != 0) {
-        openCompletion(index.data().toString(), index.row());
-    }
-}
+    if (index.isValid())
+    {
+        QUrl url;
+        auto selectedSuggestionText = index.data().toString();
 
-void SearchBarLineEdit::openCompletion(const QString& text, int index)
-{
-    QUrl url;
-    if (this->text().compare(text, Qt::CaseInsensitive) == 0) {
-        url = m_suggestionModel.index(index).data(Qt::UserRole).toUrl();
-    } else {
-        url = m_suggestionModel.index(m_suggestionModel.rowCount() - 1).data(Qt::UserRole).toUrl();
+        if (this->text().compare(selectedSuggestionText, Qt::CaseInsensitive) == 0) {
+            url = index.data(Qt::UserRole).toUrl();
+        } else {
+            url = m_suggestionModel.index(m_suggestionModel.rowCount() - 1).data(Qt::UserRole).toUrl();
+        }
+        QTimer::singleShot(0, [=](){KiwixApp::instance()->openUrl(url, false);});
     }
-    QTimer::singleShot(0, [=](){KiwixApp::instance()->openUrl(url, false);});
 }
 
 SearchBar::SearchBar(QWidget *parent) :

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -268,6 +268,11 @@ void SearchBarLineEdit::onInitialSuggestions(int)
         openCompletion(getDefaulSuggestionIndex());
     } else {
         m_completer.complete();
+
+        /* Make row 0 appear but do not highlight it */
+        const auto completerFirstIdx = m_completer.popup()->model()->index(0, 0);
+        const auto completerSelModel = m_completer.popup()->selectionModel();
+        completerSelModel->setCurrentIndex(completerFirstIdx, QItemSelectionModel::Current);
     }
 }
 

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -171,7 +171,7 @@ void SearchBarLineEdit::updateCompletion()
 
         m_suggestionModel.append(suggestionList);
         if (m_returnPressed) {
-            openCompletion(m_suggestionModel.index(0));
+            openCompletion(getDefaulSuggestionIndex());
             return;
         }
         m_completer.complete();
@@ -184,16 +184,23 @@ void SearchBarLineEdit::openCompletion(const QModelIndex &index)
 {
     if (index.isValid())
     {
-        QUrl url;
-        auto selectedSuggestionText = index.data().toString();
-
-        if (this->text().compare(selectedSuggestionText, Qt::CaseInsensitive) == 0) {
-            url = index.data(Qt::UserRole).toUrl();
-        } else {
-            url = m_suggestionModel.index(m_suggestionModel.rowCount() - 1).data(Qt::UserRole).toUrl();
-        }
+        const QUrl url = index.data(Qt::UserRole).toUrl();
         QTimer::singleShot(0, [=](){KiwixApp::instance()->openUrl(url, false);});
     }
+}
+
+QModelIndex SearchBarLineEdit::getDefaulSuggestionIndex() const
+{
+    const auto firstSuggestionIndex = m_suggestionModel.index(0);
+    if (!firstSuggestionIndex.isValid())
+        return firstSuggestionIndex;
+
+    /* If the first entry matches the typed text, use it as default, otherwise
+       use the last entry which is the fulltext search. */
+    const auto firstSuggestionText = firstSuggestionIndex.data().toString();
+    if (this->text().compare(firstSuggestionText, Qt::CaseInsensitive) == 0)
+        return firstSuggestionIndex;
+    return m_suggestionModel.index(m_suggestionModel.rowCount() - 1);
 }
 
 SearchBar::SearchBar(QWidget *parent) :

--- a/src/searchbar.cpp
+++ b/src/searchbar.cpp
@@ -50,6 +50,7 @@ void BookmarkButton::on_buttonClicked()
 
 SearchBarLineEdit::SearchBarLineEdit(QWidget *parent) :
     QLineEdit(parent),
+    m_suggestionView(new QTreeView),
     m_completer(&m_suggestionModel, this)
 {
     installEventFilter(this);
@@ -72,7 +73,13 @@ SearchBarLineEdit::SearchBarLineEdit(QWidget *parent) :
     m_completer.setMaxVisibleItems(SuggestionListWorker::getFetchSize() / 2);
     setCompleter(&m_completer);
 
-    m_completer.popup()->setStyleSheet(KiwixApp::instance()->parseStyleFromFile(":/css/popup.css"));
+    /* QCompleter's uses default list views, which do not have headers. */
+    m_completer.setPopup(m_suggestionView);
+
+    m_suggestionView->header()->setStretchLastSection(true);
+    m_suggestionView->setRootIsDecorated(false);
+    m_suggestionView->setStyleSheet(KiwixApp::instance()->parseStyleFromFile(":/css/popup.css"));
+
     connect(m_completer.popup()->verticalScrollBar(), &QScrollBar::valueChanged,
             this, &SearchBarLineEdit::onScroll);
 

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -31,6 +31,7 @@ class SearchBarLineEdit : public QLineEdit
 public:
     SearchBarLineEdit(QWidget *parent = nullptr);
     void hideSuggestions();
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 public slots:
     void on_currentTitleChanged(const QString &title);

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -25,6 +25,9 @@ public slots:
 class SearchBarLineEdit : public QLineEdit
 {
     Q_OBJECT
+
+    typedef void (SearchBarLineEdit::*NewSuggestionHandlerFuncPtr)(int start);
+
 public:
     SearchBarLineEdit(QWidget *parent = nullptr);
     void hideSuggestions();
@@ -48,6 +51,8 @@ private:
 private slots:
     void updateCompletion();
     void openCompletion(const QModelIndex& index);
+    void onInitialSuggestions(int);
+    void fetchSuggestions(NewSuggestionHandlerFuncPtr callback);
 
     QModelIndex getDefaulSuggestionIndex() const;
 };

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -48,10 +48,18 @@ private:
     QTimer* mp_typingTimer;
     int m_token;
 
+    /* We only fetch more suggestions when the user is at the end and tries to
+       scroll again. This variable is set whenever the user scrolled to the end,
+       indicating the next scroll should trigger a fetch more action. */
+    bool m_aboutToScrollPastEnd = false;
+
 private slots:
     void updateCompletion();
+    void fetchMoreSuggestions();
+    void onScroll(int value);
     void openCompletion(const QModelIndex& index);
     void onInitialSuggestions(int);
+    void onAdditionalSuggestions(int start);
     void fetchSuggestions(NewSuggestionHandlerFuncPtr callback);
 
     QModelIndex getDefaulSuggestionIndex() const;

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -48,7 +48,6 @@ private:
 private slots:
     void updateCompletion();
     void openCompletion(const QModelIndex& index);
-    void openCompletion(const QString& text, int index);
 };
 
 

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -12,6 +12,8 @@
 #include <QToolBar>
 #include "suggestionlistmodel.h"
 
+class QTreeView;
+
 class BookmarkButton : public QToolButton {
     Q_OBJECT
 public:
@@ -42,6 +44,7 @@ protected:
     virtual void focusOutEvent(QFocusEvent *);
 private:
     SuggestionListModel m_suggestionModel;
+    QTreeView *m_suggestionView;
     QCompleter m_completer;
     QString m_title;
     QString m_searchbarInput;

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -48,6 +48,7 @@ private:
     bool m_returnPressed = false;
     QTimer* mp_typingTimer;
     int m_token;
+    bool m_moreSuggestionsAreAvailable = false;
 
     /* We only fetch more suggestions when the user is at the end and tries to
        scroll again. This variable is set whenever the user scrolled to the end,

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -10,6 +10,7 @@
 #include <QTimer>
 #include <QThread>
 #include <QToolBar>
+#include "suggestionlistmodel.h"
 
 class BookmarkButton : public QToolButton {
     Q_OBJECT
@@ -36,7 +37,7 @@ protected:
     virtual void focusInEvent(QFocusEvent *);
     virtual void focusOutEvent(QFocusEvent *);
 private:
-    QStringListModel m_completionModel;
+    SuggestionListModel m_suggestionModel;
     QCompleter m_completer;
     QVector<QUrl> m_urlList;
     QString m_title;

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -39,7 +39,6 @@ protected:
 private:
     SuggestionListModel m_suggestionModel;
     QCompleter m_completer;
-    QVector<QUrl> m_urlList;
     QString m_title;
     QString m_searchbarInput;
     bool m_returnPressed = false;

--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -48,6 +48,8 @@ private:
 private slots:
     void updateCompletion();
     void openCompletion(const QModelIndex& index);
+
+    QModelIndex getDefaulSuggestionIndex() const;
 };
 
 

--- a/src/suggestionlistmodel.cpp
+++ b/src/suggestionlistmodel.cpp
@@ -27,6 +27,8 @@ QVariant SuggestionListModel::data(const QModelIndex &index, int role) const
         case Qt::DisplayRole:
         case Qt::EditRole:
             return m_suggestions.at(row).text;
+        case Qt::UserRole:
+            return m_suggestions.at(row).url;
     }
     return QVariant();
 }
@@ -38,10 +40,10 @@ void SuggestionListModel::resetSuggestions()
     endResetModel();
 }
 
-void SuggestionListModel::append(const QStringList &suggestionList)
+void SuggestionListModel::append(const QList<SuggestionData> &suggestionList)
 {
     beginResetModel();
     for (const auto& suggestion : suggestionList)
-        m_suggestions.append({suggestion});
+        m_suggestions.append(suggestion);
     endResetModel();
 }

--- a/src/suggestionlistmodel.cpp
+++ b/src/suggestionlistmodel.cpp
@@ -1,0 +1,47 @@
+#include "suggestionlistmodel.h"
+
+SuggestionListModel::SuggestionListModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+SuggestionListModel::~SuggestionListModel()
+{
+}
+
+int SuggestionListModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+
+    return m_suggestions.size();
+}
+
+QVariant SuggestionListModel::data(const QModelIndex &index, int role) const
+{
+    const int row = index.row();
+    if (row < 0 || row >= rowCount())
+        return QVariant();
+
+    switch (role)
+    {
+        case Qt::DisplayRole:
+        case Qt::EditRole:
+            return m_suggestions.at(row).text;
+    }
+    return QVariant();
+}
+
+void SuggestionListModel::resetSuggestions()
+{
+    beginResetModel();
+    m_suggestions.clear();
+    endResetModel();
+}
+
+void SuggestionListModel::append(const QStringList &suggestionList)
+{
+    beginResetModel();
+    for (const auto& suggestion : suggestionList)
+        m_suggestions.append({suggestion});
+    endResetModel();
+}

--- a/src/suggestionlistmodel.cpp
+++ b/src/suggestionlistmodel.cpp
@@ -52,7 +52,27 @@ void SuggestionListModel::resetSuggestions()
 void SuggestionListModel::append(const QList<SuggestionData> &suggestionList)
 {
     beginResetModel();
+    if (hasFullTextSearchSuggestion())
+        m_suggestions.pop_back();
+
     for (const auto& suggestion : suggestionList)
         m_suggestions.append(suggestion);
     endResetModel();
+}
+
+int SuggestionListModel::countOfRegularSuggestions() const
+{
+    return hasFullTextSearchSuggestion()
+            ? rowCount() - 1
+            : rowCount();
+}
+
+bool SuggestionListModel::hasFullTextSearchSuggestion() const
+{
+    return rowCount() > 0 && m_suggestions.last().isFullTextSearchSuggestion();
+}
+
+bool SuggestionData::isFullTextSearchSuggestion() const
+{
+    return url.host().endsWith(".search");
 }

--- a/src/suggestionlistmodel.cpp
+++ b/src/suggestionlistmodel.cpp
@@ -1,4 +1,9 @@
 #include "suggestionlistmodel.h"
+#include "kiwixapp.h"
+
+#include <QIcon>
+
+QString getZimIdFromUrl(QUrl url);
 
 SuggestionListModel::SuggestionListModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -29,6 +34,10 @@ QVariant SuggestionListModel::data(const QModelIndex &index, int role) const
             return m_suggestions.at(row).text;
         case Qt::UserRole:
             return m_suggestions.at(row).url;
+        case Qt::DecorationRole:
+            const auto library = KiwixApp::instance()->getLibrary();
+            const auto zimId = getZimIdFromUrl(m_suggestions.at(row).url);
+            return library->getBookIcon(zimId);
     }
     return QVariant();
 }

--- a/src/suggestionlistmodel.cpp
+++ b/src/suggestionlistmodel.cpp
@@ -42,6 +42,21 @@ QVariant SuggestionListModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
+QVariant SuggestionListModel::headerData(int section,
+                                         Qt::Orientation orientation,
+                                         int role) const
+{
+    if (section != 0 || orientation != Qt::Orientation::Horizontal)
+        return QVariant();
+
+    switch (role)
+    {
+        case Qt::DisplayRole:
+            return gt("kiwix-search");
+    }
+    return QVariant();
+}
+
 void SuggestionListModel::resetSuggestions()
 {
     beginResetModel();

--- a/src/suggestionlistmodel.h
+++ b/src/suggestionlistmodel.h
@@ -1,0 +1,29 @@
+#ifndef SUGGESTIONLISTMODEL_H
+#define SUGGESTIONLISTMODEL_H
+
+#include <QAbstractListModel>
+
+struct SuggestionData
+{
+    QString text;
+};
+
+class SuggestionListModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    explicit SuggestionListModel(QObject *parent = nullptr);
+    ~SuggestionListModel();
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    void resetSuggestions();
+    void append(const QStringList& suggestionList);
+
+private:
+    QList<SuggestionData> m_suggestions;
+};
+
+#endif // SUGGESTIONLISTMODEL_H

--- a/src/suggestionlistmodel.h
+++ b/src/suggestionlistmodel.h
@@ -8,6 +8,8 @@ struct SuggestionData
 {
     QString text;
     QUrl url;
+
+    bool isFullTextSearchSuggestion() const;
 };
 
 class SuggestionListModel : public QAbstractListModel
@@ -23,6 +25,9 @@ public:
 
     void resetSuggestions();
     void append(const QList<SuggestionData>& suggestionList);
+
+    int countOfRegularSuggestions() const;
+    bool hasFullTextSearchSuggestion() const;
 
 private:
     QList<SuggestionData> m_suggestions;

--- a/src/suggestionlistmodel.h
+++ b/src/suggestionlistmodel.h
@@ -22,6 +22,7 @@ public:
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
     void resetSuggestions();
     void append(const QList<SuggestionData>& suggestionList);

--- a/src/suggestionlistmodel.h
+++ b/src/suggestionlistmodel.h
@@ -2,10 +2,12 @@
 #define SUGGESTIONLISTMODEL_H
 
 #include <QAbstractListModel>
+#include <QUrl>
 
 struct SuggestionData
 {
     QString text;
+    QUrl url;
 };
 
 class SuggestionListModel : public QAbstractListModel
@@ -20,7 +22,7 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     void resetSuggestions();
-    void append(const QStringList& suggestionList);
+    void append(const QList<SuggestionData>& suggestionList);
 
 private:
     QList<SuggestionData> m_suggestions;

--- a/src/suggestionlistworker.cpp
+++ b/src/suggestionlistworker.cpp
@@ -2,10 +2,11 @@
 #include "kiwixapp.h"
 #include <zim/suggestion.h>
 
-SuggestionListWorker::SuggestionListWorker(const QString& text, int token, QObject *parent)
+SuggestionListWorker::SuggestionListWorker(const QString& text, int token, int start, QObject *parent)
 : QThread(parent),
   m_text(text),
-  m_token(token)
+  m_token(token),
+  m_start(start)
 {
 }
 
@@ -23,11 +24,10 @@ void SuggestionListWorker::run()
         QUrl url;
         url.setScheme("zim");
         url.setHost(currentZimId + ".zim");
-        int suggestionsCount = 15;
         auto prefix = m_text.toStdString();
         auto suggestionSearcher = zim::SuggestionSearcher(*archive);
         auto suggestionSearch = suggestionSearcher.suggest(prefix);
-        const auto suggestions = suggestionSearch.getResults(0, suggestionsCount);
+        const auto suggestions = suggestionSearch.getResults(m_start, getFetchSize());
         for (auto current : suggestions) {
             QString path = QString("/") + QString::fromStdString(current.getPath());
             url.setPath(path);

--- a/src/suggestionlistworker.cpp
+++ b/src/suggestionlistworker.cpp
@@ -11,8 +11,7 @@ SuggestionListWorker::SuggestionListWorker(const QString& text, int token, QObje
 
 void SuggestionListWorker::run()
 {
-    QStringList suggestionList;
-    QVector<QUrl> urlList;
+    QList<SuggestionData> suggestionList;
 
     WebView *current = KiwixApp::instance()->getTabWidget()->currentWebView();
     if(!current)
@@ -32,8 +31,8 @@ void SuggestionListWorker::run()
         for (auto current : suggestions) {
             QString path = QString("/") + QString::fromStdString(current.getPath());
             url.setPath(path);
-            suggestionList.append(QString::fromStdString(current.getTitle()));
-            urlList.append(url);
+            const auto text = QString::fromStdString(current.getTitle());
+            suggestionList.append({text, url});
         }
 
         // Propose fulltext search
@@ -46,8 +45,8 @@ void SuggestionListWorker::run()
             query.addQueryItem("content", currentZimId);
             query.addQueryItem("pattern", m_text);
             url.setQuery(query);
-            suggestionList.append(m_text + " (" + gt("fulltext-search") + ")");
-            urlList.append(url);
+            const auto text = m_text + " (" + gt("fulltext-search") + ")";
+            suggestionList.append({text, url});
         }
     } catch (std::out_of_range& e) {
         // Impossible to find the requested archive (bug ?)
@@ -56,5 +55,5 @@ void SuggestionListWorker::run()
         // but we don't have a correct UI to select on which zim search, how to display results, ...
         // So do nothing for now
     }
-    emit(searchFinished(suggestionList, urlList, m_token));
+    emit(searchFinished(suggestionList, m_token));
 }

--- a/src/suggestionlistworker.h
+++ b/src/suggestionlistworker.h
@@ -1,9 +1,9 @@
 #ifndef SUGGESTIONLISTWORKER_H
 #define SUGGESTIONLISTWORKER_H
 
-#include <QUrl>
-#include <QVector>
 #include <QThread>
+
+struct SuggestionData;
 
 class SuggestionListWorker : public QThread
 {
@@ -13,7 +13,7 @@ public:
     void run() override;
 
 signals:
-    void searchFinished(const QStringList& suggestions, const QVector<QUrl>& urlList, int token);
+    void searchFinished(const QList<SuggestionData>& suggestionList, int token);
 
 private:
     QString m_text;

--- a/src/suggestionlistworker.h
+++ b/src/suggestionlistworker.h
@@ -9,7 +9,9 @@ class SuggestionListWorker : public QThread
 {
     Q_OBJECT
 public:
-    SuggestionListWorker(const QString& text, int token, QObject *parent = nullptr);
+    static int getFetchSize() { return 15; };
+
+    SuggestionListWorker(const QString& text, int token, int start, QObject *parent = nullptr);
     void run() override;
 
 signals:
@@ -18,6 +20,7 @@ signals:
 private:
     QString m_text;
     int m_token = 0;
+    int m_start;
 };
 
 #endif // SUGGESTIONLISTWORKER_H

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -203,24 +203,10 @@ void WebView::onUrlChanged(const QUrl& url) {
     }
     m_currentZimId = zimId;
     emit zimIdChanged(m_currentZimId);
-    std::shared_ptr<zim::Archive> archive;
-    try {
-        archive = app->getLibrary()->getArchive(m_currentZimId);
-    } catch (std::out_of_range& e) {
-        return;
-    }
+    m_icon = app->getLibrary()->getBookIcon(m_currentZimId);
     auto zoomFactor = app->getSettingsManager()->getZoomFactorByZimId(zimId);
     this->setZoomFactor(zoomFactor);
-    try {
-        std::string favicon, _mimetype;
-        auto item = archive->getIllustrationItem(48);
-        favicon = item.getData();
-        _mimetype = item.getMimetype();
-        QPixmap pixmap;
-        pixmap.loadFromData((const uchar*)favicon.data(), favicon.size());
-        m_icon = QIcon(pixmap);
-        emit iconChanged(m_icon);
-    } catch (zim::EntryNotFound& e) {}
+    emit iconChanged(m_icon);
 }
 
 void WebView::wheelEvent(QWheelEvent *event) {


### PR DESCRIPTION
Fixes (part of) #413 

Changes:
  - Added a custom model to enable endless suggestions
  - Added basic UI elements such as the search header and icon of the zim for convenience.
  - Endless can be triggered by up/down/page-down keypresses and mouse scrolls.

Known Issues to be fixed in #1189: The first suggestion is hidden by the header due to QCompleter's incorrect size management. 