### PR TITLE
fix: Make settings tab scrollable for better accessibility on small screens

### DIFF
--- a/src/settingsview.cpp
+++ b/src/settingsview.cpp
@@ -6,6 +6,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QToolTip>
+#include <QScrollArea>
 
 namespace 
 {
@@ -29,7 +30,7 @@ namespace
 }
 
 SettingsView::SettingsView(QWidget *parent)
-    : QWidget(parent)
+    : QScrollArea(parent)
     , ui(new Ui::Settings)
 {
     SettingsManager *settingsMgr = KiwixApp::instance()->getSettingsManager();

--- a/src/settingsview.h
+++ b/src/settingsview.h
@@ -3,10 +3,11 @@
 
 #include <QWidget>
 #include <QPushButton>
+#include <QScrollArea>
 namespace Ui {
 class Settings;
 }
-class SettingsView : public QWidget
+class SettingsView : public QScrollArea
 {
     Q_OBJECT
 public:

--- a/ui/settings.ui
+++ b/ui/settings.ui
@@ -1,6 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>Settings</class>
+<widget class="QScrollArea" name="scrollArea">
+<property name="geometry">
+<rect>
+<x>0</x>
+<y>0</y>
+<width>1029</width>
+<height>580</height>
+</rect>
+</property>
+<property name="widgetResizable">
+	<bool>true</bool>
+</property>
+<widget class="QWidget" name="scrollAreaWidgetContents">
+	<property name="geometry">
+	<rect>
+		<x>0</x>
+		<y>0</y>
+		<width>1029</width>
+		<height>580</height>
+	</rect>
+	</property>
+	<layout class="QVBoxLayout" name="verticalLayout">
+		<property name="alignment">
+			<set>Qt::AlignCenter</set>
+		</property>
+	<item>
  <widget class="QWidget" name="Settings">
   <property name="geometry">
    <rect>
@@ -19,7 +45,7 @@
   <property name="minimumSize">
    <size>
     <width>600</width>
-    <height>0</height>
+    <height>450</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -406,6 +432,10 @@
    </item>
   </layout>
  </widget>
+ 	</item>
+</layout>
+</widget>
+</widget>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
fix #1261 


Changes:

- Made settings tab scrollable, for better accessibility on small screens, by adding QScrollArea on top of Settings Frame.

![image](https://github.com/user-attachments/assets/254d5652-d1d4-4db6-b321-49e80ca1b338)
