### PR TITLE
Switch Linux CI to jammy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,16 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - focal
+          - jammy
         include:
-          - target: focal
-            image_variant: focal
+          - target: jammy
+            image_variant: jammy
             lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:38
+      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-11-06
 
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Fixed the Windows CI (broken because of kiwix/kiwix-build#779) and swtiched the Linux CI to jammy.