### PR TITLE
BugFix: Should Open Default Suggestion on Search Bar when Nothing is Selected

### DIFF
--- a/src/searchbar.h
+++ b/src/searchbar.h
@@ -48,6 +48,7 @@ private:
     QCompleter m_completer;
     QString m_title;
     QString m_searchbarInput;
+    QString m_suggestionsAreValidFor;
     bool m_returnPressed = false;
     QTimer* mp_typingTimer;
     int m_token;


### PR DESCRIPTION
Fix #1230

Two potential implementations listed here:
  
  1. Open default suggestions whenever enter is pressed on an invalid index. Added 'relevant' search bar input checker to avoid race conditions. 2929d91469bb3a0c493ff2651410cc5e62a9af7a
  
  2. Similar approach as before #1224, where we check text in search bar matches the suggestion text before opening. ad2e2b323c4e49be95f07413e6f44f2f56ee6b95

I am leaning toward the first one since it is a much cleaner change.
