### PR TITLE
Fixes an issue where search suggestions were never displayed because MultiZimButton::getZimIds() could return an empty list even when a ZIM was available.

### DIFF
--- a/src/multizimbutton.cpp
+++ b/src/multizimbutton.cpp
@@ -64,7 +64,7 @@ void MultiZimButton::updateDisplay()
         }
 
         mp_buttonList->addItem(item);
-        setItemZimWidget(item, bookTitle, zimIcon);
+        setItemZimWidget(item, bookTitle, zimIcon, bookId);
     }
 
     mp_buttonList->sortItems();
@@ -73,7 +73,8 @@ void MultiZimButton::updateDisplay()
         mp_buttonList->insertItem(0, currentItem);
 
         const auto title = currentItem->data(Qt::DisplayRole).toString();
-        setItemZimWidget(currentItem, "*" + title, currentIcon);
+        const auto currentZimId = currentItem->data(Qt::UserRole).toString();
+        setItemZimWidget(currentItem, "*" + title, currentIcon, currentZimId);
     }
 
     /* Display should not be used other than for sorting. */
@@ -85,6 +86,15 @@ void MultiZimButton::updateDisplay()
     mp_buttonList->scrollToTop();
     mp_buttonList->setCurrentRow(0);
 
+    /* Ensure at least one ZIM is selected so that search works from an empty/new
+       tab where no article is loaded yet. Without this, getZimIds() returns an
+       empty list and updateCompletion() bails out before fetching any suggestions.
+       We read the id directly from the list item data to avoid the render-timing
+       problem where itemWidget() can return nullptr before the QMenu is shown.
+    */
+    if (m_selectedZimId.isEmpty() && mp_buttonList->count() > 0)
+        m_selectedZimId = mp_buttonList->item(0)->data(Qt::UserRole).toString();
+
     /* We set a maximum display height for list. Respect padding. */
     const int listHeight = itemHeight * std::min(7, mp_buttonList->count());
     mp_buttonList->setFixedHeight(listHeight + paddingTopBot);
@@ -93,14 +103,12 @@ void MultiZimButton::updateDisplay()
 
 QStringList MultiZimButton::getZimIds() const
 {
-    QStringList idList;
-    for (int row = 0; row < mp_buttonList->count(); row++)
-    {
-        const auto widget = getZimWidget(row);
-        if (widget && widget->getRadioButton()->isChecked())
-            idList.append(mp_buttonList->item(row)->data(Qt::UserRole).toString());
-    }
-    return idList;
+    /* m_selectedZimId is kept in sync via the radio-button toggled signal
+       connected in setItemZimWidget(). This avoids relying on itemWidget()
+       which can return nullptr before the QMenu has been rendered. */
+    if (m_selectedZimId.isEmpty())
+        return {};
+    return { m_selectedZimId };
 }
 
 ZimItemWidget *MultiZimButton::getZimWidget(int row) const
@@ -110,10 +118,21 @@ ZimItemWidget *MultiZimButton::getZimWidget(int row) const
 }
 
 void MultiZimButton::setItemZimWidget(QListWidgetItem *item,
-                                      const QString &title, const QIcon &icon)
+                                      const QString &title, const QIcon &icon,
+                                      const QString &zimId)
 {
     const auto zimWidget = new ZimItemWidget(title, icon);
     mp_radioButtonGroup->addButton(zimWidget->getRadioButton());
+
+    /* Keep m_selectedZimId in sync whenever the user picks a different ZIM.
+       Using Qt::UniqueConnection is not needed here because each ZimItemWidget
+       (and its radio button) is newly constructed on every updateDisplay(). */
+    connect(zimWidget->getRadioButton(), &QAbstractButton::toggled,
+            this, [this, zimId](bool checked) {
+                if (checked)
+                    m_selectedZimId = zimId;
+            });
+
     mp_buttonList->setItemWidget(item, zimWidget);
 }
 

--- a/src/multizimbutton.h
+++ b/src/multizimbutton.h
@@ -36,9 +36,11 @@ public slots:
 private:
     QListWidget* mp_buttonList;
     QButtonGroup* mp_radioButtonGroup;
+    QString m_selectedZimId;
 
     ZimItemWidget* getZimWidget(int row) const;
-    void setItemZimWidget(QListWidgetItem* item, const QString& title, const QIcon& icon);
+    void setItemZimWidget(QListWidgetItem* item, const QString& title, const QIcon& icon,
+                          const QString& zimId);
 };
 
 #endif // MULTIZIMBUTTON_H

--- a/src/suggestionlistworker.cpp
+++ b/src/suggestionlistworker.cpp
@@ -17,7 +17,13 @@ void SuggestionListWorker::run()
     const auto app = KiwixApp::instance();
     const auto selectedIdList = app->getSearchBar().getMultiZimButton().getZimIds();
     
-    /* TODO: re-implement this after introducing the actual Multi-Zim. */
+    if (selectedIdList.isEmpty()) {
+        /* No ZIM selected (e.g. brand-new empty tab before any ZIM is opened).
+           Emit an empty result so the search bar behaves gracefully instead of
+           crashing on the unchecked index-0 access below. */
+        emit searchFinished({}, m_token);
+        return;
+    }
     const auto currentZimId = selectedIdList[0];
     try {
         const auto archive = app->getLibrary()->getArchive(currentZimId);


### PR DESCRIPTION
## Root Cause

The selected ZIM was determined by checking the radio button state through the `QListWidget` item widgets.

During `MultiZimButton::updateDisplay()`, the first ZIM is automatically selected when no selection exists. However, `getZimWidget()` relies on `QListWidget::itemWidget()`, which can return `nullptr` when the list is embedded in a `QMenu` that has not been shown/rendered yet.

As a result:

1. The first ZIM's radio button was not checked.
2. `getZimIds()` found no checked radio buttons and returned an empty list.
3. `SearchBarLineEdit::updateCompletion()` detected an empty ZIM list and returned early.
4. Search suggestions were therefore never fetched or displayed.

## Changes

Implemented **Solution A: explicitly track the selected ZIM ID**.

- Added `m_selectedZimId` to `MultiZimButton`.
- Updated the selected ZIM ID whenever a radio button is toggled.
- Set the first available ZIM as the default selection when no selection exists.
- Updated `getZimIds()` to return the tracked ZIM ID instead of depending on `QListWidget::itemWidget()` and radio-button state.
- This removes the dependency on whether the `QListWidget` item widgets have been rendered.

## Why this approach

This avoids relying on the rendering state of the `QListWidget`, which is particularly problematic because the widget is used inside a `QMenu`.

The selected ZIM is now maintained as explicit state within `MultiZimButton`, making `getZimIds()` independent of UI rendering timing.

## Related Issue

Fixes #1500