### PR TITLE
Feat: Added speed control option for Text-to-Speech module

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -185,5 +185,8 @@
     "select-read-voice": "Select reading voice",
     "select-read-language": "Select reading language",
     "save-or-open": "Save or Open file",
-    "save-or-open-text": "What should Kiwix do with this file?"
+    "save-or-open-text": "What should Kiwix do with this file?",
+    "speed": "Speed",
+    "increase-tts-speed": "Increase TTS speed.",
+    "decrease-tts-speed": "Decrease TTS speed."
 }

--- a/resources/i18n/qqq.json
+++ b/resources/i18n/qqq.json
@@ -192,5 +192,8 @@
 	"select-read-voice": "Represents the action of opening the voice selection for text-to-speech.",
 	"select-read-language": "Represents the action of opening the language selection for text-to-speech.",
 	"save-or-open": "Title of the message box allowing to choose whether a remote resource should be saved to disk or opened with a respective application",
-	"save-or-open-text": "Text of the message box allowing to choose whether a remote resource should be saved to disk or opened with a respective application"
+	"save-or-open-text": "Text of the message box allowing to choose whether a remote resource should be saved to disk or opened with a respective application",
+	"speed": "Label for text-to-speech speed adjustment control.",
+	"increase-tts-speed": "Represents the action of increasing the speed of the text-to-speech.",
+	"decrease-tts-speed": "Represents the action of decreasing the speed of the text-to-speech."
 }

--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -406,6 +406,8 @@ void KiwixApp::createActions()
     CREATE_ACTION_SHORTCUT(ReadStopAction, gt("read-stop"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_X));
     CREATE_ACTION_SHORTCUT(ToggleTTSLanguageAction, gt("select-read-language"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_L));
     CREATE_ACTION_SHORTCUT(ToggleTTSVoiceAction, gt("select-read-voice"), QKeySequence(Qt::ALT | Qt::SHIFT | Qt::Key_V));
+    CREATE_ACTION_SHORTCUT(IncreaseTTSSpeedAction, gt("increase-tts-speed"), QKeySequence(Qt::Key_Greater));
+    CREATE_ACTION_SHORTCUT(DecreaseTTSSpeedAction, gt("decrease-tts-speed"), QKeySequence(Qt::Key_Less));
     mpa_actions[ToggleTTSLanguageAction]->setCheckable(true);
     mpa_actions[ToggleTTSVoiceAction]->setCheckable(true);
 
@@ -562,6 +564,11 @@ void KiwixApp::saveVoiceName(const QString& langName, const QString& voiceName)
   mp_session->setValue("voice/" + langName, voiceName);
 }
 
+void KiwixApp::saveTtsSpeed(const QString& langName, double speed)
+{
+    mp_session->setValue("speed/" + langName, speed);
+}
+
 void KiwixApp::restoreWindowState()
 {
   getMainWindow()->restoreGeometry(mp_session->value("geometry").toByteArray());
@@ -581,6 +588,11 @@ void KiwixApp::savePrevSaveDir(const QString &prevSaveDir)
 QString KiwixApp::getSavedVoiceName(const QString& langName) const
 {
   return mp_session->value("voice/" + langName, "").toString();
+}
+
+double KiwixApp::getSavedTtsSpeed(const QString& langName) const
+{
+    return mp_session->value("speed/" + langName, 1.0).toDouble(); // Default: 1.0 (normal speed)
 }
 
 QString KiwixApp::getPrevSaveDir() const

--- a/src/kiwixapp.h
+++ b/src/kiwixapp.h
@@ -50,6 +50,8 @@ public:
         ToggleAddBookmarkAction,
         ToggleTTSLanguageAction,
         ToggleTTSVoiceAction,
+        IncreaseTTSSpeedAction,
+        DecreaseTTSSpeedAction,
         ZoomInAction,
         ZoomOutAction,
         ZoomResetAction,
@@ -101,10 +103,12 @@ public:
     void saveListOfOpenTabs();
     void saveWindowState();
     void saveVoiceName(const QString& langName, const QString& voiceName);
+    void saveTtsSpeed(const QString& langName, double speed);
     void restoreWindowState();
     void saveCurrentTabIndex();
     void savePrevSaveDir(const QString& prevSaveDir);
     QString getSavedVoiceName(const QString& langName) const;
+    double getSavedTtsSpeed(const QString& langName) const;
     QString getPrevSaveDir() const;
     void restoreTabs();
     void setupDirectoryMonitoring();

--- a/src/mainmenu.cpp
+++ b/src/mainmenu.cpp
@@ -49,6 +49,8 @@ MainMenu::MainMenu(QWidget *parent) :
     m_viewMenu.ADD_ACTION(ToggleReadingListAction);
     m_viewMenu.ADD_ACTION(ToggleTTSLanguageAction);
     m_viewMenu.ADD_ACTION(ToggleTTSVoiceAction);
+    m_viewMenu.ADD_ACTION(IncreaseTTSSpeedAction);
+    m_viewMenu.ADD_ACTION(DecreaseTTSSpeedAction);
     m_viewMenu.ADD_ACTION(ZoomInAction);
     m_viewMenu.ADD_ACTION(ZoomOutAction);
     m_viewMenu.ADD_ACTION(ZoomResetAction);

--- a/src/texttospeechbar.h
+++ b/src/texttospeechbar.h
@@ -35,6 +35,8 @@ public:
     void setupLanguageComboBox();
     void setupVoiceComboBox();
     void resetVoiceComboBox();
+    void setupSpeedOptionsComboBox();
+    void resetSpeedComboBox();
 
     int getVoiceIndex();
 
@@ -46,6 +48,9 @@ public slots:
     void toggleLanguage();
     void languageSelected(int index);
     void voiceSelected(int index);
+    void onSpeedChanged(int index);
+    void increaseSpeed();
+    void decreaseSpeed();
 
 protected:
     void keyPressEvent(QKeyEvent *event);

--- a/src/texttospeechbar.ui
+++ b/src/texttospeechbar.ui
@@ -52,6 +52,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="speedLabel">
+     <property name="text">
+      <string>Speed</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="speedComboBox">
+     <property name="editable">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
fix #1299 

- Made a function to change rate of speech based on user's choice.
- User can select speed of their choice from the ui.
- User can also use keyboard shortcut `>`/`<` to increase/decrease speed.
- When a user changes speed, the speech is stopped and 'restarted' with new speed.

![image](https://github.com/user-attachments/assets/4934283b-bd22-4a2b-b2a2-3137cb20fa0a)

