### PR TITLE
Add oracular to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,19 +57,23 @@ jobs:
       matrix:
         target:
           - jammy-qt5
-          - noble-qt6
+          - noble-qt6.4
+          - oracular-qt6.6
         include:
           - target: jammy-qt5
             image_variant: jammy
             lib_postfix: '/x86_64-linux-gnu'
-          - target: noble-qt6
+          - target: noble-qt6.4
             image_variant: noble
+            lib_postfix: '/x86_64-linux-gnu'
+          - target: oracular-qt6.6
+            image_variant: oracular
             lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-12-17
+      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-12-18
 
     steps:
       - name: Install dependencies

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -24,6 +24,14 @@ QMAKE_LFLAGS +=  -std=c++17
 
 !win32 {
     QMAKE_CXXFLAGS += -Werror
+    equals(QT_MAJOR_VERSION, 6):equals(QT_MINOR_VERSION, 6) {
+        # Fail the build on errors, except for 'template-id-cdtor' due to a problem with Qt headers.
+        # This can be removed when the Ubuntu package is fixed.
+        # See
+        # https://github.com/RfidResearchGroup/proxmark3/issues/2382
+        # https://bugreports.qt.io/browse/QTBUG-126989
+        QMAKE_CXXFLAGS += -Wno-error=template-id-cdtor
+    }
 }
 
 !win32:!static {


### PR DESCRIPTION
Ubuntu Noble comes with Qt 6.4. Oracular (24.10) comes with Qt 6.6. Creating this PR to test out the CI for oracular to see if we can get the additional Qt version coverage.