### PR TITLE
Use windows-2025 runner in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         config:
           - native_mixed
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
We just have moved on kiwix-build side, see https://github.com/kiwix/kiwix-build/pull/838