### PR TITLE
Enable Fetch API for zim:// scheme on Qt 6.6+

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,15 @@ int main(int argc, char *argv[])
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     QWebEngineUrlScheme scheme("zim");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    // Needed so the Fetch API / XHR can load zim:// resources (issue #1476).
+    // FetchApiAllowed was introduced in Qt 6.6.
+    scheme.setSyntax(QWebEngineUrlScheme::Syntax::Host);
+    scheme.setFlags(QWebEngineUrlScheme::SecureScheme
+                  | QWebEngineUrlScheme::LocalAccessAllowed
+                  | QWebEngineUrlScheme::CorsEnabled
+                  | QWebEngineUrlScheme::FetchApiAllowed);
+#endif
     QWebEngineUrlScheme::registerScheme(scheme);
 #endif
     KiwixApp a(argc, argv);


### PR DESCRIPTION
Fixes #1476

Registers the `zim:` custom scheme with `FetchApiAllowed` (plus `CorsEnabled`, `SecureScheme`, `LocalAccessAllowed`) so that modern Chromium accepts `fetch()` / XHR requests against in-ZIM resources. Without this, maps scraper ZIMs and any other ZIM whose JS uses `fetch()` fail client-side with:

> Fetch API cannot load zim://&lt;uuid&gt;/&lt;path&gt;. URL scheme "zim" is not supported.

## Why version-gated

`QWebEngineUrlScheme::FetchApiAllowed` was introduced in Qt 6.6, and @veloman-yunkan noted in #1476 that an unconditional fix is blocked because the `noble` CI image ships Qt 6.4.2.

The patch is gated with `#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)`, so the new flag code is excluded by the preprocessor on Qt < 6.6. With this gate:

| Target | Qt version | Behavior |
|---|---|---|
| Windows CI (`install-qt-action` 6.8.3) | 6.8.3 | Fix active |
| Linux `resolute` image | 6.8+ (expected) | Fix active |
| Linux `noble` image | 6.4.2 | Compiles cleanly, no fix (unchanged) |

So this PR unblocks Windows users and `resolute` Linux users immediately, without waiting on the `kiwix-build` container image bump for `noble`. Once `noble` is retired or upgraded, the fix activates there for free — no further code change needed.

## Bug repro (against unpatched 2.5.1)

Reproduced against a real-world maps ZIM (`osm-europe.zim` from the OSM scraper), not just the synthetic test ZIM in #1476:

- Build: `kiwix-desktop` 2.5.1 Windows x64 official release (`libqt 6.4.3`)
- Command: `QTWEBENGINE_REMOTE_DEBUGGING=9222 kiwix-desktop.exe osm-europe.zim`
- UI shows "Error Failed to fetch" where the map should render.
- Captured via CDP over `http://localhost:9222`, the DevTools console shows exactly the bug from #1476:

```
[error] Fetch API cannot load zim://e00a7b13-c473-cbb0-76c5-ea55928ece83.zim/map-config.json.
        URL scheme "zim" is not supported.
```

No network-layer failure — the request is rejected by Chromium client-side before `UrlSchemeHandler::requestStarted` is ever called, matching the analysis in #1476.

## Verification — A/B tested on a local Linux build

I built `kiwix-desktop` from source on Ubuntu 24.04 (WSL2) against **Qt 6.8.0** (via `aqtinstall`) using the same `kiwix-build` deps archive the CI `linux-x86_64-dyn` target uses, then A/B-tested the same tree with and without this patch. Identical binary, Qt, deps, ZIM, and environment — the only difference is `src/main.cpp`.

**Unpatched build** (HEAD^, main branch `src/main.cpp`):
```
=== [UNPATCHED] CONSOLE (2 entries) ===
[log.error] Fetch API cannot load zim://e00a7b13-c473-cbb0-76c5-ea55928ece83.zim/map-config.json. URL scheme "zim" is not supported.
[log.error] Fetch API cannot load zim://e00a7b13-c473-cbb0-76c5-ea55928ece83.zim/map-config.json. URL scheme "zim" is not supported.
[UNPATCHED] summary: req=4 resp=4 fails=0 console=2
```

**Patched build** (this branch):
```
=== [PATCHED] CONSOLE (0 entries) ===
[PATCHED] summary: req=5 resp=5 fails=0 console=0
```

The fetch-api error is reproducibly present in the unpatched build and reproducibly absent in the patched build, with one additional successful request (the previously-blocked `map-config.json`). This isolates the fix to the source change and rules out "maybe Qt 6.8 alone was enough" — it wasn't, the flag is load-bearing.

**Test harness:** captured via Chrome DevTools Protocol against `QTWEBENGINE_REMOTE_DEBUGGING=9224`, reading `Runtime.consoleAPICalled`, `Log.entryAdded`, and `Network.*` events for 10 seconds after `Page.reload`. Same harness run against both builds back-to-back.

**Not yet tested — caveats for reviewers:**
- I only tested against `osm-europe.zim`. I did not run a regression pass against Wikipedia ZIMs, older OSM ZIMs, zimit/warc2zim (#1281-related) ZIMs, or PhET (#915-related) ZIMs. Happy to add those runs if you want a broader datapoint before merge — just point me at test ZIMs.
- WSLg rendering was software (no GPU passthrough), so I couldn't visually confirm tile rendering — only that fetch succeeds at the protocol level. The maps scraper renders tiles via Leaflet, which uses `fetch()` for tile metadata and `<img>` for tile images; the former is what was broken and is what my test confirms is fixed.
- Linux build rather than Windows. Can't directly attest to the Windows `install-qt-action` path beyond "the patch is source-side and Qt-version-gated, and Windows CI already uses Qt 6.8.3" — if a reviewer wants a Windows-side verification I can try to stand up an MSVC toolchain, it just takes longer.

## Flag rationale — and open scoping question

@veloman-yunkan wrote in #1476: *"just need to enable `QWebEngineUrlScheme::FetchApiAllowed`"*. I included a larger set. **I'd like the reviewer to confirm the intended scope — I may be over-fixing.** My reasoning for each addition below; happy to reduce to a minimal `FetchApiAllowed`-only patch if you prefer.

- **`FetchApiAllowed`** — the actual fix per @veloman-yunkan. Without it Chromium's fetch allowlist rejects the scheme.
- **`Syntax::Host`** — *this is the addition I'm least sure about and most want feedback on.* Qt's default `Syntax` for custom schemes is `Path` (no authority component), which means Chromium treats `zim://` as having an opaque per-request origin. My concern: `FetchApiAllowed` alone may not be fully effective if the scheme has no real origin to anchor same-origin fetch against. Declaring `Syntax::Host` gives the scheme a proper origin keyed on `<uuid>.zim`, matching what [`UrlSchemeHandler::requestStarted`](https://github.com/kiwix/kiwix-desktop/blob/main/src/urlschemehandler.cpp) already assumes (it already routes on `qurl.host().endsWith(".zim")`). I may be wrong about this interaction — if so, drop this line and I'll test whichever version you prefer.
- **`CorsEnabled`** — makes the scheme participate in the CORS protocol, needed if any in-ZIM fetch crosses origins. Included for completeness alongside `FetchApiAllowed` since they're frequently paired in Qt docs examples.
- **`SecureScheme`** — lets pages use powerful features (service workers, `crypto.subtle`, secure-context-only APIs) and prevents mixed-content downgrades. Matches how `http://localhost` is treated as a secure context and would unblock #487-adjacent work.
- **`LocalAccessAllowed`** — mirrors `file:`-style semantics for cross-origin access to `LocalScheme` resources.

**If you want the minimum-diff version**, replace the whole `setFlags(...)` call with:
```cpp
scheme.setFlags(QWebEngineUrlScheme::FetchApiAllowed);
```
and remove the `setSyntax` line. I'll rebase. I went fuller on the first pass because modern scraper ZIMs (service workers, zimit/warc2zim wombat) will eventually need all of these, and landing them together seemed more coherent than a sequence of single-flag PRs — but that's a judgment call and you own the codebase.

## Risk

Low. The flags only *add* permissions for a scheme that is already served exclusively by `UrlSchemeHandler`. No ZIM ever sees an externally-originating request on this scheme. Worst theoretical regression would be a ZIM that relied on `zim:` being treated as an opaque/unique origin — unlikely given libkiwix already emits canonical `zim://<uuid>/` URLs.

## Not included

- Updating `noble` container Qt version — separate concern in `kiwix/kiwix-build`.
- Fix for #1281 (wombat URL rewriting) — different root cause, unrelated.
