### PR TITLE
fix: Update filters after sideloading a ZIM file

### DIFF
--- a/src/contentmanager.cpp
+++ b/src/contentmanager.cpp
@@ -94,6 +94,8 @@ ContentManager::ContentManager(Library* library)
     connect(this, &ContentManager::filterParamsChanged, this, &ContentManager::updateLibrary);
     connect(this, &ContentManager::booksChanged, this, [=]() {
         updateModel();
+        setCategories();
+        setLanguages();
     });
     connect(&m_remoteLibraryManager, &OpdsRequestManager::requestReceived, this, &ContentManager::updateRemoteLibrary);
     connect(mp_view->getView(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onCustomContextMenu(const QPoint &)));


### PR DESCRIPTION
fix #1255 

Changes:

- Added calls to `setCategories()` and `setLanguages()` to be triggered whenever the `booksChanged` signal is emitted.

Now, whenever `booksChanged` event is called, eg. when a file is deleted or sideloaded.., the filter list will get updated.