### PR TITLE
Under Windows settings are persisted in files too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         set PKG_CONFIG_PATH=%cd%\BUILD_win-amd64\INSTALL\lib\pkgconfig
         qmake PREFIX=%cd%\BUILD_win-amd64\INSTALL
-        nmake debug-all
+        nmake release-all
 
   Linux:
     strategy:

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -39,7 +39,7 @@ KiwixApp::KiwixApp(int& argc, char *argv[])
     /* Place session file in our global library path */
     QDir dir(m_libraryDirectory);
     mp_session = new QSettings(dir.filePath("kiwix-desktop.session"),
-                               QSettings::defaultFormat(), this);
+                               QSettings::IniFormat, this);
     try {
         m_translation.setTranslation(QLocale());
     } catch (std::exception& e) {

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -45,7 +45,7 @@ QString getSettingsConfPath()
 
 SettingsManager::SettingsManager(QObject *parent)
     : QObject(parent),
-    m_settings(getSettingsConfPath(), QSettings::NativeFormat),
+    m_settings(getSettingsConfPath(), QSettings::IniFormat),
     m_view(nullptr)
 {
     initSettings();


### PR DESCRIPTION
Fixes #1254 

Before this fix the settings and session information should have been written to the Windows registry however for some reason it didn't work.

In any case we want the settings to be saved in files so that it plays better with portable mode (when we start supporting it for Windows builds too).

Explicit settings (those configurable through the settings dialog, and library filters) are saved in
**C:\\Users\\**_USER_**\\AppData\\Local\\kiwix-desktop\\Kiwix-desktop.conf**

Session info (window size, list of open tabs, last directory used for opening a ZIM file) are saved in
**C:\\Users\\**_USER_**\\AppData\\Roaming\\kiwix-desktop\\kiwix-desktop.session**