### PR TITLE
Windows version of kiwix-desktop no longer crashes when launched from a network folder

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -109,10 +109,7 @@ void KiwixApp::init()
         }
     });
 
-    /* Restore Tabs before directory monitoring to ensure we know what tabs user had. */
-    restoreTabs();
     restoreWindowState();
-    setupDirectoryMonitoring();
 }
 
 void KiwixApp::setupDirectoryMonitoring()

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -106,6 +106,8 @@ public:
     void savePrevSaveDir(const QString& prevSaveDir);
     QString getSavedVoiceName(const QString& langName) const;
     QString getPrevSaveDir() const;
+    void restoreTabs();
+    void setupDirectoryMonitoring();
 
 public slots:
     void newTab();
@@ -137,9 +139,7 @@ private:
 
     QAction*     mpa_actions[MAX_ACTION];
 
-    void setupDirectoryMonitoring();
     QString findLibraryDirectory();
-    void restoreTabs();
     void loadAndInstallTranslations(QTranslator& translator, const QString& filename, const QString& directory);
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
 bool wasAppStartedFromARemoteDrive()
 {
     const std::string exePath = kiwix::getExecutablePath();
+    if ( exePath.substr(0, 2) == "\\\\" )
+        return true;
 
     return GetDriveTypeA(exePath.substr(0, 3).c_str()) == DRIVE_REMOTE;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,11 @@ int main(int argc, char *argv[])
         if (result == QMessageBox::No) return 0;
     }
 #endif
+
+    /* Restore Tabs before directory monitoring to ensure we know what tabs user had. */
+    a.restoreTabs();
+    a.setupDirectoryMonitoring();
+
     for (QString zimfile : positionalArguments) {
         a.openZimFile(zimfile);
     }

--- a/src/texttospeechbar.cpp
+++ b/src/texttospeechbar.cpp
@@ -90,6 +90,9 @@ void TextToSpeechBar::resetVoiceComboBox()
     ui->voiceComboBox->clear();
 
     m_voices = m_speech.availableVoices();
+    if ( m_voices.isEmpty() )
+	    return;
+
     for (const auto& voice : m_voices)
     {
         ui->voiceComboBox->addItem(QString("%1 - %2 - %3").arg(voice.name())


### PR DESCRIPTION
Fixes #1236 

Also
- fixed a crash when no TTS voices are available
- fixed the issue of exposing the user to the potential risk we warn them about (regarding using a web browser with disabled sandbox) before the approval to proceed is granted.