### PR TITLE
Libtorrent downloads persist across kiwix-desktop sessions

### DIFF
--- a/src/downloadmanagement.cpp
+++ b/src/downloadmanagement.cpp
@@ -18,12 +18,26 @@ namespace
 {
 
 #if defined(ENABLE_LIBTORRENT)
+const std::string LTPREFIX = "libtorrent:";
+
 std::string toHexString(lt::sha1_hash const& s)
 {
 	std::stringstream ret;
 	ret << s;
 	return ret.str();
 }
+
+bool isLibtorrentDownloadId(const std::string& downloadId)
+{
+    return downloadId.substr(0, LTPREFIX.size()) == LTPREFIX;
+}
+
+std::string getDirPath(const std::string& path)
+{
+    QFileInfo f(QString::fromStdString(path));
+    return f.absoluteDir().path().toStdString();
+}
+
 #endif
 
 QString convertToUnits(double bytes)
@@ -192,12 +206,31 @@ void DownloadManager::startDownloadUpdaterThread()
     timer->start(1000);
 }
 
+std::shared_ptr<DownloadState> DownloadManager::restoreDownload(const kiwix::Book& b)
+{
+    const auto d = std::make_shared<DownloadState>();
+
+#ifdef ENABLE_LIBTORRENT
+    if ( isLibtorrentDownloadId(b.getDownloadId()) ) {
+        lt::add_torrent_params p = lt::parse_magnet_uri(b.getUrl());
+        p.save_path = getDirPath(b.getPath());
+        const auto th = m_libtorrentSession.add_torrent(p);
+        th.force_recheck();
+        th.unset_flags(lt::torrent_flags::auto_managed);
+        th.pause();
+        d->torrentHandle = th;
+    }
+#endif
+
+    return d;
+}
+
 void DownloadManager::restoreDownloads()
 {
     for ( const auto& bookId : mp_library->getBookIds() ) {
         const kiwix::Book& book = mp_library->getBookById(bookId);
         if ( ! book.getDownloadId().empty() ) {
-            const auto newDownload = std::make_shared<DownloadState>();
+            const auto newDownload = restoreDownload(book);
             m_downloads.set(bookId, newDownload);
         }
     }
@@ -371,7 +404,7 @@ std::string DownloadManager::startTorrentDownload(const kiwix::Book& book, const
     downloadState->torrentHandle = m_libtorrentSession.add_torrent(params);
     const auto torrentHash = toHexString(params.info_hashes.get_best());
     std::cerr << "Now downloading using libtorrent: " << book.getUrl() << std::endl;
-    return "libtorrent:" + torrentHash;
+    return LTPREFIX + torrentHash;
 }
 #endif
 

--- a/src/downloadmanagement.h
+++ b/src/downloadmanagement.h
@@ -208,6 +208,7 @@ private: // functions
 #if defined(ENABLE_LIBTORRENT)
     std::string startTorrentDownload(const kiwix::Book& book, const std::string& downloadDirPath);
 #endif
+    std::shared_ptr<DownloadState> restoreDownload(const kiwix::Book& b);
 
 private: // data
     const Library* const     mp_library;


### PR DESCRIPTION
Related to #1465

As a result of this enhancement incomplete libtorrent-backed downloads from the previous app session now reappear when kiwix-desktop is launched again (this should apply to a crash of kiwix-desktop too).

However no special download resume data is persisted. The download state is restored from the partially downloaded file (which has to be fully scanned in order to detect the locally available pieces).

Note that resuming a libtorrent download remaining from a previous session doesn't immediately show the progress of the download. The download progress data appears after the torrent data is re-fetched from the magnet link and the local file is compared against it. Both of these steps can take a while.