### PR TITLE
fix: resolve Wayland icon issue by correcting desktop filename

### DIFF
--- a/src/kiwixapp.cpp
+++ b/src/kiwixapp.cpp
@@ -84,7 +84,7 @@ void KiwixApp::init()
     setWindowIcon(icon);
 
     setApplicationName("Kiwix");
-    setDesktopFileName("kiwix.desktop");
+    setDesktopFileName("org.kiwix.desktop.desktop");
     setStyleSheet(parseStyleFromFile(":/css/style.css"));
 
     createActions();


### PR DESCRIPTION
Before: ![image](https://github.com/user-attachments/assets/08d2c54d-0e0e-4795-9e34-2e31968f4472)


After: 
![image](https://github.com/user-attachments/assets/2f212694-ff1c-41a5-b54f-39cea36370e1)

