### PR TITLE
Workaround for strange libkiwix-dev dependency issue

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,8 @@ Build-Depends: debhelper-compat (= 13),
  qtbase5-dev,
  qtwebengine5-dev,
  libqt5texttospeech5-dev,
- libkiwix-dev (>= 14.0.0), libkiwix-dev (<< 15.0.0),
- libzim-dev (>= 9.0.0), libzim-dev (<< 10.0.0),
+ libkiwix-dev (>= 14.0), libkiwix-dev (<< 15.0),
+ libzim-dev (>= 9.0), libzim-dev (<< 10.0),
 Standards-Version: 4.5.0
 Homepage: https://www.kiwix.org/
 Rules-Requires-Root: no


### PR DESCRIPTION
Should fix #1285

For some mysterious reason the dependency requirement `libkiwix-dev (>= 14.0.0)` in the Debian control file results in PPA build failure. After unpacking `kiwix-build-deps_2.4.0~focal_all.deb` the `apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes install -f` commands reports:

    Reading package lists...
    Building dependency tree...
    Reading state information...
    Starting pkgProblemResolver with broken count: 1
    Starting 2 pkgProblemResolver with broken count: 1
    Investigating (0) kiwix-build-deps:amd64 < 2.4.0~focal @iU mK Nb Ib >
    Broken kiwix-build-deps:amd64 Depends on libkiwix-dev:amd64 < none -> 14.0.0~focal @un uN > (>= 14.0.0)
      Removing kiwix-build-deps:amd64 because I can't find libkiwix-dev:amd64
    Done

Shortening the libkiwix-dev minimal version string to "14.0" (`libkiwix-dev (>= 14.0)`) works around that issue.