### PR TITLE
BugFix: Prevent crashes from tab switches due to Table Of Content

### DIFF
--- a/resources/js/headerAnchor.js
+++ b/resources/js/headerAnchor.js
@@ -31,7 +31,7 @@ function anchorHeaderElements(headers)
     });
 }
 
-function getHeaders()
+function getHeadersJSONStr()
 {
     const headerInfo = { url: window.location.href.replace(location.hash,""), headers: [] };
 
@@ -40,12 +40,12 @@ function getHeaders()
         const headers = getDOMElementsPreorderDFS(document.body, isHeaderElement);
         headerInfo.headers = anchorHeaderElements(headers);
     }
-    return headerInfo;
+    return JSON.stringify(headerInfo);
 }
 
 new QWebChannel(qt.webChannelTransport, function(channel) {
     var kiwixObj = channel.objects.kiwixChannelObj;
-    kiwixObj.sendHeaders(getHeaders());
+    kiwixObj.sendHeadersJSONStr(getHeadersJSONStr());
     kiwixObj.navigationRequested.connect(function(url, anchor) {
         if (window.location.href.replace(location.hash,"") == url)
             document.getElementById(anchor).scrollIntoView();

--- a/src/kiwixwebchannelobject.h
+++ b/src/kiwixwebchannelobject.h
@@ -10,10 +10,10 @@ class KiwixWebChannelObject : public QObject
 public:
     explicit KiwixWebChannelObject(QObject *parent = nullptr) : QObject(parent) {};
 
-    Q_INVOKABLE void sendHeaders(const QJsonObject& headers) { emit headersChanged(headers); };
+    Q_INVOKABLE void sendHeadersJSONStr(const QString& headersJSONStr) { emit headersChanged(headersJSONStr); };
 
 signals:
-    void headersChanged(const QJsonObject& headers);
+    void headersChanged(const QString& headersJSONStr);
     void navigationRequested(const QString& url, const QString& anchor);
 };
 

--- a/src/tableofcontentbar.cpp
+++ b/src/tableofcontentbar.cpp
@@ -85,8 +85,11 @@ void createSubTree(QTreeWidgetItem* parent, QString parentNo, QJsonArray& header
 
 void TableOfContentBar::setupTree(const QJsonObject& headers)
 {
-    const auto headerUrl = headers["url"].toString();
     const auto webView = KiwixApp::instance()->getTabWidget()->currentWebView();
+    if (!webView)
+        return;
+
+    const auto headerUrl = headers["url"].toString();
     const auto currentUrl = webView->url().url(QUrl::RemoveFragment);
     if (headerUrl != currentUrl)
         return;

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -221,10 +221,10 @@ void WebView::onCurrentTitleChanged()
         emit headersChanged(m_headers);
 }
 
-void WebView::onHeadersReceived(const QJsonObject& headers)
+void WebView::onHeadersReceived(const QString& headersJSONStr)
 {
     const auto tabbar = KiwixApp::instance()->getTabWidget();
-    m_headers = QJsonObject(headers);
+    m_headers = QJsonDocument::fromJson(headersJSONStr.toUtf8()).object();
     
     if (tabbar->currentWebView() == this)
         emit headersChanged(m_headers);

--- a/src/webview.h
+++ b/src/webview.h
@@ -71,7 +71,7 @@ protected:
 private slots:
     void gotoTriggeredHistoryItemAction();
     void onCurrentTitleChanged();
-    void onHeadersReceived(const QJsonObject& headers);
+    void onHeadersReceived(const QString& headersJSONStr);
     void onNavigationRequested(const QString& url, const QString& anchor);
 
 private:


### PR DESCRIPTION
Bug: Crashes can happen to the TOC management when the user switches tabs. Qt's QJsonObject copies are unreliable (though they shouldn't). I am uncertain as to why, but it appears references to the copied header array elements trigger segmentation faults. It also seems to be a race condition so in some cases it doesn't happen (when I tested it before merging it never occurred).

Fixes:
- Pass the header array as a string and create our own copy of QJsonObject instead.
- A nullptr guard was added to `tableofcontentbar.cpp` to prevent potential nullptr access. (This is irrelevant to the bug but something to carry over.)

