### PR TITLE
Add options for downloading multimedia content 

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -172,7 +172,7 @@
     "import-reading-list": "Import reading list",
     "import-reading-list-error": "An error has occured during import of the reading list.",
     "disable-sandbox": "Kiwix has been launched from a network drive. This is known to cause compatibility issues with the browsing sandboxing. As a result, the sandbox will be disabled. Do you want to continue?",
-    "save-page-as": "Save As...",
+    "save-page-as": "Save article as PDF",
     "portable-disabled-tooltip": "Function disabled in portable mode",
     "scroll-next-tab": "Scroll to next tab",
     "scroll-previous-tab": "Scroll to previous tab",


### PR DESCRIPTION
Fixes #1274 
This PR adds an option to save image when right clicked on an image, save video when right clicked on an video and save video when right clicked on an audio.
In rest of the cases it gives you an option to save page as html.
I think this a better fix then the last one
