### PR TITLE
Deprecation of writeToFile method, so updating to writeAsXML

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -209,7 +209,7 @@ void Library::removeBookmark(const QString &zimId, const QString &url)
 
 void Library::save()
 {
-    mp_library->writeToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"));
+    mp_library->writeAsXML(kiwix::appendToDirectory(m_libraryDirectory.toStdString(),"library.xml"));
     mp_library->writeBookmarksToFile(kiwix::appendToDirectory(m_libraryDirectory.toStdString(), "library.bookmarks.xml"));
 }
 


### PR DESCRIPTION
# Use `writeAsXML` instead of deprecated `writeToFile`

## Why

libkiwix deprecated `Library::writeToFile()` in favor of `writeAsXML()`. The deprecation warning was breaking the kiwix-build CI, which treats warnings as errors.

## What

- `Library::save()` (`src/library.cpp`) now calls `writeAsXML(...)` instead of `writeToFile(...)`.

## Impact on kiwix-desktop

No behavior change — `writeAsXML` is what `writeToFile` already delegated to. Unblocks kiwix-build.

## Why

libkiwix deprecated `Library::writeToFile()` in favor of `writeAsXML()`. The deprecation warning was breaking the kiwix-build CI, which treats warnings as errors.

## What

- `Library::save()` (`src/library.cpp`) now calls `mp_library->writeAsXML(...)` instead of `mp_library->writeToFile(...)`.

## Impact on kiwix-desktop

No behavior change — `writeAsXML` is what `writeToFile` already delegated to. Unblocks kiwix-build.

Will fix issues below
https://github.com/kiwix/kiwix-desktop/issues/1504
https://github.com/kiwix/libkiwix/issues/1336
