### PR TITLE
Fix typo in download error message

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -6,7 +6,7 @@
     "name":"English",
     "error-title":"Error",
     "error-downloader-window-title":"Cannot create downloader",
-    "error-downloader-launch-message":"Impossible to launch downloader, Kiwix-desktop will start but all download functions will not working!",
+    "error-downloader-launch-message":"Impossible to launch downloader. Kiwix-desktop will start, but all download functions will not work.",
     "error-launch-server-message":"An error has occured!",
     "error-archive":"Cannot get the archive",
     "error-opening-file": "There was an error opening the file.",


### PR DESCRIPTION
New error message: “Impossible to launch downloader. Kiwix-desktop will start, but all download functions will not work.”
Fixes #1330