### PR TITLE
Undo the hack breaking WebGL in appimage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,14 +34,6 @@ bool wasAppStartedFromARemoteDrive()
 
 int main(int argc, char *argv[])
 {
-// Small hack to make QtWebEngine works with AppImage.
-// See https://github.com/probonopd/linuxdeployqt/issues/554
-    if (qEnvironmentVariableIsSet("APPIMAGE")) {
-        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu --no-sandbox");
-        QApplication::setAttribute(Qt::AA_UseOpenGLES);
-    }
-// End of hack ^^^
-
 #ifdef Q_OS_WIN
     const bool appWasStartedFromARemoteDrive = wasAppStartedFromARemoteDrive();
     if ( appWasStartedFromARemoteDrive ) {


### PR DESCRIPTION
Fixes #1477

The hack was introduced as a workaround for a bug in `linuxdeployqt` (see #810). Since we no longer use `linuxdeployqt` in our AppImage creation script (see kiwix/kiwix-build#771) the hack is rolled back in the hope that it doesn't revive the issue reported in #810 (I didn't test that; I only checked that the AppImage created after applying this change doesn't have the WebGL problem unlike the AppImage created before applying this change).