### PR TITLE
Fix tab closing issue - ensure correct tab is closed

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -158,7 +158,11 @@ void TabBar::setCloseTabButton(int index)
     tb->setDefaultAction(a);
     setTabButton(index, QTabBar::RightSide, tb);
     connect(tb, &QToolButton::triggered, this, [=]() {
-        closeTab(index);
+        // Get the tab index directly from the tab rect that contains this button
+        const QRect tabRect = tabRect(index);
+        if (tabRect.isValid()) {
+            closeTab(index);
+        }
     });
 }
 


### PR DESCRIPTION
Hey , so the problem we're dealing with actually comes from the **TabBar** class in the **setCloseTabButton** method. Before this  code tries to figure out which tab's close button was clicked by comparing pointers. The thing is this method can be inconsistent and unreliable at times . When tabs get shuffled around or reordered those close buttons are recreated and Qt's widget management system does the same which makes pointer comparisons unreliable. 

The solution is pretty straightforward. Instead of looping through all the tabs to find the clicked button we can simply use the index parameter that we passed to **setCloseTabButton** and capture it by value in the lambda function. This way we can be sure that the index is always accurate when the close button is created and we can skip the unreliable pointer check altogether. With this fix clicking a close button will consistently close the right tab no matter which one is active. 
Also this issue was initially assigned to someone else who had requested it but since it sat unresolved for over two weeks I addressed the bug before it causes more inconvenience to the users. If there are any mistakes in the code please let me know so I can make the necessary corrections before merging . @rgaudin @kelson42 