### PR TITLE
Add noble to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,19 @@ jobs:
       matrix:
         target:
           - jammy
+          - noble
         include:
           - target: jammy
             image_variant: jammy
+            lib_postfix: '/x86_64-linux-gnu'
+          - target: noble
+            image_variant: noble
             lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-11-06
+      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-12-17
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,13 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - jammy
-          - noble
+          - jammy-qt5
+          - noble-qt6
         include:
-          - target: jammy
+          - target: jammy-qt5
             image_variant: jammy
             lib_postfix: '/x86_64-linux-gnu'
-          - target: noble
+          - target: noble-qt6
             image_variant: noble
             lib_postfix: '/x86_64-linux-gnu'
     env:


### PR DESCRIPTION
Fixes #1103 

Adds ubuntu noble to the build matrix and updates to the new container image that can build kiwix-desktop on qt6.