### PR TITLE
Explicitly make Qt6 known to qtchooser when building the debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,5 +3,6 @@ export QT_SELECT=qt6
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
+	qtchooser -install -f qt6 $$(which qmake6)
 	qmake --version
 	dh $@


### PR DESCRIPTION
Courtesy of https://askubuntu.com/questions/1460242/ubuntu-22-04-with-qt6-qmake-could-not-find-a-qt-installation-of

Fixes #1473