### PR TITLE
 Allow ingesting a library directly from an OPDS feed (closes #1309)

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -32,7 +32,7 @@ Library::Library(const QString& libraryDirectory)
     m_libraryDirectory(libraryDirectory)
 {
     auto manager = kiwix::Manager(LibraryManipulator(this));
-    manager.readFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"), false);
+    manager.readFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"), "", false);
     manager.readBookmarkFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.bookmarks.xml"));
     emit(booksChanged());
 }
@@ -209,7 +209,7 @@ void Library::removeBookmark(const QString &zimId, const QString &url)
 
 void Library::save()
 {
-    mp_library->writeToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"));
+    mp_library->writeToXMLFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"));// todo
     mp_library->writeBookmarksToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(), "library.bookmarks.xml"));
 }
 


### PR DESCRIPTION
- Update `Library::Library` to pass the new required `password` argument (empty string) to `kiwix::Manager::readFile`, matching the updated libkiwix signature.      
  - Update `Library::save` to call the renamed `writeToXMLFile` instead of the removed `writeToFile` on `kiwix::Library`.   