### PR TITLE
Fixes for Qt 6.4.3 on Windows

### DIFF
--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -9,6 +9,10 @@ QT       += webenginewidgets webchannel
 QT       += printsupport
 qtHaveModule(texttospeech): QT += texttospeech
 
+win32 {
+    QT += gui-private
+}
+
 # Avoid stripping incompatible files, due to false identification as executables, on WSL
 DETECT_WSL = $$system(test -f /proc/sys/fs/binfmt_misc/WSLInterop && echo true || echo false)
 equals(DETECT_WSL , "true"): CONFIG += nostrip


### PR DESCRIPTION
kiwix-build was unable to build on Windows with Qt 6.4.3. The fix makes use of the `gui-private` module (aka platform-specific Qt code) on windows instead of the direct win32 calls.

Tested out using artifacts generated from kiwix-build and the application appears to work normally.