### PR TITLE
Support for libtorrent-based downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       HOME: /home/runner
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-02-15
+      image: ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25
 
     steps:
       - name: Install dependencies

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends: debhelper-compat (= 13),
  qt6-wayland-dev,
  libkiwix-dev (>= 14.0), libkiwix-dev (<< 15.0),
  libzim-dev (>= 9.0), libzim-dev (<< 10.0),
+ libtorrent-rasterbar-dev (>= 2.0),
 Standards-Version: 4.5.0
 Homepage: https://www.kiwix.org/
 Rules-Requires-Root: no

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -247,6 +247,7 @@ QMAKE_CFLAGS += $$PKGCONFIG_CFLAGS
 !win32 {
    LIBS += $$system(pkg-config --libs $$PKGCONFIG_OPTION $$DEPS_DEFINITION)
    LIBS += -ltorrent-rasterbar
+   QMAKE_CXXFLAGS += -DENABLE_LIBTORRENT
 }
 
 win32 {

--- a/kiwix-desktop.pro
+++ b/kiwix-desktop.pro
@@ -246,6 +246,7 @@ QMAKE_CFLAGS += $$PKGCONFIG_CFLAGS
 
 !win32 {
    LIBS += $$system(pkg-config --libs $$PKGCONFIG_OPTION $$DEPS_DEFINITION)
+   LIBS += -ltorrent-rasterbar
 }
 
 win32 {

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -217,9 +217,13 @@ void DownloadManager::updateDownload(QString bookId)
 namespace
 {
 
-QString torrentStatus2QString(lt::torrent_status::state_t status)
+QString torrentStatus2QString(const lt::torrent_status& status)
 {
-    switch(status){
+    if ( status.flags & lt::torrent_flags::paused ) {
+        return "paused";
+    }
+
+    switch(status.state){
     case lt::torrent_status::checking_files:
     case lt::torrent_status::downloading_metadata:
     case lt::torrent_status::downloading:
@@ -257,7 +261,7 @@ DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
         const auto st = th.status(th.query_save_path|th.query_name);
         const auto filePath = st.save_path + "/" + st.name;
         return {
-                 { "status"          , torrentStatus2QString(st.state)   },
+                 { "status"          , torrentStatus2QString(st)   },
                  { "completedLength" , QString::number(st.total_done) },
                  { "totalLength"     , QString::number(st.total)     },
                  { "downloadSpeed"   , QString::number(st.download_rate)   },
@@ -402,7 +406,8 @@ void DownloadManager::pauseDownload(const QString& bookId)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
-        // TODO: not yet implemented
+        th.unset_flags(lt::torrent_flags::auto_managed);
+        th.pause();
         return;
     }
 
@@ -435,7 +440,7 @@ void DownloadManager::resumeDownload(const QString& bookId)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
-        // TODO: not yet implemented
+        th.resume();
         return;
     }
 

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -456,7 +456,8 @@ void DownloadManager::cancelDownload(const QString& bookId)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
-        // TODO: not yet implemented
+        m_libtorrentSession.remove_torrent(th);
+        emit downloadCancelled(bookId);
         return;
     }
 

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -3,7 +3,9 @@
 #include "kiwixapp.h"
 #include "kiwixmessagebox.h"
 
+#if defined(ENABLE_LIBTORRENT)
 #include <libtorrent/magnet_uri.hpp>
+#endif
 
 #include <QStorageInfo>
 #include <QThread>
@@ -15,12 +17,14 @@
 namespace
 {
 
+#if defined(ENABLE_LIBTORRENT)
 std::string toHexString(lt::sha1_hash const& s)
 {
 	std::stringstream ret;
 	ret << s;
 	return ret.str();
 }
+#endif
 
 QString convertToUnits(double bytes)
 {
@@ -217,6 +221,7 @@ void DownloadManager::updateDownload(QString bookId)
 namespace
 {
 
+#if defined(ENABLE_LIBTORRENT)
 QString torrentStatus2QString(const lt::torrent_status& status)
 {
     if ( status.flags & lt::torrent_flags::paused ) {
@@ -237,6 +242,7 @@ QString torrentStatus2QString(const lt::torrent_status& status)
         return "unknown";
     }
 }
+#endif
 
 QString downloadStatus2QString(kiwix::Download::StatusResult status)
 {
@@ -255,6 +261,7 @@ QString downloadStatus2QString(kiwix::Download::StatusResult status)
 
 DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
 {
+#if defined(ENABLE_LIBTORRENT)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
@@ -268,6 +275,7 @@ DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
                  { "path"            , QString::fromStdString(filePath)     }
         };
     }
+#endif
 
     auto& b = mp_library->getBookById(bookId);
     const auto d = mp_downloader->getDownload(b.getDownloadId());
@@ -351,6 +359,7 @@ void DownloadManager::checkThatBookCanBeDownloaded(const kiwix::Book& book, cons
     checkThatBookCanBeSaved(book, downloadDirPath);
 }
 
+#if defined(ENABLE_LIBTORRENT)
 std::string DownloadManager::startTorrentDownload(const kiwix::Book& book, const std::string& downloadDirPath)
 {
     const std::string& url = book.getUrl();
@@ -364,14 +373,17 @@ std::string DownloadManager::startTorrentDownload(const kiwix::Book& book, const
     std::cerr << "Now downloading using libtorrent: " << book.getUrl() << std::endl;
     return "libtorrent:" + torrentHash;
 }
+#endif
 
 std::string DownloadManager::startDownload(const kiwix::Book& book, const QString& downloadDirPath)
 {
+#if defined(ENABLE_LIBTORRENT)
     try {
         return startTorrentDownload(book, downloadDirPath.toStdString());
     } catch ( ... ) {
         std::cerr << "Failed to start download using libtorrent: " << book.getUrl() << std::endl;
     }
+#endif
 
     const std::string& url = book.getUrl();
     const QString bookId = QString::fromStdString(book.getId());
@@ -403,6 +415,7 @@ void DownloadManager::addRequest(Action action, QString bookId)
 
 void DownloadManager::pauseDownload(const QString& bookId)
 {
+#if defined(ENABLE_LIBTORRENT)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
@@ -410,6 +423,7 @@ void DownloadManager::pauseDownload(const QString& bookId)
         th.pause();
         return;
     }
+#endif
 
     const auto downloadId = mp_library->getBookById(bookId).getDownloadId();
     if ( downloadId.empty() ) {
@@ -437,12 +451,14 @@ void DownloadManager::pauseDownload(const QString& bookId)
 
 void DownloadManager::resumeDownload(const QString& bookId)
 {
+#if defined(ENABLE_LIBTORRENT)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
         th.resume();
         return;
     }
+#endif
 
     auto& b = mp_library->getBookById(bookId);
     auto download = mp_downloader->getDownload(b.getDownloadId());
@@ -453,6 +469,7 @@ void DownloadManager::resumeDownload(const QString& bookId)
 
 void DownloadManager::cancelDownload(const QString& bookId)
 {
+#if defined(ENABLE_LIBTORRENT)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
@@ -460,6 +477,7 @@ void DownloadManager::cancelDownload(const QString& bookId)
         emit downloadCancelled(bookId);
         return;
     }
+#endif
 
     const auto downloadId = mp_library->getBookById(bookId).getDownloadId();
     if ( downloadId.empty() ) {
@@ -485,10 +503,12 @@ void DownloadManager::cancelDownload(const QString& bookId)
 
 void DownloadManager::removeDownload(QString bookId)
 {
+#if defined(ENABLE_LIBTORRENT)
     const auto ds = getDownloadState(bookId);
     const auto th = ds->torrentHandle;
     if ( th.is_valid() ) {
         m_libtorrentSession.remove_torrent(th);
     }
+#endif
     m_downloads.remove(bookId);
 }

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -3,6 +3,8 @@
 #include "kiwixapp.h"
 #include "kiwixmessagebox.h"
 
+#include <libtorrent/magnet_uri.hpp>
+
 #include <QStorageInfo>
 #include <QThread>
 
@@ -12,6 +14,13 @@
 
 namespace
 {
+
+std::string toHexString(lt::sha1_hash const& s)
+{
+	std::stringstream ret;
+	ret << s;
+	return ret.str();
+}
 
 QString convertToUnits(double bytes)
 {
@@ -208,6 +217,23 @@ void DownloadManager::updateDownload(QString bookId)
 namespace
 {
 
+QString torrentStatus2QString(lt::torrent_status::state_t status)
+{
+    switch(status){
+    case lt::torrent_status::checking_files:
+    case lt::torrent_status::downloading_metadata:
+    case lt::torrent_status::downloading:
+        return "active";
+
+    case lt::torrent_status::finished:
+    case lt::torrent_status::seeding:
+        return "completed";
+
+    default:
+        return "unknown";
+    }
+}
+
 QString downloadStatus2QString(kiwix::Download::StatusResult status)
 {
     switch(status){
@@ -225,6 +251,20 @@ QString downloadStatus2QString(kiwix::Download::StatusResult status)
 
 DownloadInfo DownloadManager::getDownloadInfo(QString bookId) const
 {
+    const auto ds = getDownloadState(bookId);
+    const auto th = ds->torrentHandle;
+    if ( th.is_valid() ) {
+        const auto st = th.status(th.query_save_path|th.query_name);
+        const auto filePath = st.save_path + "/" + st.name;
+        return {
+                 { "status"          , torrentStatus2QString(st.state)   },
+                 { "completedLength" , QString::number(st.total_done) },
+                 { "totalLength"     , QString::number(st.total)     },
+                 { "downloadSpeed"   , QString::number(st.download_rate)   },
+                 { "path"            , QString::fromStdString(filePath)     }
+        };
+    }
+
     auto& b = mp_library->getBookById(bookId);
     const auto d = mp_downloader->getDownload(b.getDownloadId());
     d->updateStatus(true);
@@ -307,8 +347,28 @@ void DownloadManager::checkThatBookCanBeDownloaded(const kiwix::Book& book, cons
     checkThatBookCanBeSaved(book, downloadDirPath);
 }
 
+std::string DownloadManager::startTorrentDownload(const kiwix::Book& book, const std::string& downloadDirPath)
+{
+    const std::string& url = book.getUrl();
+    std::cerr << "Trying to start download using libtorrent: " << book.getUrl() << std::endl;
+    const QString bookId = QString::fromStdString(book.getId());
+    lt::add_torrent_params params = lt::parse_magnet_uri(url);
+    params.save_path = downloadDirPath;
+    const auto downloadState = getDownloadState(bookId);
+    downloadState->torrentHandle = m_libtorrentSession.add_torrent(params);
+    const auto torrentHash = toHexString(params.info_hashes.get_best());
+    std::cerr << "Now downloading using libtorrent: " << book.getUrl() << std::endl;
+    return "libtorrent:" + torrentHash;
+}
+
 std::string DownloadManager::startDownload(const kiwix::Book& book, const QString& downloadDirPath)
 {
+    try {
+        return startTorrentDownload(book, downloadDirPath.toStdString());
+    } catch ( ... ) {
+        std::cerr << "Failed to start download using libtorrent: " << book.getUrl() << std::endl;
+    }
+
     const std::string& url = book.getUrl();
     const QString bookId = QString::fromStdString(book.getId());
 
@@ -339,6 +399,13 @@ void DownloadManager::addRequest(Action action, QString bookId)
 
 void DownloadManager::pauseDownload(const QString& bookId)
 {
+    const auto ds = getDownloadState(bookId);
+    const auto th = ds->torrentHandle;
+    if ( th.is_valid() ) {
+        // TODO: not yet implemented
+        return;
+    }
+
     const auto downloadId = mp_library->getBookById(bookId).getDownloadId();
     if ( downloadId.empty() ) {
         // Completion of the download has been detected (and its id was reset)
@@ -365,6 +432,13 @@ void DownloadManager::pauseDownload(const QString& bookId)
 
 void DownloadManager::resumeDownload(const QString& bookId)
 {
+    const auto ds = getDownloadState(bookId);
+    const auto th = ds->torrentHandle;
+    if ( th.is_valid() ) {
+        // TODO: not yet implemented
+        return;
+    }
+
     auto& b = mp_library->getBookById(bookId);
     auto download = mp_downloader->getDownload(b.getDownloadId());
     if (download->getStatus() == kiwix::Download::K_PAUSED) {
@@ -374,6 +448,13 @@ void DownloadManager::resumeDownload(const QString& bookId)
 
 void DownloadManager::cancelDownload(const QString& bookId)
 {
+    const auto ds = getDownloadState(bookId);
+    const auto th = ds->torrentHandle;
+    if ( th.is_valid() ) {
+        // TODO: not yet implemented
+        return;
+    }
+
     const auto downloadId = mp_library->getBookById(bookId).getDownloadId();
     if ( downloadId.empty() ) {
         // Completion of the download has been detected (and its id was reset)

--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -485,5 +485,10 @@ void DownloadManager::cancelDownload(const QString& bookId)
 
 void DownloadManager::removeDownload(QString bookId)
 {
+    const auto ds = getDownloadState(bookId);
+    const auto th = ds->torrentHandle;
+    if ( th.is_valid() ) {
+        m_libtorrentSession.remove_torrent(th);
+    }
     m_downloads.remove(bookId);
 }

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -9,6 +9,9 @@
 #include <QVariant>
 #include <QWaitCondition>
 
+#include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/session.hpp>
+
 #include <chrono>
 #include <memory>
 #include <queue>
@@ -77,6 +80,7 @@ public: // types
 
 public: // data
 
+    lt::torrent_handle torrentHandle;
     double progress = 0;
     QString completedLength;
 
@@ -197,6 +201,7 @@ private: // functions
     void resumeDownload(const QString& bookId);
     void updateDownload(QString bookId);
     void cancelDownload(const QString& bookId);
+    std::string startTorrentDownload(const kiwix::Book& book, const std::string& downloadDirPath);
 
 private: // data
     const Library* const     mp_library;
@@ -204,6 +209,7 @@ private: // data
     Downloads                m_downloads;
     QThread*                 mp_downloadUpdaterThread = nullptr;
     RequestQueue             m_requestQueue;
+    lt::session              m_libtorrentSession;
 };
 
 #endif // DOWNLOADMANAGEMENT_H

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -9,8 +9,10 @@
 #include <QVariant>
 #include <QWaitCondition>
 
+#if defined(ENABLE_LIBTORRENT)
 #include <libtorrent/torrent_handle.hpp>
 #include <libtorrent/session.hpp>
+#endif
 
 #include <chrono>
 #include <memory>
@@ -80,7 +82,9 @@ public: // types
 
 public: // data
 
+#if defined(ENABLE_LIBTORRENT)
     lt::torrent_handle torrentHandle;
+#endif
     double progress = 0;
     QString completedLength;
 
@@ -201,7 +205,9 @@ private: // functions
     void resumeDownload(const QString& bookId);
     void updateDownload(QString bookId);
     void cancelDownload(const QString& bookId);
+#if defined(ENABLE_LIBTORRENT)
     std::string startTorrentDownload(const kiwix::Book& book, const std::string& downloadDirPath);
+#endif
 
 private: // data
     const Library* const     mp_library;
@@ -209,7 +215,9 @@ private: // data
     Downloads                m_downloads;
     QThread*                 mp_downloadUpdaterThread = nullptr;
     RequestQueue             m_requestQueue;
+#if defined(ENABLE_LIBTORRENT)
     lt::session              m_libtorrentSession;
+#endif
 };
 
 #endif // DOWNLOADMANAGEMENT_H


### PR DESCRIPTION
Fixes #1464

This PR introduces minimal support for `libtorrent`-based downloads on Linux. The `libtorrent-rasterbar-dev` package must be installed on the build system. Thus, this feature is disabled on Windows.

`libtorrent` kicks in (instead of `aria2c`) if the URL of the OPDS catalog entry is a magnet link (rather than
  an HTTP link).