### PR TITLE
BugFix: HTML Web Page incorrect behavior when canceling save page actions 

### DIFF
--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -54,10 +54,6 @@ void KProfile::startDownload(QWebEngineDownloadRequest* download)
         return;
     }
 
-    if (download->isSavePageDownload()) {
-        download->page()->printToPdf(fileName);
-        return;
-    }
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     download->setPath(fileName);
 #else

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -5,6 +5,26 @@
 #include <QMessageBox>
 #include <QWebEngineSettings>
 
+QString askForSaveFilePath(const QString& suggestedName)
+{
+    const auto app = KiwixApp::instance();
+    const QString suggestedPath = app->getPrevSaveDir() + "/" + suggestedName;
+    const QString extension = suggestedName.section(".", -1);
+    const QString filter = extension.isEmpty() ? "" : "(*" + extension + ")";
+    QString fileName = QFileDialog::getSaveFileName(
+            app->getMainWindow(), gt("save-file-as-window-title"),
+            suggestedPath, filter);
+
+    if (fileName.isEmpty())
+        return QString();
+    
+    if (!fileName.endsWith(extension)) {
+        fileName.append(extension);
+    }
+    app->savePrevSaveDir(QFileInfo(fileName).absolutePath());
+    return fileName;
+}
+
 KProfile::KProfile(QObject *parent) :
     QWebEngineProfile(parent)
 {
@@ -24,27 +44,15 @@ void KProfile::startDownload(QWebEngineDownloadItem* download)
 void KProfile::startDownload(QWebEngineDownloadRequest* download)
 #endif
 {
-    auto app = KiwixApp::instance();
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     QString defaultFileName = QUrl(download->path()).fileName();
 #else
     QString defaultFileName = download->downloadFileName();
 #endif
-    QString suggestedPath = app->getPrevSaveDir() + "/" + defaultFileName;
-    QString extension = defaultFileName.section('.', -1);
-    QString filter = extension != '.' ? "(*" + extension + ")" : "";
-
-    QString fileName = QFileDialog::getSaveFileName(
-            app->getMainWindow(), gt("save-file-as-window-title"),
-            suggestedPath, filter);
-
+    const QString fileName = askForSaveFilePath(defaultFileName);
     if (fileName.isEmpty()) {
         return;
     }
-    if (!fileName.endsWith(extension)) {
-        fileName.append(extension);
-    }
-    app->savePrevSaveDir(QFileInfo(fileName).absolutePath());
 
     if (download->isSavePageDownload()) {
         download->page()->printToPdf(fileName);

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -159,20 +159,25 @@ zim::Item getZimItem(const QUrl& url)
     return entry.getItem(true);
 }
 
+bool isHTMLContent(const zim::Item& item)
+{
+    auto mimeType = QByteArray::fromStdString(item.getMimetype());
+    mimeType = mimeType.split(';')[0];
+    return mimeType == "text/html";
+}
+
 }
 
 void WebView::saveViewContent()
 {
     try {
         const auto item = getZimItem(url());
-        auto mimeType = QByteArray::fromStdString(item.getMimetype());
-        mimeType = mimeType.split(';')[0];
 
         /* We have to sanitize here, as parsing will start once we pass the file
            name to either save or download method.
         */
         QString suggestedFileName = QString::fromStdString(kiwix::getSlugifiedFileName(item.getTitle()));
-        if (mimeType == "text/html")
+        if (isHTMLContent(item))
             page()->save(suggestedFileName + ".pdf");
         else
             page()->download(this->url(), suggestedFileName);

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -18,6 +18,7 @@ class QMenu;
 #include <kiwix/tools.h>
 
 zim::Entry getArchiveEntryFromUrl(const zim::Archive& archive, const QUrl& url);
+QString askForSaveFilePath(const QString& suggestedName);
 
 void WebViewBackMenu::showEvent(QShowEvent *)
 {
@@ -176,9 +177,13 @@ void WebView::saveViewContent()
         /* We have to sanitize here, as parsing will start once we pass the file
            name to either save or download method.
         */
-        QString suggestedFileName = QString::fromStdString(kiwix::getSlugifiedFileName(item.getTitle()));
+        const QString suggestedFileName = QString::fromStdString(kiwix::getSlugifiedFileName(item.getTitle()));
         if (isHTMLContent(item))
-            page()->save(suggestedFileName + ".pdf");
+        {
+            const QString fileName = askForSaveFilePath(suggestedFileName + ".pdf");
+            if (!fileName.isEmpty())
+                page()->printToPdf(fileName);
+        }
         else
             page()->download(this->url(), suggestedFileName);
     }

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -138,17 +138,33 @@ QMenu* WebView::getHistoryForwardMenu() const
     return ret;
 }
 
+namespace
+{
+
+/**
+ * @brief Get the Zim Item object corresponding to the given url.
+ * 
+ * @param url QUrl
+ * @return zim::Item
+ * 
+ * @exception throws exception if zimId is invalid, archive doesn't exist,
+ * entry is invalid or not found, or entry is redirect.
+ */
+zim::Item getZimItem(const QUrl& url)
+{
+    const auto app = KiwixApp::instance();
+    const auto library = app->getLibrary();
+    const auto archive = library->getArchive(getZimIdFromUrl(url));
+    const auto entry = getArchiveEntryFromUrl(*archive, url);
+    return entry.getItem(true);
+}
+
+}
+
 void WebView::saveViewContent()
 {
     try {
-        auto app = KiwixApp::instance();
-        auto library = app->getLibrary();
-        auto archive = library->getArchive(m_currentZimId);
-        auto entry = getArchiveEntryFromUrl(*archive, this->url());
-        if (entry.isRedirect()) 
-            return;
-
-        auto item = entry.getItem(true);
+        const auto item = getZimItem(url());
         auto mimeType = QByteArray::fromStdString(item.getMimetype());
         mimeType = mimeType.split(';')[0];
 


### PR DESCRIPTION
Bug: If you do **Save Page** on an HTML pages and cancel during file selection, it will still leave a download artifact in **Download** folder.
1. Trigger Save Page on an HTML tab
2. cancel the save page.
3. Check Download folder, and will see an invalid PDF. (its the HTMl file that the save() call tried to save.)

Reason: This is due to Qt bug, which fails to cancel download requests for QWebEnginePage::save() in KProfile::startDownload.

Changes: We use QWebEnginePage::download() only. We determine whether a page is HTML (i.e. will save as .pdf files) in KProfile::startDownload.