### PR TITLE
Introduce Table of Content Without Intense JS Invasion

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -85,6 +85,7 @@ SOURCES += \
     src/tabbar.cpp \
     src/contentmanagerside.cpp \
     src/readinglistbar.cpp \
+    src/tableofcontentbar.cpp \
     src/klistwidgetitem.cpp \
     src/opdsrequestmanager.cpp \
     src/localkiwixserver.cpp \
@@ -135,6 +136,7 @@ HEADERS += \
     src/tabbar.h \
     src/contentmanagerside.h \
     src/readinglistbar.h \
+    src/tableofcontentbar.h \
     src/klistwidgetitem.h \
     src/opdsrequestmanager.h \
     src/localkiwixserver.h \
@@ -158,7 +160,8 @@ FORMS += \
     src/contentmanagerside.ui \
     src/readinglistbar.ui \
     ui/localkiwixserver.ui \
-    ui/settings.ui
+    ui/settings.ui \
+    src/tableofcontentbar.ui \
 
 include(subprojects/QtSingleApplication/src/qtsingleapplication.pri)
 CODECFORSRC = UTF-8

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui network
-QT       += webenginewidgets
+QT       += webenginewidgets webchannel
 QT       += printsupport
 
 # Avoid stripping incompatible files, due to false identification as executables, on WSL
@@ -145,6 +145,7 @@ HEADERS += \
     src/portutils.h \
     src/css_constants.h \
     src/multizimbutton.h \
+    src/kiwixwebchannelobject.h \
 
 FORMS += \
     src/choiceitem.ui \

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -232,6 +232,7 @@ RESOURCES += \
     resources/translations.qrc \
     resources/contentmanager.qrc \
     resources/settingsmanager.qrc \
-    resources/style.qrc
+    resources/style.qrc \
+    resources/js.qrc
 
 RC_ICONS = resources/icons/kiwix/app_icon.ico

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -401,6 +401,64 @@ ContentTypeFilter {
     height: 0;
 }
 
+#tableofcontentbar {
+    background-color: white;
+}
+
+#tableofcontentbar QTreeWidget,
+#tableofcontentbar QLabel,
+#tableofcontentbar QFrame {
+    background-color: white;
+}
+
+#tableofcontentbar QTreeWidget {
+    outline: none;
+}
+
 #tableofcontentbar QTreeWidget::item {
     height: 26px;
+    padding: 0px 10px;
+    outline: none;
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid transparent;
+}
+
+#tableofcontentbar QTreeWidget::item:selected,
+#tableofcontentbar QTreeWidget::item:hover {
+    outline: none;
+    border-top: 1px solid #3366CC;
+    border-bottom: 1px solid #3366CC;
+    background-color: #D9E9FF;
+    color: black;
+}
+
+#tableofcontentbar QTreeWidget::branch:selected,
+#tableofcontentbar QTreeWidget::branch:hover {
+    outline: none;
+    border-top: 1px solid #3366CC;
+    border-bottom: 1px solid #3366CC;
+    background-color: #D9E9FF;
+}
+
+#tableofcontentbar QTreeWidget::branch {
+    image: none;
+}
+
+#tableofcontentbar #titleLabel {
+    padding: 0px;
+    margin: 10px;
+}
+
+#tableofcontentbar #hideLabel {
+    margin: 13px 10px 10px; /* 3px to match bottom with titleLabel */ 
+}
+
+#tableofcontentbar QScrollBar {
+    width: 5px;
+    border: none;
+    outline: none;
+}
+
+#tableofcontentbar QScrollBar::handle {
+    background-color: grey;
 }

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -400,3 +400,7 @@ ContentTypeFilter {
     width: 0;
     height: 0;
 }
+
+#tableofcontentbar QTreeWidget::item {
+    height: 26px;
+}

--- a/resources/js.qrc
+++ b/resources/js.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>js/headerAnchor.js</file>
+    </qresource>
+</RCC>

--- a/resources/js/headerAnchor.js
+++ b/resources/js/headerAnchor.js
@@ -1,0 +1,3 @@
+new QWebChannel(qt.webChannelTransport, function(channel) {
+    var kiwixObj = channel.objects.kiwixChannelObj;
+});

--- a/resources/js/headerAnchor.js
+++ b/resources/js/headerAnchor.js
@@ -1,3 +1,49 @@
+function isHeaderElement(elem)
+{
+    return elem.nodeName.match(/^H\d+$/) && elem.textContent;
+}
+
+function getDOMElementsPreorderDFS(elem, pred)
+{
+    var result = [];
+    if (pred(elem))
+        result.push(elem);
+
+    for ( const child of elem.children)
+        result = result.concat(getDOMElementsPreorderDFS(child, pred));
+    return result;
+}
+
+function anchorHeaderElements(headers)
+{
+    return Array.from(headers, function(elem, i)
+    {
+        const text = elem.textContent.trim().replace(/"/g, '\\"');
+        const level = parseInt(elem.nodeName.substr(1));
+        const anchor = `kiwix-toc-${i}`;
+
+        const anchorElem = document.createElement("a");
+        anchorElem.id = anchor;
+
+        /* Mark header content with something we can reference. */
+        elem.insertAdjacentElement("afterbegin", anchorElem);
+        return { text, level, anchor };
+    });
+}
+
+function getHeaders()
+{
+    const headerInfo = { url: window.location.href.replace(location.hash,""), headers: [] };
+
+    if (document.body !== undefined)
+    {
+        const headers = getDOMElementsPreorderDFS(document.body, isHeaderElement);
+        headerInfo.headers = anchorHeaderElements(headers);
+    }
+    return headerInfo;
+}
+
 new QWebChannel(qt.webChannelTransport, function(channel) {
     var kiwixObj = channel.objects.kiwixChannelObj;
+    kiwixObj.sendHeaders(getHeaders());
 });

--- a/resources/js/headerAnchor.js
+++ b/resources/js/headerAnchor.js
@@ -46,4 +46,8 @@ function getHeaders()
 new QWebChannel(qt.webChannelTransport, function(channel) {
     var kiwixObj = channel.objects.kiwixChannelObj;
     kiwixObj.sendHeaders(getHeaders());
+    kiwixObj.navigationRequested.connect(function(url, anchor) {
+        if (window.location.href.replace(location.hash,"") == url)
+            document.getElementById(anchor).scrollIntoView();
+    });
 });

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -435,8 +435,8 @@ void KiwixApp::createActions()
     });
     mpa_actions[ToggleFullscreenAction]->setCheckable(true);
 
-    CREATE_ACTION_SHORTCUT(ToggleTOCAction, gt("table-of-content"), QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_1));
-    HIDE_ACTION(ToggleTOCAction);
+    CREATE_ACTION_ICON_SHORTCUT(ToggleTOCAction, "toc", gt("table-of-content"), QKeySequence(Qt::CTRL | Qt::Key_M));
+    mpa_actions[ToggleTOCAction]->setCheckable(true);
 
     CREATE_ACTION_ICON_SHORTCUT(OpenMultiZimAction, "filter", gt("search-options"), QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_L));
 
@@ -492,6 +492,7 @@ void KiwixApp::handleItemsState(TabType tabType)
     auto libraryOrSettingsTab =  (tabType == TabType::LibraryTab || tabType == TabType::SettingsTab);
     auto notBookmarkableTab = libraryOrSettingsTab || getTabWidget()->currentArticleUrl().isEmpty();
     auto app = KiwixApp::instance();
+    app->getAction(KiwixApp::ToggleTOCAction)->setDisabled(libraryOrSettingsTab);
     app->getAction(KiwixApp::ToggleReadingListAction)->setDisabled(libraryOrSettingsTab);
     app->getAction(KiwixApp::ToggleAddBookmarkAction)->setDisabled(notBookmarkableTab);
     app->getAction(KiwixApp::FindInPageAction)->setDisabled(libraryOrSettingsTab);

--- a/src/kiwixwebchannelobject.h
+++ b/src/kiwixwebchannelobject.h
@@ -9,6 +9,11 @@ class KiwixWebChannelObject : public QObject
 
 public:
     explicit KiwixWebChannelObject(QObject *parent = nullptr) : QObject(parent) {};
+
+    Q_INVOKABLE void sendHeaders(const QJsonObject& headers) { emit headersChanged(headers); };
+
+signals:
+    void headersChanged(const QJsonObject& headers);
 };
 
 #endif // KIWIXWEBCHANNELOBJECT_H

--- a/src/kiwixwebchannelobject.h
+++ b/src/kiwixwebchannelobject.h
@@ -1,0 +1,14 @@
+#ifndef KIWIXWEBCHANNELOBJECT_H
+#define KIWIXWEBCHANNELOBJECT_H
+
+#include <QObject>
+
+class KiwixWebChannelObject : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit KiwixWebChannelObject(QObject *parent = nullptr) : QObject(parent) {};
+};
+
+#endif // KIWIXWEBCHANNELOBJECT_H

--- a/src/kiwixwebchannelobject.h
+++ b/src/kiwixwebchannelobject.h
@@ -14,6 +14,7 @@ public:
 
 signals:
     void headersChanged(const QJsonObject& headers);
+    void navigationRequested(const QString& url, const QString& anchor);
 };
 
 #endif // KIWIXWEBCHANNELOBJECT_H

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -58,6 +58,8 @@ KProfile::KProfile(QObject *parent) :
 #endif
 
     scripts()->insert(getScript(":/js/headerAnchor.js"));
+    scripts()->insert(getScript(":/qtwebchannel/qwebchannel.js", 
+                      QWebEngineScript::DocumentCreation));
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/kprofile.cpp
+++ b/src/kprofile.cpp
@@ -4,6 +4,26 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QWebEngineSettings>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
+
+namespace
+{
+
+QWebEngineScript getScript(QString filename,
+    QWebEngineScript::InjectionPoint point = QWebEngineScript::DocumentReady)
+{
+    QWebEngineScript script;
+    script.setInjectionPoint(point);
+    script.setWorldId(QWebEngineScript::UserWorld);
+
+    QFile scriptFile(filename);
+    scriptFile.open(QIODevice::ReadOnly);
+    script.setSourceCode(scriptFile.readAll());
+    return script;
+}
+
+}
 
 QString askForSaveFilePath(const QString& suggestedName)
 {
@@ -36,6 +56,8 @@ KProfile::KProfile(QObject *parent) :
 #else // Qt 5.13 and later
     setUrlRequestInterceptor(new ExternalReqInterceptor(this));
 #endif
+
+    scripts()->insert(getScript(":/js/headerAnchor.js"));
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -172,9 +172,18 @@ void MainWindow::resizeEvent(QResizeEvent *event)
     updateTabButtons();
 }
 
+void checkActionNoSignal(KiwixApp::Actions actionFlag, bool checked)
+{
+    const auto action = KiwixApp::instance()->getAction(actionFlag);
+    const bool oldState = action->blockSignals(true);
+    action->setChecked(checked);
+    action->blockSignals(oldState);
+}
+
 void MainWindow::readingListToggled(bool state)
 {
     if (state) {
+        checkActionNoSignal(KiwixApp::ToggleTOCAction, false);
         mp_ui->sideBar->setCurrentWidget(mp_ui->readinglistbar);
         mp_ui->sideBar->show();
     }
@@ -186,6 +195,7 @@ void MainWindow::readingListToggled(bool state)
 void MainWindow::tableOfContentToggled(bool state)
 {
     if (state) {
+        checkActionNoSignal(KiwixApp::ToggleReadingListAction, false);
         mp_ui->sideBar->setCurrentWidget(mp_ui->tableofcontentbar);
         mp_ui->sideBar->show();
     }
@@ -197,13 +207,18 @@ void MainWindow::tableOfContentToggled(bool state)
 void MainWindow::tabChanged(TabType tabType) 
 {
     QAction *readingList = KiwixApp::instance()->getAction(KiwixApp::ToggleReadingListAction);
+    QAction *tableOfContent = KiwixApp::instance()->getAction(KiwixApp::ToggleTOCAction);
     if (tabType == TabType::SettingsTab) { 
         mp_ui->sideBar->hide();    
     } else if(tabType == TabType::LibraryTab) { 
         mp_ui->sideBar->setCurrentWidget(mp_ui->contentmanagerside);
         mp_ui->sideBar->show();
-    } else { 
-        readingListToggled(readingList->isChecked());
+    } else if (readingList->isChecked()) {
+        readingListToggled(true);
+    } else if (tableOfContent->isChecked()) {
+        tableOfContentToggled(true);
+    } else {
+        mp_ui->sideBar->hide();
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -231,3 +231,8 @@ TopWidget *MainWindow::getTopWidget()
 {
     return mp_ui->mainToolBar;
 }
+
+TableOfContentBar *MainWindow::getTableOfContentBar()
+{
+    return mp_ui->tableofcontentbar;
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -45,6 +45,8 @@ MainWindow::MainWindow(QWidget *parent) :
             this, &MainWindow::toggleFullScreen);
     connect(app->getAction(KiwixApp::ToggleReadingListAction), &QAction::toggled,
             this, &MainWindow::readingListToggled);
+    connect(app->getAction(KiwixApp::ToggleTOCAction), &QAction::toggled,
+            this, &MainWindow::tableOfContentToggled);
     connect(app->getAction(KiwixApp::AboutAction), &QAction::triggered,
             mp_about, &QDialog::show);
     connect(app->getAction(KiwixApp::DonateAction), &QAction::triggered,
@@ -174,6 +176,17 @@ void MainWindow::readingListToggled(bool state)
 {
     if (state) {
         mp_ui->sideBar->setCurrentWidget(mp_ui->readinglistbar);
+        mp_ui->sideBar->show();
+    }
+    else {
+        mp_ui->sideBar->hide();
+    }
+}
+
+void MainWindow::tableOfContentToggled(bool state)
+{
+    if (state) {
+        mp_ui->sideBar->setCurrentWidget(mp_ui->tableofcontentbar);
         mp_ui->sideBar->show();
     }
     else {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -35,6 +35,7 @@ private slots:
     void toggleFullScreen();
     void tabChanged(TabBar::TabType);
     void readingListToggled(bool state);
+    void tableOfContentToggled(bool state);
     void hideTabAndTop();
     void showTabAndTop();
     void updateTabButtons();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -14,6 +14,8 @@ namespace Ui {
 class MainWindow;
 }
 
+class TableOfContentBar;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -25,6 +27,7 @@ public:
     TabBar*   getTabBar();
     TopWidget* getTopWidget();
     QWidget getMainView();
+    TableOfContentBar *getTableOfContentBar();
 
 protected:
     bool eventFilter(QObject* object, QEvent* event) override;

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -9,7 +9,9 @@ TableOfContentBar::TableOfContentBar(QWidget *parent) :
     ui(new Ui::tableofcontentbar)
 {
     ui->setupUi(this);
+    ui->titleLabel->setFont(QFont("Selawik", 18, QFont::Weight::Medium));
     ui->titleLabel->setText(gt("table-of-content"));
+    ui->hideLabel->setFont(QFont("Selawik", 12));
     ui->hideLabel->setTextFormat(Qt::RichText);
 
     /* href is needed to make hide clickable, but not used. So Kiwix it is :) */
@@ -44,6 +46,7 @@ QTreeWidgetItem* createChildItem(QTreeWidgetItem* parent, const QString& childNo
 
     const auto display = childNo + "  " + headerObj["text"].toString();
     item->setData(0, Qt::DisplayRole, display);
+    item->setData(0, Qt::FontRole, QFont("Selawik", 12));
     item->setData(0, Qt::UserRole, headerObj["anchor"].toString());
 
     return item;

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -12,11 +12,18 @@ TableOfContentBar::TableOfContentBar(QWidget *parent) :
     ui->titleLabel->setText(gt("table-of-content"));
     ui->tree->setRootIsDecorated(false);
     ui->tree->setItemsExpandable(false);
+    connect(ui->tree, &QTreeWidget::itemClicked, this, &TableOfContentBar::onTreeItemActivated);
+    connect(ui->tree, &QTreeWidget::itemActivated, this, &TableOfContentBar::onTreeItemActivated);
 }
 
 TableOfContentBar::~TableOfContentBar()
 {
     delete ui;
+}
+
+void TableOfContentBar::onTreeItemActivated(QTreeWidgetItem *item)
+{
+    emit navigationRequested(m_url, item->data(0, Qt::UserRole).toString());
 }
 
 namespace
@@ -27,6 +34,7 @@ QTreeWidgetItem* createChildItem(QTreeWidgetItem* parent, const QJsonObject& hea
     const auto item = new QTreeWidgetItem(parent);
     item->setExpanded(true);
     item->setData(0, Qt::DisplayRole, headerObj["text"].toString());
+    item->setData(0, Qt::UserRole, headerObj["anchor"].toString());
 
     return item;
 }
@@ -68,6 +76,7 @@ void TableOfContentBar::setupTree(const QJsonObject& headers)
     if (headerUrl != currentUrl)
         return;
     
+    m_url = headerUrl;
     ui->tree->clear();
     QJsonArray headerArr = headers["headers"].toArray();
     createSubTree(ui->tree->invisibleRootItem(), headerArr);

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -10,6 +10,14 @@ TableOfContentBar::TableOfContentBar(QWidget *parent) :
 {
     ui->setupUi(this);
     ui->titleLabel->setText(gt("table-of-content"));
+    ui->hideLabel->setTextFormat(Qt::RichText);
+
+    /* href is needed to make hide clickable, but not used. So Kiwix it is :) */
+    ui->hideLabel->setText("<a href=\"https://kiwix.org/en/\">" + gt("hide") + "</a>");
+    connect(ui->hideLabel, &QLabel::linkActivated, this, [=](){
+        KiwixApp::instance()->getAction(KiwixApp::ToggleTOCAction)->setChecked(false);
+    });
+
     ui->tree->setRootIsDecorated(false);
     ui->tree->setItemsExpandable(false);
     connect(ui->tree, &QTreeWidget::itemClicked, this, &TableOfContentBar::onTreeItemActivated);

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -29,11 +29,13 @@ void TableOfContentBar::onTreeItemActivated(QTreeWidgetItem *item)
 namespace
 {
 
-QTreeWidgetItem* createChildItem(QTreeWidgetItem* parent, const QJsonObject& headerObj)
+QTreeWidgetItem* createChildItem(QTreeWidgetItem* parent, const QString& childNo, const QJsonObject& headerObj)
 {
     const auto item = new QTreeWidgetItem(parent);
     item->setExpanded(true);
-    item->setData(0, Qt::DisplayRole, headerObj["text"].toString());
+
+    const auto display = childNo + "  " + headerObj["text"].toString();
+    item->setData(0, Qt::DisplayRole, display);
     item->setData(0, Qt::UserRole, headerObj["anchor"].toString());
 
     return item;
@@ -54,15 +56,16 @@ QJsonArray takeDeeperEntries(QJsonArray& headerArr, int level)
     return result;
 }
 
-void createSubTree(QTreeWidgetItem* parent, QJsonArray& headerArr)
+void createSubTree(QTreeWidgetItem* parent, QString parentNo, QJsonArray& headerArr)
 {
     while (!headerArr.isEmpty())
     {
         const auto childHeader = headerArr.takeAt(0).toObject();
         const int childLevel = childHeader["level"].toInt();
-        QTreeWidgetItem* childItem = createChildItem(parent, childHeader);
+        const QString childNo = parentNo + QString::number(parent->childCount() + 1);
+        QTreeWidgetItem* childItem = createChildItem(parent, childNo, childHeader);
         QJsonArray deeperEntries = takeDeeperEntries(headerArr, childLevel);
-        createSubTree(childItem, deeperEntries);
+        createSubTree(childItem, childNo + ".", deeperEntries);
     }
 }
 
@@ -79,5 +82,5 @@ void TableOfContentBar::setupTree(const QJsonObject& headers)
     m_url = headerUrl;
     ui->tree->clear();
     QJsonArray headerArr = headers["headers"].toArray();
-    createSubTree(ui->tree->invisibleRootItem(), headerArr);
+    createSubTree(ui->tree->invisibleRootItem(), "", headerArr);
 }

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -1,0 +1,16 @@
+#include "tableofcontentbar.h"
+#include "ui_tableofcontentbar.h"
+#include "kiwixapp.h"
+
+TableOfContentBar::TableOfContentBar(QWidget *parent) :
+    QFrame(parent),
+    ui(new Ui::tableofcontentbar)
+{
+    ui->setupUi(this);
+    ui->titleLabel->setText(gt("table-of-content"));
+}
+
+TableOfContentBar::~TableOfContentBar()
+{
+    delete ui;
+}

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -45,6 +45,7 @@ QTreeWidgetItem* createChildItem(QTreeWidgetItem* parent, const QString& childNo
     item->setExpanded(true);
 
     const auto display = childNo + "  " + headerObj["text"].toString();
+    item->setToolTip(0, display);
     item->setData(0, Qt::DisplayRole, display);
     item->setData(0, Qt::FontRole, QFont("Selawik", 12));
     item->setData(0, Qt::UserRole, headerObj["anchor"].toString());

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -1,6 +1,8 @@
 #include "tableofcontentbar.h"
 #include "ui_tableofcontentbar.h"
 #include "kiwixapp.h"
+#include <QJsonObject>
+#include <QTreeWidgetItem>
 
 TableOfContentBar::TableOfContentBar(QWidget *parent) :
     QFrame(parent),
@@ -8,9 +10,65 @@ TableOfContentBar::TableOfContentBar(QWidget *parent) :
 {
     ui->setupUi(this);
     ui->titleLabel->setText(gt("table-of-content"));
+    ui->tree->setRootIsDecorated(false);
+    ui->tree->setItemsExpandable(false);
 }
 
 TableOfContentBar::~TableOfContentBar()
 {
     delete ui;
+}
+
+namespace
+{
+
+QTreeWidgetItem* createChildItem(QTreeWidgetItem* parent, const QJsonObject& headerObj)
+{
+    const auto item = new QTreeWidgetItem(parent);
+    item->setExpanded(true);
+    item->setData(0, Qt::DisplayRole, headerObj["text"].toString());
+
+    return item;
+}
+
+QJsonArray takeDeeperEntries(QJsonArray& headerArr, int level)
+{
+    QJsonArray result;
+    while (!headerArr.isEmpty())
+    {
+        const auto& nextHeader = headerArr.first().toObject();
+        if (nextHeader["level"].toInt() <= level)
+           break;
+
+        result.push_back(nextHeader);
+        headerArr.pop_front();
+    }
+    return result;
+}
+
+void createSubTree(QTreeWidgetItem* parent, QJsonArray& headerArr)
+{
+    while (!headerArr.isEmpty())
+    {
+        const auto childHeader = headerArr.takeAt(0).toObject();
+        const int childLevel = childHeader["level"].toInt();
+        QTreeWidgetItem* childItem = createChildItem(parent, childHeader);
+        QJsonArray deeperEntries = takeDeeperEntries(headerArr, childLevel);
+        createSubTree(childItem, deeperEntries);
+    }
+}
+
+}
+
+void TableOfContentBar::setupTree(const QJsonObject& headers)
+{
+    const auto headerUrl = headers["url"].toString();
+    const auto webView = KiwixApp::instance()->getTabWidget()->currentWebView();
+    const auto currentUrl = webView->url().url(QUrl::RemoveFragment);
+    if (headerUrl != currentUrl)
+        return;
+    
+    ui->tree->clear();
+    QJsonArray headerArr = headers["headers"].toArray();
+    createSubTree(ui->tree->invisibleRootItem(), headerArr);
 }

--- a/src/tableofcontentbar.h
+++ b/src/tableofcontentbar.h
@@ -1,0 +1,22 @@
+#ifndef TABLEOFCONTENTBAR_H
+#define TABLEOFCONTENTBAR_H
+
+#include <QFrame>
+
+namespace Ui {
+class tableofcontentbar;
+}
+
+class TableOfContentBar : public QFrame
+{
+    Q_OBJECT
+
+public:
+    explicit TableOfContentBar(QWidget *parent = nullptr);
+    ~TableOfContentBar();
+
+private:
+    Ui::tableofcontentbar *ui;
+};
+
+#endif // TABLEOFCONTENTBAR_H

--- a/src/tableofcontentbar.h
+++ b/src/tableofcontentbar.h
@@ -7,6 +7,8 @@ namespace Ui {
 class tableofcontentbar;
 }
 
+class QTreeWidgetItem;
+
 class TableOfContentBar : public QFrame
 {
     Q_OBJECT
@@ -17,9 +19,14 @@ public:
 
 public slots:
     void setupTree(const QJsonObject& headers);
+    void onTreeItemActivated(QTreeWidgetItem* item);
+
+signals:
+    void navigationRequested(const QString& url, const QString& anchor);
 
 private:
     Ui::tableofcontentbar *ui;
+    QString m_url;
 };
 
 #endif // TABLEOFCONTENTBAR_H

--- a/src/tableofcontentbar.h
+++ b/src/tableofcontentbar.h
@@ -15,6 +15,9 @@ public:
     explicit TableOfContentBar(QWidget *parent = nullptr);
     ~TableOfContentBar();
 
+public slots:
+    void setupTree(const QJsonObject& headers);
+
 private:
     Ui::tableofcontentbar *ui;
 };

--- a/src/tableofcontentbar.ui
+++ b/src/tableofcontentbar.ui
@@ -59,6 +59,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QLabel" name="hideLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/tableofcontentbar.ui
+++ b/src/tableofcontentbar.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>tableofcontentbar</class>
+ <widget class="QWidget" name="tableofcontentbar">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="titleLabel">
+       <property name="font">
+        <font>
+         <pointsize>16</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeWidget" name="tree">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="textElideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="indentation">
+      <number>30</number>
+     </property>
+     <property name="uniformRowHeights">
+      <bool>true</bool>
+     </property>
+     <property name="itemsExpandable">
+      <bool>true</bool>
+     </property>
+     <property name="headerHidden">
+      <bool>true</bool>
+     </property>
+     <property name="expandsOnDoubleClick">
+      <bool>false</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/tableofcontentbar.ui
+++ b/src/tableofcontentbar.ui
@@ -20,6 +20,9 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -44,6 +47,9 @@
        <property name="text">
         <string/>
        </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
       </widget>
      </item>
      <item>
@@ -63,6 +69,9 @@
       <widget class="QLabel" name="hideLabel">
        <property name="text">
         <string/>
+       </property>
+       <property name="indent">
+        <number>0</number>
        </property>
       </widget>
      </item>
@@ -90,7 +99,7 @@
       <enum>QAbstractScrollArea::AdjustToContents</enum>
      </property>
      <property name="textElideMode">
-      <enum>Qt::ElideNone</enum>
+      <enum>Qt::ElideRight</enum>
      </property>
      <property name="indentation">
       <number>30</number>

--- a/src/topwidget.cpp
+++ b/src/topwidget.cpp
@@ -30,6 +30,9 @@ TopWidget::TopWidget(QWidget *parent) :
     QAction *random = app->getAction(KiwixApp::RandomArticleAction);
     addAction(random);
 
+    QAction *toc = app->getAction(KiwixApp::ToggleTOCAction);
+    addAction(toc);
+
     // For CSS
     if (QGuiApplication::isLeftToRight()) {
         widgetForAction(back)->setObjectName("leftHistoryButton");

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -19,6 +19,7 @@ class QMenu;
 #include <QWebChannel>
 #include <QWebEngineScript>
 #include "kiwixwebchannelobject.h"
+#include "tableofcontentbar.h"
 
 zim::Entry getArchiveEntryFromUrl(const zim::Archive& archive, const QUrl& url);
 QString askForSaveFilePath(const QString& suggestedName);
@@ -109,6 +110,9 @@ WebView::WebView(QWidget *parent)
     const auto tabbar = KiwixApp::instance()->getTabWidget();
     connect(tabbar, &TabBar::currentTitleChanged, this, &WebView::onCurrentTitleChanged);
     connect(kiwixChannelObj, &KiwixWebChannelObject::headersChanged, this, &WebView::onHeadersReceived);
+
+    const auto tocbar = KiwixApp::instance()->getMainWindow()->getTableOfContentBar();
+    connect(this, &WebView::headersChanged, tocbar, &TableOfContentBar::setupTree);
 }
 
 WebView::~WebView()

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -113,6 +113,8 @@ WebView::WebView(QWidget *parent)
 
     const auto tocbar = KiwixApp::instance()->getMainWindow()->getTableOfContentBar();
     connect(this, &WebView::headersChanged, tocbar, &TableOfContentBar::setupTree);
+    connect(tocbar, &TableOfContentBar::navigationRequested, this, &WebView::onNavigationRequested);
+    connect(this, &WebView::navigationRequested, kiwixChannelObj, &KiwixWebChannelObject::navigationRequested);
 }
 
 WebView::~WebView()
@@ -226,6 +228,13 @@ void WebView::onHeadersReceived(const QJsonObject& headers)
     
     if (tabbar->currentWebView() == this)
         emit headersChanged(m_headers);
+}
+
+void WebView::onNavigationRequested(const QString &url, const QString &anchor)
+{
+    const auto tabbar = KiwixApp::instance()->getTabWidget();
+    if (tabbar->currentWebView() == this)
+        emit navigationRequested(url, anchor);
 }
 
 void WebView::addHistoryItemAction(QMenu *menu,

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -16,6 +16,9 @@ class QMenu;
 #include <zim/error.h>
 #include <zim/item.h>
 #include <kiwix/tools.h>
+#include <QWebChannel>
+#include <QWebEngineScript>
+#include "kiwixwebchannelobject.h"
 
 zim::Entry getArchiveEntryFromUrl(const zim::Archive& archive, const QUrl& url);
 QString askForSaveFilePath(const QString& suggestedName);
@@ -97,6 +100,11 @@ WebView::WebView(QWidget *parent)
         }
     });
 #endif
+
+    const auto channel = new QWebChannel(this);
+    const auto kiwixChannelObj = new KiwixWebChannelObject;
+    page()->setWebChannel(channel, QWebEngineScript::UserWorld);
+    channel->registerObject("kiwixChannelObj", kiwixChannelObj);
 }
 
 WebView::~WebView()

--- a/src/webview.h
+++ b/src/webview.h
@@ -55,6 +55,7 @@ signals:
     void iconChanged(const QIcon& icon);
     void zimIdChanged(const QString& zimId);
     void headersChanged(const QJsonObject& headers);
+    void navigationRequested(const QString& url, const QString& anchor);
 
 protected:
     virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type);
@@ -71,6 +72,7 @@ private slots:
     void gotoTriggeredHistoryItemAction();
     void onCurrentTitleChanged();
     void onHeadersReceived(const QJsonObject& headers);
+    void onNavigationRequested(const QString& url, const QString& anchor);
 
 private:
     void addHistoryItemAction(QMenu *menu, const QWebEngineHistoryItem &item, int n) const;

--- a/src/webview.h
+++ b/src/webview.h
@@ -5,6 +5,7 @@
 #include <QWebEngineView>
 #include <QIcon>
 #include <QWheelEvent>
+#include <QJsonObject>
 
 #include "findinpagebar.h"
 
@@ -53,6 +54,7 @@ public slots:
 signals:
     void iconChanged(const QIcon& icon);
     void zimIdChanged(const QString& zimId);
+    void headersChanged(const QJsonObject& headers);
 
 protected:
     virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type);
@@ -67,12 +69,15 @@ protected:
 
 private slots:
     void gotoTriggeredHistoryItemAction();
+    void onCurrentTitleChanged();
+    void onHeadersReceived(const QJsonObject& headers);
 
 private:
     void addHistoryItemAction(QMenu *menu, const QWebEngineHistoryItem &item, int n) const;
     void applyCorrectZoomFactor();
     QMenu* createStandardContextMenu();
     QMenu* createLinkContextMenu();
+    QJsonObject m_headers;
 };
 
 #endif // WEBVIEW_H

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -145,6 +145,7 @@
             </sizepolicy>
            </property>
           </widget>
+          <widget class="TableOfContentBar" name="tableofcontentbar"/>
           <widget class="ReadingListBar" name="readinglistbar"/>
          </widget>
         </item>
@@ -199,6 +200,12 @@
    <class>ReadingListBar</class>
    <extends>QWidget</extends>
    <header>src/readinglistbar.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>TableOfContentBar</class>
+   <extends>QWidget</extends>
+   <header>src/tableofcontentbar.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Alternative to #1201. FIx #42 

Changes:
- Uses QTreeWidget to handle TOC display
- The TOC now resides in the sidebar along with the Content Manager Side and ReadingList Bar.
- Styling is slightly different since QTreeWidget doesn't perform the same way as HTML and JS.

Benefits:
- More extensible when future features come
- Easier handling inside Qt for styling and parsing.

Loses:
- The TOC requesting is asynchronous and requires some fine-tuned race checking.
- Slow due to extra parsing and passing around of the TOC.